### PR TITLE
Update changelog and pyproject.toml for major rebranding to access_mo…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,3 +3,18 @@ Changelog
 
 This CHANGELOG documents only key changes between versions. For a full description
 of all changes see https://github.com/ACCESS-NRI/ACCESS-MOPPy/releases
+
+moppy-v1.0.0 (2025-10-27)
+--------------------------
+
+**Major Rebranding Release**
+
+* **BREAKING CHANGE**: Rebranded from ACCESS-MOPPeR to access_moppy
+* **Package name**: Changed from ``access_mopper`` to ``access_moppy``
+* **New versioning**: Reset to v1.0.0 with new tag prefix ``moppy-v``
+* **Import changes**: All imports now use ``from access_moppy import ...``
+* **Installation**: Now install via ``pip install access_moppy``
+
+This release marks the official rebranding of the package while maintaining
+all existing functionality. Please update your imports and installation
+commands accordingly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ VCS = "git"
 style = "pep440"
 versionfile_source = "src/access_moppy/_version.py"
 versionfile_build = "access_moppy/_version.py"
-tag_prefix = "v"
+tag_prefix = "moppy-v"
 parentdir_prefix = "access_moppy-"
 
 [tool.ruff]


### PR DESCRIPTION
This pull request introduces a major rebranding of the project, transitioning from "ACCESS-MOPPeR" to "access_moppy". The package name, import paths, versioning, and installation instructions have all been updated to reflect the new branding. This is a breaking change, so users will need to update their code and installation processes accordingly.

**Rebranding and Versioning Changes:**

* The project has been rebranded from "ACCESS-MOPPeR" to "access_moppy", including a change in the package name from `access_mopper` to `access_moppy`. All import statements should now use `from access_moppy import ...`.
* The versioning scheme has been reset to v1.0.0, and the tag prefix for releases has changed from `v` to `moppy-v` to match the new branding. [[1]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR6-R20) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L88-R88)
* Installation instructions have been updated: the package should now be installed using `pip install access_moppy`.