### PR TITLE
fix_iris_issue

### DIFF
--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -218,7 +218,6 @@ class ACCESS_ESM_CMORiser:
             auxiliary coordinates, bounds, and masking applied.
         """
         try:
-            import iris
             import numpy as np
             from ncdata.iris_xarray import cubes_from_xarray
         except ImportError:


### PR DESCRIPTION
Promote 2D `latitude/longitude` from data vars to `xarray` coords so ncdata converts them to iris `AuxCoords` instead of separate `Cubes`

Convert CMIP6 fill values (1e20) to `NaN` → masked arrays so `iris` properly masks invalid ocean cells

Promote `vertices_latitude/vertices_longitude` to coords so bounds are preserved on the `auxiliary` coordinates

Drop `time_bnds` before conversion to avoid extra cubes

Return a single `Cube` instead of a `CubeList`

Add 14 unit tests covering aux coords, masking, bounds, atmosphere data, edge cases, and dataset immutability

fixed #192 