### PR TITLE
Add function to retrieve requested variables from data request API

### DIFF
--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -2706,12 +2706,14 @@ def get_requested_variables_from_data_request(
         priority_cutoff=priority.lower(),
     )
 
-    if experiment not in requested.get("experiment", {}):  
-        raise KeyError(f"Experiment '{experiment}' not found in data request.")  
-    
+    if experiment not in requested.get("experiment", {}):
+        raise KeyError(f"Experiment '{experiment}' not found in data request.")
+
     if priority.capitalize() not in requested["experiment"][experiment]:
-        raise KeyError(f"Priority '{priority}' not found for experiment '{experiment}' in data request.")
-    
+        raise KeyError(
+            f"Priority '{priority}' not found for experiment '{experiment}' in data request."
+        )
+
     return list(requested["experiment"][experiment][priority.capitalize()])
 
 

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -423,6 +423,7 @@ if __name__ == "__main__":
 # Helpers shared by get_requested_variables_from_data_request tests
 # ---------------------------------------------------------------------------
 
+
 def _make_dreq_api_mocks(variables):
     """Return a (dc_mock, dq_mock, update_config_mock) triple.
 
@@ -576,4 +577,3 @@ class TestGetRequestedVariablesKeyErrors:
                     get_requested_variables_from_data_request(
                         experiment="historical", priority="Tier1"
                     )
-


### PR DESCRIPTION

Add utility function to get the list of required variable for a CMIP7 experiment, based on priority level.

Utility for #227