### PR TITLE
Refactor CI workflow for PyPI and Conda: standardize job names, utili…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,36 +13,66 @@ on:
 
 jobs:
   pypi:
-    name: build and deploy to PyPI
+    name: Build and Deploy to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build dependencies
+        run: python -m pip install build twine
+
+      - name: Build distributions
+        run: |
+          git clean -xdf
+          python -m build --wheel --sdist
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.python-version }}
+          path: dist/
+
+  publish:
+    # publish only once (not in matrix)
+    name: Publish package to PyPI
+    needs: pypi
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v5.0.0
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+      - uses: actions/download-artifact@v4
         with:
-          python-version: 3.11
-      - name: Install build dependencies
-        run: python -m pip install build twine
-      - name: Build distributions
-        shell: bash -l {0}
-        run: |
-          git clean -xdf
-          pyproject-build
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
 
   conda:
-    name: build and deploy to conda
-    needs: pypi
+    name: Build and Deploy to Conda
+    needs: publish
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5
+
       - name: Wait for PyPI propagation
         run: |
           echo "Waiting for PyPI package to be downloadable..."
@@ -74,11 +104,11 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
           environment-file: .conda/environment.yml
           auto-update-conda: false
           auto-activate-base: false
-          show-channel-urls: true
+
       - name: Build and upload the conda package
         uses: ACCESS-NRI/action-build-and-upload-conda-packages@d97711bc4445ba5c4de55f5a1bccbd4815286289
         with:


### PR DESCRIPTION
This pull request updates the continuous deployment workflow in `.github/workflows/cd.yml` to improve Python version support and streamline the build and publish process for both PyPI and Conda. The main changes include introducing a build matrix for multiple Python versions, separating the PyPI publishing step, and ensuring consistent deployment to Conda after PyPI publishing.

**Python version matrix and workflow improvements:**

* Added a build matrix to both the PyPI and Conda jobs to build and test with Python versions 3.11, 3.12, and 3.13, improving compatibility and release coverage.
* Modified the PyPI job to build distributions for each Python version, upload artifacts, and then publish the package in a separate job to avoid duplicate publishing and simplify artifact management.
* Updated the Conda job to depend on the new publish job (instead of PyPI), ensuring Conda deployment only occurs after PyPI publishing is complete.
* Updated the Conda setup step to use the matrix Python version for environment consistency across builds.

**General workflow and naming improvements:**

* Improved job and step naming for clarity and consistency, and updated action versions to recommended tags.…ze matrix for Python versions, and improve artifact handling