### PR TITLE
Optional import of data_request_api

### DIFF
--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -15,6 +15,7 @@ from cftime import date2num, num2date
 try:
     from data_request_api.content import dump_transformation as dt
     from data_request_api.query import data_request as dr
+
     DATA_REQUEST_API_AVAILABLE = True
 except ImportError:
     dt = None
@@ -2513,7 +2514,7 @@ def generate_cmip7_to_cmip6_mapping(
             "data_request_api package is required for generating CMIP7 mappings. "
             "Install it with: pip install CMIP7-data-request-api"
         )
-    
+
     # Generate both mappings efficiently and return only the forward mapping
     forward_mapping, _ = generate_both_cmip_mappings(
         version=version,
@@ -2597,7 +2598,7 @@ def generate_cmip6_to_cmip7_mapping(
             "data_request_api package is required for generating CMIP7 mappings. "
             "Install it with: pip install CMIP7-data-request-api"
         )
-    
+
     # Generate both mappings efficiently and return only the reverse mapping
     _, reverse_mapping = generate_both_cmip_mappings(
         version=version,
@@ -2725,7 +2726,7 @@ def generate_both_cmip_mappings(
             "data_request_api package is required for generating CMIP7 mappings. "
             "Install it with: pip install CMIP7-data-request-api"
         )
-    
+
     print("Generating both CMIP7<->CMIP6 compound name mappings...")
     print("This may take a moment as it queries the CMIP7 data request API...")
 


### PR DESCRIPTION
This pull request improves the robustness and user-friendliness of the CMIP7/CMIP6 mapping utilities in `src/access_moppy/utilities.py` by handling the optional dependency on the `data_request_api` package. The main changes ensure that informative errors are raised if the required package is missing, and the import logic is more resilient.

Dependency management and error handling:

* Added a try/except block around the import of `data_request_api` modules, setting a `DATA_REQUEST_API_AVAILABLE` flag and providing fallback values if the import fails.
* Updated the functions `generate_cmip7_to_cmip6_mapping`, `generate_cmip6_to_cmip7_mapping`, and `generate_both_cmip_mappings` to raise a clear `ImportError` with installation instructions if `data_request_api` is not available. [[1]](diffhunk://#diff-1ac6a9f917351286c9932609f921642c90f55c1e76c0154e32190af6ddf69a17R2505-R2517) [[2]](diffhunk://#diff-1ac6a9f917351286c9932609f921642c90f55c1e76c0154e32190af6ddf69a17R2589-R2601) [[3]](diffhunk://#diff-1ac6a9f917351286c9932609f921642c90f55c1e76c0154e32190af6ddf69a17R2716-R2729)