### PR TITLE
Reorder dimension

### DIFF
--- a/src/access_moppy/atmosphere.py
+++ b/src/access_moppy/atmosphere.py
@@ -241,6 +241,10 @@ class Atmosphere_CMORiser(CMORiser):
             transpose_order = ["time"] + [
                 dim for dim in transpose_order if dim != "time"
             ]
+        if "lat" in transpose_order and "lon" in transpose_order:
+            if transpose_order.index("lat") > transpose_order.index("lon"):
+                transpose_order.remove("lat")
+                transpose_order.insert(transpose_order.index("lon"), "lat")
 
         self.ds[self.cmor_name] = self.ds[self.cmor_name].transpose(*transpose_order)
 

--- a/src/access_moppy/atmosphere.py
+++ b/src/access_moppy/atmosphere.py
@@ -237,14 +237,14 @@ class Atmosphere_CMORiser(CMORiser):
             if dim not in transpose_order and self.ds[self.cmor_name][dim].size == 1:
                 self.ds[self.cmor_name] = self.ds[self.cmor_name].squeeze(dim)
 
-        if "time" in transpose_order:
-            transpose_order = ["time"] + [
-                dim for dim in transpose_order if dim != "time"
-            ]
-        if "lat" in transpose_order and "lon" in transpose_order:
-            if transpose_order.index("lat") > transpose_order.index("lon"):
-                transpose_order.remove("lat")
-                transpose_order.insert(transpose_order.index("lon"), "lat")
+        # Enforce dimension order: time first, lat/lon last (lat before lon),
+        # with any remaining dimensions (e.g. lev) in between.
+        time_dims = [dim for dim in transpose_order if dim == "time"]
+        middle_dims = [
+            dim for dim in transpose_order if dim not in ("time", "lat", "lon")
+        ]
+        lat_lon_dims = [dim for dim in ("lat", "lon") if dim in transpose_order]
+        transpose_order = time_dims + middle_dims + lat_lon_dims
 
         self.ds[self.cmor_name] = self.ds[self.cmor_name].transpose(*transpose_order)
 


### PR DESCRIPTION
## Summary

Replace two separate dimension-ordering checks with a unified three-segment
approach to enforce a consistent output dimension order:
**`time → [other dims] → lat → lon`**

## Changes

`src/access_moppy/atmosphere.py` — `reorder_dims` method

**Before:**

```python
if "time" in transpose_order:
    transpose_order = ["time"] + [
        dim for dim in transpose_order if dim != "time"
    ]

if "lat" in transpose_order and "lon" in transpose_order:
    if transpose_order.index("lat") > transpose_order.index("lon"):
        transpose_order.remove("lat")
        transpose_order.insert(transpose_order.index("lon"), "lat")
```
**After:**
```
# Enforce dimension order: time first, lat/lon last (lat before lon),
# with any remaining dimensions (e.g. lev) in between.
time_dims = [dim for dim in transpose_order if dim == "time"]
middle_dims = [dim for dim in transpose_order if dim not in ("time", "lat", "lon")]
lat_lon_dims = [dim for dim in ("lat", "lon") if dim in transpose_order]
transpose_order = time_dims + middle_dims + lat_lon_dims
```

## Behaviour

- `[lon, lat, lev, time]` → `[time, lev, lat, lon]`
- `[lon, lat, time]` → `[time, lat, lon]`
- `[lat, lon]` → `[lat, lon]`