### PR TITLE
Fix: Drop `time_0`/`time_1` auxiliary coordinates in `_preprocess` to prevent Dask task graph bloat

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -318,7 +318,15 @@ class CMORiser:
         else:
             # Original file-based loading logic
             def _preprocess(ds):
-                return ds[list(required_vars & set(ds.data_vars))]
+                ds = ds[list(required_vars & set(ds.data_vars))]
+                # Drop auxiliary UM time coordinates (time_0, time_1) that differ
+                # across files. Without this, xr.open_mfdataset's join='outer'
+                # unions every distinct value into a growing dimension, inflating
+                # the Dask task graph to several GiB before any computation starts.
+                aux_time_coords = [c for c in ("time_0", "time_1") if c in ds]
+                if aux_time_coords:
+                    ds = ds.drop_vars(aux_time_coords)
+                return ds
 
             # Validate frequency consistency and CMIP6 compatibility before concatenation
             # Skip validation for time-independent variables (e.g., areacello, static grids)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1440,9 +1440,17 @@ class TestCMIP6CMORiserWrite:
 class TestPreprocessAuxTimeCoords:
     """Tests that _preprocess drops time_0/time_1 auxiliary UM coordinates.
 
-    Without this, xr.open_mfdataset join='outer' unions every distinct
-    time_0/time_1 value across files into a full dimension, inflating the
-    Dask task graph to several GiB before any computation starts.
+    The fix must run inside _preprocess (per-file, before xr.open_mfdataset
+    combines files), because join='outer' unions every distinct coordinate
+    value into a full dimension during the combine step.
+
+    We mock xr.open_mfdataset so that the preprocess kwarg receives a
+    dataset that already has time_1/time_0 as non-dimension coordinates.
+    This is necessary because with decode_cf=False, xarray does not parse
+    the NetCDF 'coordinates' attribute, so aux coords read from real files
+    appear as data variables and are filtered out before _preprocess can
+    call drop_vars.  The mock lets us test the coordinate-dropping branch
+    directly.
     """
 
     @pytest.fixture
@@ -1460,38 +1468,10 @@ class TestPreprocessAuxTimeCoords:
             "positive": None,
         }
 
