### PR TITLE
solved auxiliary coords misplaced as variable

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -787,6 +787,14 @@ class CMORiser:
             if info["is_scalar"] or name not in self.ds.dims:
                 aux_coords.append(name)
 
+        # Also include non-string scalar coordinates (e.g. float 'height')
+        for coord_name in self.ds.coords:
+            coord = self.ds[coord_name]
+            is_scalar = coord.ndim == 0
+            is_non_dim = coord_name not in self.ds.dims
+            if (is_scalar or is_non_dim) and coord_name not in aux_coords:
+                aux_coords.append(coord_name)
+
         attrs = self.ds.attrs
 
         # Get required attributes from the vocabulary (works for both CMIP6 and CMIP7)
@@ -982,7 +990,7 @@ class CMORiser:
 
                             # Add string coordinates that aren't already in the attribute
                             coords_to_add = [
-                                c for c in aux_coords if c not in existing_coords
+                                c for c in aux_coords if c != existing_coords
                             ]
 
                             if coords_to_add:


### PR DESCRIPTION
solved #232 

## Fix scalar height coordinate missing from CMORised output (`tas` and similar)

### Problem

Near-surface variables (e.g. `tas`, `huss`, `uas`, `vas`) in ACCESS model output are written by iris with a raw NetCDF attribute `coordinates = "height_0"` on the data variable. Because `base.py` opens files with `decode_cf=False`, this raw attribute is preserved in `.attrs` unchanged (unlike `decode_cf=True` which would consume it). Two issues then compound:

1. The stale `coordinates = "height_0"` attribute is inherited by `tas` after renaming, but `height_0` is never loaded into the dataset — creating a dangling reference in the output file.
2. When the code later tried to append the CMIP6-standard `height` scalar coordinate to the `coordinates` attribute, the check `c not in existing_coords` used substring matching, causing `"height" in "height_0"` to evaluate `True` — silently skipping `height` entirely.

The net result was an invalid output file:
```
tas:coordinates = "height_0" ;   ← variable does not exist in file
```

### Changes

**`base.py` — collect non-string scalar coordinates into `aux_coords`**

Added a second loop after the existing `string_coords_info` loop to capture scalar (0-dimensional) and non-dimension coordinates that are not of string type (e.g. the float `height` coordinate created from the CMOR table `value` field). Without this, `height` was written as a plain variable rather than being declared in the `coordinates` attribute.

```python
# Also include non-string scalar coordinates (e.g. float 'height')
for coord_name in self.ds.coords:
    coord = self.ds[coord_name]
    is_scalar = coord.ndim == 0
    is_non_dim = coord_name not in self.ds.dims
    if (is_scalar or is_non_dim) and coord_name not in aux_coords:
        aux_coords.append(coord_name)
```

**`base.py` — fix substring match when deduplicating `coordinates` attribute**

Changed the guard that prevents duplicate entries in the `coordinates` attribute from a substring check to an equality check, so that `"height"` is no longer incorrectly treated as already present when `existing_coords = "height_0"`.

```python
# Before (substring match — buggy)
coords_to_add = [c for c in aux_coords if c not in existing_coords]

# After
coords_to_add = [c for c in aux_coords if c != existing_coords]
```