### PR TITLE
fix dims and coords order issue,Solved `time` order in NETcdf file

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -735,6 +735,41 @@ class CMORiser:
 
         self.ds = ordered(self.ds)
 
+    def ensure_time_first_dimension(self):
+        """
+        Ensure `time` is the first dimension in all CMORised data variables.
+
+        CMIP tables do not always list `time` first (e.g. `longitude latitude time`),
+        but actual CMIP6 NetCDF files follow the NetCDF convention of placing the
+        unlimited record dimension first: `(time, [vertical], lat, lon)`.
+
+        This method transposes any data variable whose leading dimension is not
+        `time` while preserving the relative order of the remaining dimensions.
+        Coordinate variables (1-D coords, bounds, scalar coords) are left untouched.
+        """
+        if "time" not in self.ds.dims:
+            return
+
+        for var in list(self.ds.variables):
+            dims = list(self.ds[var].dims)
+            if "time" in dims and dims[0] != "time":
+                new_order = ["time"] + [d for d in dims if d != "time"]
+                self.ds[var] = self.ds[var].transpose(*new_order)
+
+        current_sizes = list(self.ds.sizes.keys())
+        if current_sizes and current_sizes[0] == "time":
+            return
+
+        ordered_vars = {}
+        for name in ("time", "time_bnds"):
+            if name in self.ds.variables:
+                ordered_vars[name] = self.ds[name]
+        for name in self.ds.variables:
+            if name not in ordered_vars:
+                ordered_vars[name] = self.ds[name]
+
+        self.ds = xr.Dataset(ordered_vars, attrs=self.ds.attrs)
+
     def _build_drs_path(self, attrs: Dict[str, str]) -> Path:
         """
         Build DRS path using the vocabulary class's controlled vocabulary specifications.
@@ -755,6 +790,31 @@ class CMORiser:
             latest_link.symlink_to(versioned_path.name, target_is_directory=True)
         except Exception as e:
             print(f"Warning: Failed to update latest symlink at {latest_link}: {e}")
+
+    def _get_ordered_variables(self):
+        """
+        Ensure variable write order:
+        1. time coordinate first
+        2. other coordinates
+        3. remaining variables (data vars, bounds, etc.)
+        """
+        vars_all = list(self.ds.variables)
+
+        ordered_vars = []
+
+        # time first
+        if "time" in vars_all:
+            ordered_vars.append("time")
+
+        # other coordinates
+        coord_vars = [c for c in self.ds.coords if c != "time"]
+        ordered_vars.extend([c for c in coord_vars if c in vars_all])
+
+        # remaining variables
+        remaining = [v for v in vars_all if v not in ordered_vars]
+        ordered_vars.extend(remaining)
+
+        return ordered_vars
 
     def write(self):
         """
@@ -895,13 +955,24 @@ class CMORiser:
             path = Path(self.output_path) / filename
             path.parent.mkdir(parents=True, exist_ok=True)
 
+        if "time" in self.ds.coords:
+            coord_order = ["time"] + [c for c in self.ds.coords if c != "time"]
+            self.ds = self.ds.assign_coords({c: self.ds[c] for c in coord_order})
+
+        ordered_vars = self._get_ordered_variables()
+
         with nc.Dataset(path, "w", format="NETCDF4") as dst:
             # Set global attributes
             for k, v in attrs.items():
                 dst.setncattr(k, v)
 
-            # Create dimensions
-            for dim, size in self.ds.sizes.items():
+            # Create dimensions - time must come first (NetCDF unlimited/CMIP6 convention)
+            dim_items = list(self.ds.sizes.items())
+            if "time" in self.ds.sizes:
+                dim_items = [("time", self.ds.sizes["time"])] + [
+                    (d, s) for d, s in dim_items if d != "time"
+                ]
+            for dim, size in dim_items:
                 if dim == "time":
                     dst.createDimension(dim, None)  # Unlimited dimension
                 else:
@@ -919,7 +990,7 @@ class CMORiser:
             # Combined with our chunking strategy (at least 4MB chunks), this optimizes
             # both file layout and chunk size for efficient I/O operations.
             created_vars = {}
-            for var in self.ds.variables:
+            for var in ordered_vars:
                 vdat = self.ds[var]
 
                 # Check if this is a string coordinate
@@ -1007,7 +1078,7 @@ class CMORiser:
 
             # PHASE 2: Write actual data chunks
             # Now all B-tree metadata is written, data chunks come after
-            for var in self.ds.variables:
+            for var in ordered_vars:
                 vdat = self.ds[var]
 
                 # Check if this is a string coordinate
@@ -1259,7 +1330,10 @@ class CMORiser:
         self.standardize_missing_values()
         self.update_attributes()
         self.reorder()
+        # Ensure time is the leading dimension, matching NetCDF/CMIP6 conventions
+        self.ensure_time_first_dimension()
         # Final rechunking before writing for optimal I/O performance
         if write_output:
             self.rechunk_dataset()
+            self.ensure_time_first_dimension()
             self.write()

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -735,7 +735,7 @@ class CMORiser:
 
         self.ds = ordered(self.ds)
 
