### PR TITLE
Chunking of data to follow new CMIP7 directives

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+import dask.array as da
 import netCDF4 as nc
 import psutil
 import xarray as xr
@@ -505,7 +506,6 @@ class CMIP6_CMORiser:
 
         client = None
         worker_memory = None  # Memory limit of a single worker
-        total_cluster_memory = None  # Sum of all workers' memory limits
 
         try:
             # Attempt to get an existing Dask client
@@ -517,11 +517,6 @@ class CMIP6_CMORiser:
             if worker_info:
                 # Get the minimum memory_limit across all workers
                 worker_memory = min(w["memory_limit"] for w in worker_info.values())
-
-                # Sum up all workers' memory for total cluster capacity
-                total_cluster_memory = sum(
-                    w["memory_limit"] for w in worker_info.values()
-                )
 
         except ValueError:
             # No Dask client exists - we'll use local/system memory for writing
@@ -551,7 +546,7 @@ class CMIP6_CMORiser:
 
         if use_chunked_write:
             print(f"📦 Dataset size: {data_size / 1024**3:.2f} GB")
-            print(f"   Using chunked writing with DatasetChunker")
+            print("   Using chunked writing with DatasetChunker")
         else:
             if data_size > available_memory:
                 raise MemoryError(


### PR DESCRIPTION


* Added the `DatasetChunker` class, which applies CMIP7 chunking rules: time coordinates and bounds are single-chunked, while data variables are chunked into blocks of at least 4MB . (`src/access_moppy/base.py`)
* Introduced new configuration options to the CMORiser base class: `enable_chunking`, `chunk_size_mb`, `enable_compression`, and `compression_level`, allowing users to control chunking and compression behavior. (`__init__` in `src/access_moppy/base.py`) [[1]](diffhunk://#diff-3027542b7a72c5536bfa80aa4d2045ea8eda1d79f19bb8033af82929330491edR183-R186) [[2]](diffhunk://#diff-3027542b7a72c5536bfa80aa4d2045ea8eda1d79f19bb8033af82929330491edR202-R211)

**Optimized NetCDF write process:**

* Refactored the `write` method to ensure all variable metadata (B-tree fragments) is written before any data chunks, and applied HDF5 optimizations (shuffle, zlib compression, fletcher32 checksum) to time-dependent data variables for improved read/write performance and data integrity. (`src/access_moppy/base.py`) [[1]](diffhunk://#diff-3027542b7a72c5536bfa80aa4d2045ea8eda1d79f19bb8033af82929330491edR447-R462) [[2]](diffhunk://#diff-3027542b7a72c5536bfa80aa4d2045ea8eda1d79f19bb8033af82929330491edR584-R661)
