### PR TITLE
fix float chunking issue in write

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -804,7 +804,7 @@ class CMIP6_CMORiser:
                 if use_chunked_write and is_var_dask and has_time_dim:
                     # Use self.chunker to calculate optimal write chunk size
                     chunk_sizes = self.chunker.calculate_chunk_size_for_variable(vdat)
-                    time_chunk = chunk_sizes.get("time", self.ds.sizes["time"])
+                    time_chunk = int(chunk_sizes.get("time", self.ds.sizes["time"]))
                     total_timesteps = self.ds.sizes["time"]
                     time_idx = vdat.dims.index("time")
 


### PR DESCRIPTION
## Fix TypeError in chunked write: Convert time_chunk to integer

### Problem
When using chunked writing for large datasets, the `write()` method crashes with:
```
TypeError: 'float' object cannot be interpreted as an integer
```

This occurs because `calculate_chunk_size_for_variable()` returns float values for chunk sizes, but Python's `range()` function requires integer arguments.

### Root Cause
In the chunked write loop (line 813), `time_chunk` is used directly in `range()`:
```python
for t_start in range(0, total_timesteps, time_chunk):  # time_chunk is float
```

### Solution
Convert `time_chunk` to integer before using it in `range()`:
```python
time_chunk = int(chunk_sizes.get("time", self.ds.sizes["time"]))
```