-    def ensure_time_first_dimension(self):
+    def ensure_time_first(self):
         """
         Ensure `time` is the first dimension in all CMORised data variables.
 
@@ -790,31 +790,6 @@ class CMORiser:
             latest_link.symlink_to(versioned_path.name, target_is_directory=True)
         except Exception as e:
             print(f"Warning: Failed to update latest symlink at {latest_link}: {e}")
-
-    def _get_ordered_variables(self):
-        """
-        Ensure variable write order:
-        1. time coordinate first
-        2. other coordinates
-        3. remaining variables (data vars, bounds, etc.)
-        """
-        vars_all = list(self.ds.variables)
-
-        ordered_vars = []
-
-        # time first
-        if "time" in vars_all:
-            ordered_vars.append("time")
-
-        # other coordinates
-        coord_vars = [c for c in self.ds.coords if c != "time"]
-        ordered_vars.extend([c for c in coord_vars if c in vars_all])
-
-        # remaining variables
-        remaining = [v for v in vars_all if v not in ordered_vars]
-        ordered_vars.extend(remaining)
-
-        return ordered_vars
 
     def write(self):
         """
@@ -955,24 +930,13 @@ class CMORiser:
             path = Path(self.output_path) / filename
             path.parent.mkdir(parents=True, exist_ok=True)
 
-        if "time" in self.ds.coords:
-            coord_order = ["time"] + [c for c in self.ds.coords if c != "time"]
-            self.ds = self.ds.assign_coords({c: self.ds[c] for c in coord_order})
-
-        ordered_vars = self._get_ordered_variables()
-
         with nc.Dataset(path, "w", format="NETCDF4") as dst:
             # Set global attributes
             for k, v in attrs.items():
                 dst.setncattr(k, v)
 
-            # Create dimensions - time must come first (NetCDF unlimited/CMIP6 convention)
-            dim_items = list(self.ds.sizes.items())
-            if "time" in self.ds.sizes:
-                dim_items = [("time", self.ds.sizes["time"])] + [
-                    (d, s) for d, s in dim_items if d != "time"
-                ]
-            for dim, size in dim_items:
+            # Create dimensions
+            for dim, size in self.ds.sizes.items():
                 if dim == "time":
                     dst.createDimension(dim, None)  # Unlimited dimension
                 else:
@@ -990,7 +954,7 @@ class CMORiser:
             # Combined with our chunking strategy (at least 4MB chunks), this optimizes
             # both file layout and chunk size for efficient I/O operations.
             created_vars = {}
-            for var in ordered_vars:
+            for var in self.ds.variables:
                 vdat = self.ds[var]
 
                 # Check if this is a string coordinate
@@ -1078,7 +1042,7 @@ class CMORiser:
 
             # PHASE 2: Write actual data chunks
             # Now all B-tree metadata is written, data chunks come after
-            for var in ordered_vars:
+            for var in self.ds.variables:
                 vdat = self.ds[var]
 
                 # Check if this is a string coordinate
@@ -1331,9 +1295,8 @@ class CMORiser:
         self.update_attributes()
         self.reorder()
         # Ensure time is the leading dimension, matching NetCDF/CMIP6 conventions
-        self.ensure_time_first_dimension()
+        self.ensure_time_first()
         # Final rechunking before writing for optimal I/O performance
         if write_output:
             self.rechunk_dataset()
-            self.ensure_time_first_dimension()
             self.write()


### PR DESCRIPTION

This violates the CMIP6 / NetCDF convention that `time`, as the unlimited record dimension, must come first: `(time, [lev], lat, lon)`.

**Ocean data was unaffected** — see root cause analysis below.

## Root Cause

The problem exists at three independent levels:

**Level 1 — Data variable dimension order**  
CMIP tables define most variable dimensions as `longitude latitude time` (time last). `select_and_process_variables()` transposes the data variable to match, producing `tas.dims = (lon, lat, time)`.

**Level 2 — Per-variable `transpose()` cannot fix dataset-level dimension ordering**  
`xr.Dataset.sizes` key order is determined by the order dimensions are **first encountered** across all variables when the Dataset is constructed. Assigning `self.ds[var] = self.ds[var].transpose(...)` only fixes that variable's own `.dims`; it **does not change `ds.sizes` key order**.

**Level 3 — Why atmosphere differs from ocean**

| | Atmosphere | Ocean |
|---|---|---|
| `lat` / `lon` type | 1-D dimension coordinates — introduce `lat`, `lon` dimensions | 2-D auxiliary coordinates — do not introduce dimension coordinates |
| `ds.sizes` result | `{lat, bnds, lon, time}` — time last ❌ | `{time, lev, j, i}` — time first ✓ |

The old `reorder()` used `core=("lat", "lon", "time", "height")`, causing `lat`/`lon` coordinate variables to be written to the NetCDF file before `time`, which made xarray place `time` last in `ds.coords` on read-back.

## Changes

### `src/access_moppy/base.py`

**`ensure_time_first_dimension()` — add Dataset reconstruction step**

The original implementation only transposed variables one by one, which fixed per-variable `.dims` but left `ds.sizes`/`ds.coords` ordering unchanged. A second step is added: if `ds.sizes` does not already start with `time`, reconstruct the Dataset placing `time`/`time_bnds` first in the variable dict, so xarray encounters the `time` dimension first during construction.

```python
# Step 2: rebuild dataset so 'time' is first in ds.sizes / ds.coords
current_sizes = list(self.ds.sizes.keys())
if current_sizes and current_sizes[0] == "time":
    return  # already correct

ordered_vars = {}
for name in ("time", "time_bnds"):
    if name in self.ds.variables:
        ordered_vars[name] = self.ds[name]
for name in self.ds.variables:
    if name not in ordered_vars:
        ordered_vars[name] = self.ds[name]

self.ds = xr.Dataset(ordered_vars, attrs=self.ds.attrs)
```

#221 Solved