-    def _make_nc_file(self, path, time_val, extra_coords):
-        """Write a minimal single-timestep NetCDF file with optional aux time coords."""
-        ds = xr.Dataset(
-            {"cSoil": (["time", "lat", "lon"], np.ones((1, 2, 2), dtype="f4"))},
-            coords={
-                "time": (
-                    ["time"],
-                    [time_val],
-                    {"units": "days since 2000-01-01", "calendar": "standard"},
-                ),
-                "lat": (["lat"], [0.0, 1.0]),
-                "lon": (["lon"], [0.0, 1.0]),
-                **extra_coords,
-            },
-        )
-        ds.to_netcdf(str(path))
-        return path
-
-    @pytest.mark.unit
-    def test_preprocess_drops_time_1(self, mock_vocab, mock_mapping, tmp_path):
-        """time_1 present in every file must be absent from the combined dataset."""
-        files = [
-            self._make_nc_file(
-                tmp_path / f"f{i}.nc",
-                time_val=i,
-                extra_coords={"time_1": (["time"], [float(i)])},
-            )
-            for i in range(3)
-        ]
-
-        cmoriser = CMORiser(
-            input_paths=[str(f) for f in files],
+    @pytest.fixture
+    def base_cmoriser(self, mock_vocab, mock_mapping, tmp_path):
+        return CMORiser(
+            input_paths=["dummy.nc"],
             output_path=str(tmp_path),
             vocab=mock_vocab,
             variable_mapping=mock_mapping,
@@ -1500,102 +1480,77 @@ class TestPreprocessAuxTimeCoords:
             enable_chunking=False,
         )
 
-        with patch.object(cmoriser, "_normalize_missing_values_early"):
-            cmoriser.load_dataset(required_vars={"cSoil"})
+    def _make_open_mfdataset_mock(self, extra_coords):
+        """Return a side_effect for xr.open_mfdataset that applies the
+        preprocess kwarg to a single-file dataset containing extra_coords
+        as non-dimension coordinates.  This simulates what open_mfdataset
+        does per file, bypassing the decode_cf=False coordinate-detection
+        limitation of the real NetCDF backend."""
 
-        assert "time_1" not in cmoriser.ds.coords
-        assert "time_1" not in cmoriser.ds.dims
-        assert "cSoil" in cmoriser.ds.data_vars
-
-    @pytest.mark.unit
-    def test_preprocess_drops_time_0(self, mock_vocab, mock_mapping, tmp_path):
-        """time_0 present in every file must be absent from the combined dataset."""
-        files = [
-            self._make_nc_file(
-                tmp_path / f"f{i}.nc",
-                time_val=i,
-                extra_coords={"time_0": (["time"], [float(i)])},
-            )
-            for i in range(3)
-        ]
-
-        cmoriser = CMORiser(
-            input_paths=[str(f) for f in files],
-            output_path=str(tmp_path),
-            vocab=mock_vocab,
-            variable_mapping=mock_mapping,
-            compound_name="Lmon.cSoil",
-            validate_frequency=False,
-            enable_chunking=False,
-        )
-
-        with patch.object(cmoriser, "_normalize_missing_values_early"):
-            cmoriser.load_dataset(required_vars={"cSoil"})
-
-        assert "time_0" not in cmoriser.ds.coords
-        assert "time_0" not in cmoriser.ds.dims
-        assert "cSoil" in cmoriser.ds.data_vars
-
-    @pytest.mark.unit
-    def test_preprocess_drops_both_time_0_and_time_1(
-        self, mock_vocab, mock_mapping, tmp_path
-    ):
-        """Both time_0 and time_1 must be dropped when both are present."""
-        files = [
-            self._make_nc_file(
-                tmp_path / f"f{i}.nc",
-                time_val=i,
-                extra_coords={
-                    "time_0": (["time"], [float(i)]),
-                    "time_1": (["time"], [float(i) + 0.5]),
+        def fake_open_mfdataset(paths, *, preprocess=None, **kwargs):
+            ds = xr.Dataset(
+                {"cSoil": (["time", "lat", "lon"], np.ones((1, 2, 2), dtype="f4"))},
+                coords={
+                    "time": (
+                        "time",
+                        [0.0],
+                        {"units": "days since 2000-01-01", "calendar": "standard"},
+                    ),
+                    "lat": ("lat", [0.0, 1.0]),
+                    "lon": ("lon", [0.0, 1.0]),
+                    **extra_coords,
                 },
             )
-            for i in range(3)
-        ]
+            if preprocess is not None:
+                ds = preprocess(ds)
+            return ds
 
-        cmoriser = CMORiser(
-            input_paths=[str(f) for f in files],
-            output_path=str(tmp_path),
-            vocab=mock_vocab,
-            variable_mapping=mock_mapping,
-            compound_name="Lmon.cSoil",
-            validate_frequency=False,
-            enable_chunking=False,
-        )
-
-        with patch.object(cmoriser, "_normalize_missing_values_early"):
-            cmoriser.load_dataset(required_vars={"cSoil"})
-
-        assert "time_0" not in cmoriser.ds.coords
-        assert "time_1" not in cmoriser.ds.coords
-        assert "cSoil" in cmoriser.ds.data_vars
+        return fake_open_mfdataset
 
     @pytest.mark.unit
-    def test_preprocess_no_aux_coords_unaffected(
-        self, mock_vocab, mock_mapping, tmp_path
-    ):
-        """Files without time_0/time_1 must load normally without error."""
-        files = [
-            self._make_nc_file(
-                tmp_path / f"f{i}.nc",
-                time_val=i,
-                extra_coords={},
-            )
-            for i in range(3)
-        ]
+    def test_preprocess_drops_time_1(self, base_cmoriser):
+        """time_1 as a non-dimension coordinate must be dropped by _preprocess."""
+        mock_fn = self._make_open_mfdataset_mock({"time_1": ("time", [-0.5])})
+        with patch("access_moppy.base.xr.open_mfdataset", side_effect=mock_fn):
+            with patch.object(base_cmoriser, "_normalize_missing_values_early"):
+                base_cmoriser.load_dataset(required_vars={"cSoil"})
 
-        cmoriser = CMORiser(
-            input_paths=[str(f) for f in files],
-            output_path=str(tmp_path),
-            vocab=mock_vocab,
-            variable_mapping=mock_mapping,
-            compound_name="Lmon.cSoil",
-            validate_frequency=False,
-            enable_chunking=False,
+        assert "time_1" not in base_cmoriser.ds.coords
+        assert "time_1" not in base_cmoriser.ds.data_vars
+        assert "cSoil" in base_cmoriser.ds.data_vars
+
+    @pytest.mark.unit
+    def test_preprocess_drops_time_0(self, base_cmoriser):
+        """time_0 as a non-dimension coordinate must be dropped by _preprocess."""
+        mock_fn = self._make_open_mfdataset_mock({"time_0": ("time", [-1.0])})
+        with patch("access_moppy.base.xr.open_mfdataset", side_effect=mock_fn):
+            with patch.object(base_cmoriser, "_normalize_missing_values_early"):
+                base_cmoriser.load_dataset(required_vars={"cSoil"})
+
+        assert "time_0" not in base_cmoriser.ds.coords
+        assert "time_0" not in base_cmoriser.ds.data_vars
+        assert "cSoil" in base_cmoriser.ds.data_vars
+
+    @pytest.mark.unit
+    def test_preprocess_drops_both_time_0_and_time_1(self, base_cmoriser):
+        """Both time_0 and time_1 must be dropped when both are present."""
+        mock_fn = self._make_open_mfdataset_mock(
+            {"time_0": ("time", [-1.0]), "time_1": ("time", [-0.5])}
         )
+        with patch("access_moppy.base.xr.open_mfdataset", side_effect=mock_fn):
+            with patch.object(base_cmoriser, "_normalize_missing_values_early"):
+                base_cmoriser.load_dataset(required_vars={"cSoil"})
 
-        with patch.object(cmoriser, "_normalize_missing_values_early"):
-            cmoriser.load_dataset(required_vars={"cSoil"})
+        assert "time_0" not in base_cmoriser.ds.coords
+        assert "time_1" not in base_cmoriser.ds.coords
+        assert "cSoil" in base_cmoriser.ds.data_vars
 
-        assert "cSoil" in cmoriser.ds.data_vars
-        assert cmoriser.ds.dims["time"] == 3
+    @pytest.mark.unit
+    def test_preprocess_no_aux_coords_unaffected(self, base_cmoriser):
+        """Files without time_0/time_1 must load normally without error."""
+        mock_fn = self._make_open_mfdataset_mock({})
+        with patch("access_moppy.base.xr.open_mfdataset", side_effect=mock_fn):
+            with patch.object(base_cmoriser, "_normalize_missing_values_early"):
+                base_cmoriser.load_dataset(required_vars={"cSoil"})
+
+        assert "cSoil" in base_cmoriser.ds.data_vars

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1435,3 +1435,167 @@ class TestCMIP6CMORiserWrite:
             with nc.Dataset(output_files[0], "r") as ds_nc:
                 assert "type_strlen" in ds_nc.dimensions
                 assert ds_nc.dimensions["type_strlen"].size == 11
+
+
+class TestPreprocessAuxTimeCoords:
+    """Tests that _preprocess drops time_0/time_1 auxiliary UM coordinates.
+
+    Without this, xr.open_mfdataset join='outer' unions every distinct
+    time_0/time_1 value across files into a full dimension, inflating the
+    Dask task graph to several GiB before any computation starts.
+    """
+
+    @pytest.fixture
+    def mock_vocab(self):
+        vocab = Mock()
+        vocab.__class__.__name__ = "CMIP6Vocabulary"
+        return vocab
+
+    @pytest.fixture
+    def mock_mapping(self):
+        return {
+            "CF standard Name": "soil_carbon_content",
+            "units": "kg m-2",
+            "dimensions": {"time": "time", "lat": "lat", "lon": "lon"},
+            "positive": None,
+        }
+
+    def _make_nc_file(self, path, time_val, extra_coords):
+        """Write a minimal single-timestep NetCDF file with optional aux time coords."""
+        ds = xr.Dataset(
+            {"cSoil": (["time", "lat", "lon"], np.ones((1, 2, 2), dtype="f4"))},
+            coords={
+                "time": (
+                    ["time"],
+                    [time_val],
+                    {"units": "days since 2000-01-01", "calendar": "standard"},
+                ),
+                "lat": (["lat"], [0.0, 1.0]),
+                "lon": (["lon"], [0.0, 1.0]),
+                **extra_coords,
+            },
+        )
+        ds.to_netcdf(str(path))
+        return path
+
+    @pytest.mark.unit
+    def test_preprocess_drops_time_1(self, mock_vocab, mock_mapping, tmp_path):
+        """time_1 present in every file must be absent from the combined dataset."""
+        files = [
+            self._make_nc_file(
+                tmp_path / f"f{i}.nc",
+                time_val=i,
+                extra_coords={"time_1": (["time"], [float(i)])},
+            )
+            for i in range(3)
+        ]
+
+        cmoriser = CMORiser(
+            input_paths=[str(f) for f in files],
+            output_path=str(tmp_path),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="Lmon.cSoil",
+            validate_frequency=False,
+            enable_chunking=False,
+        )
+
+        with patch.object(cmoriser, "_normalize_missing_values_early"):
+            cmoriser.load_dataset(required_vars={"cSoil"})
+
+        assert "time_1" not in cmoriser.ds.coords
+        assert "time_1" not in cmoriser.ds.dims
+        assert "cSoil" in cmoriser.ds.data_vars
+
+    @pytest.mark.unit
+    def test_preprocess_drops_time_0(self, mock_vocab, mock_mapping, tmp_path):
+        """time_0 present in every file must be absent from the combined dataset."""
+        files = [
+            self._make_nc_file(
+                tmp_path / f"f{i}.nc",
+                time_val=i,
+                extra_coords={"time_0": (["time"], [float(i)])},
+            )
+            for i in range(3)
+        ]
+
+        cmoriser = CMORiser(
+            input_paths=[str(f) for f in files],
+            output_path=str(tmp_path),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="Lmon.cSoil",
+            validate_frequency=False,
+            enable_chunking=False,
+        )
+
+        with patch.object(cmoriser, "_normalize_missing_values_early"):
+            cmoriser.load_dataset(required_vars={"cSoil"})
+
+        assert "time_0" not in cmoriser.ds.coords
+        assert "time_0" not in cmoriser.ds.dims
+        assert "cSoil" in cmoriser.ds.data_vars
+
+    @pytest.mark.unit
+    def test_preprocess_drops_both_time_0_and_time_1(
+        self, mock_vocab, mock_mapping, tmp_path
+    ):
+        """Both time_0 and time_1 must be dropped when both are present."""
+        files = [
+            self._make_nc_file(
+                tmp_path / f"f{i}.nc",
+                time_val=i,
+                extra_coords={
+                    "time_0": (["time"], [float(i)]),
+                    "time_1": (["time"], [float(i) + 0.5]),
+                },
+            )
+            for i in range(3)
+        ]
+
+        cmoriser = CMORiser(
+            input_paths=[str(f) for f in files],
+            output_path=str(tmp_path),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="Lmon.cSoil",
+            validate_frequency=False,
+            enable_chunking=False,
+        )
+
+        with patch.object(cmoriser, "_normalize_missing_values_early"):
+            cmoriser.load_dataset(required_vars={"cSoil"})
+
+        assert "time_0" not in cmoriser.ds.coords
+        assert "time_1" not in cmoriser.ds.coords
+        assert "cSoil" in cmoriser.ds.data_vars
+
+    @pytest.mark.unit
+    def test_preprocess_no_aux_coords_unaffected(
+        self, mock_vocab, mock_mapping, tmp_path
+    ):
+        """Files without time_0/time_1 must load normally without error."""
+        files = [
+            self._make_nc_file(
+                tmp_path / f"f{i}.nc",
+                time_val=i,
+                extra_coords={},
+            )
+            for i in range(3)
+        ]
+
+        cmoriser = CMORiser(
+            input_paths=[str(f) for f in files],
+            output_path=str(tmp_path),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="Lmon.cSoil",
+            validate_frequency=False,
+            enable_chunking=False,
+        )
+
+        with patch.object(cmoriser, "_normalize_missing_values_early"):
+            cmoriser.load_dataset(required_vars={"cSoil"})
+
+        assert "cSoil" in cmoriser.ds.data_vars
+        assert cmoriser.ds.dims["time"] == 3


### PR DESCRIPTION
Solved #256 

### Problem

When processing land variables that require multiple model variables (e.g. `cSoil`, `cSoilFast`, `cSoilMedium`, `cSoilSlow`), the job hangs indefinitely before `cmoriser.run()` is called and eventually gets killed by PBS walltime.

UM land output files contain auxiliary time coordinates (`time_0`, `time_1`) whose values differ between files. The previous `_preprocess` function only filtered data variables but preserved all attached coordinates:

```python
def _preprocess(ds):
    return ds[list(required_vars & set(ds.data_vars))]
```

When `xr.open_mfdataset` combines many files, `join='outer'` (xarray default) unions every distinct `time_1` value across all files into a full dimension. For a large run (e.g. 1200 monthly files), this turns a `(1200, 17, 144, 192)` array into a `(1200, 1200, 17, 144, 192)` sparse array, inflating the Dask task graph to **5.73 GiB** before any computation begins.

The main process then blocks waiting for Dask to return results from a worker that has already been killed by OOM, with no timeout — until PBS terminates the job at walltime.

### Fix

Drop `time_0` and `time_1` inside `_preprocess`, per-file and before `xr.open_mfdataset` performs any cross-file alignment:

```python
def _preprocess(ds):
    ds = ds[list(required_vars & set(ds.data_vars))]
    # Drop auxiliary UM time coordinates (time_0, time_1) that differ
    # across files. Without this, xr.open_mfdataset's join='outer'
    # unions every distinct value into a growing dimension, inflating
    # the Dask task graph to several GiB before any computation starts.
    aux_time_coords = [c for c in ("time_0", "time_1") if c in ds]
    if aux_time_coords:
        ds = ds.drop_vars(aux_time_coords)
    return ds
```

The fix must be in `_preprocess` (not after `xr.open_mfdataset` returns) because the bloated task graph is constructed during file combination — by the time `open_mfdataset` returns, the damage is already done.