### PR TITLE
feat: add utility to calculate correct UM hybrid-height b coefficients (issue #164)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -95,6 +95,55 @@ To run tests:
 
 ----
 
+Legacy model utilities
+----------------------
+
+ACCESS-MOPPy officially targets ACCESS-ESM1.6 and later models.  For users
+who need to work with older output (ACCESS-ESM1.5, ACCESS-CM2), the
+``access_moppy.legacy_utilities`` sub-package provides helper scripts that
+are not part of the main CMORisation pipeline.
+
+``moppy-calc-ab-coeffts`` — Hybrid-height b coefficient calculator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The UM (Unified Model) atmosphere uses a hybrid-height vertical coordinate
+whose orography-following ``b`` coefficients must be computed from the raw η
+(eta) values in the ``vertlevs`` namelist file via a quadratic formula::
+
+    b(k) = (1 − η(k) / η_etadot)²
+
+ACCESS-ESM1.5 and ACCESS-CM2 CMIP6 output incorrectly stored the raw η
+values directly as ``sigma_theta``, omitting this transformation.
+ACCESS-ESM1.6 output already contains the correctly transformed values, so
+no correction is needed for officially-supported data.
+
+The utility can be invoked from the command line:
+
+.. code-block:: bash
+
+   # install the optional f90nml dependency first
+   pip install "access_moppy[atmos-tools]"
+
+   moppy-calc-ab-coeffts /path/to/vertlevs_G3
+
+Or in Python:
+
+.. code-block:: python
+
+   from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+   a_theta, b_theta, a_rho, b_rho = calc_ab("/path/to/vertlevs_G3")
+
+Typical ``vertlevs`` file locations:
+
+- ESM1.5 / ESM1.6: ``/g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3``
+- CM2 / CM2.1: ``~access/umdir/vn10.6/ctldata/vert/vertlevs_L85_50t_35s_85km``
+
+See also: `Martin Dix's original script <https://gist.github.com/MartinDix/14d6ab8fa6997c18f5bf5456d22756d5>`_,
+and the discussion in `issue #164 <https://github.com/ACCESS-NRI/ACCESS-MOPPy/issues/164>`_.
+
+----
+
 License
 -------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,18 @@ dynamic = ["version"]
 dashboard = [
   "streamlit>=1.35.0"
 ]
+# pip install access_moppy[atmos-tools]
+# Required for the moppy-calc-ab-coeffts utility that reads UM vertlevs
+# Fortran namelist files to compute correct hybrid-height b coefficients.
+atmos-tools = [
+  "f90nml"
+]
 test = [
     "pytest",
     "pytest-cov",
     "pytest-subtests",
-    "ruff"
+    "ruff",
+    "f90nml"
 ]
 docs = [
     "sphinx>=7.0.0",
@@ -62,6 +69,7 @@ docs = [
 moppy-cmorise = "access_moppy.batch_cmoriser:main"
 moppy-dashboard = "access_moppy.dashboard.cmor_dashboard:main"
 moppy-example-config = "access_moppy.examples.show_config:main"
+moppy-calc-ab-coeffts = "access_moppy.legacy_utilities.calc_hybrid_height_coeffs:main"
 
 [build-system]
 build-backend = "setuptools.build_meta"

--- a/src/access_moppy/legacy_utilities/calc_hybrid_height_coeffs.py
+++ b/src/access_moppy/legacy_utilities/calc_hybrid_height_coeffs.py
@@ -1,0 +1,240 @@
+"""Utility to calculate the correct a and b coefficients for the UM hybrid
+height vertical coordinate scheme.
+
+Background
+----------
+The UM (Unified Model) atmosphere uses a "hybrid height" vertical coordinate
+where model level heights are defined as::
+
+    z(k) = a(k) + b(k) * z_surface
+
+The ``a`` coefficient represents the pure height component (metres above sea
+level) and ``b`` is a dimensionless orography-following factor that smoothly
+decreases from 1 at the model surface to 0 when levels become purely
+height-based.  Both coefficients are derived from the raw eta (η) levels
+stored in the UM vertlevs namelist file.
+
+The correct formula (from UM7 setcona.F90, ``height_gen_smooth`` option; see
+also eq. 4.1 of Davies et al., 2005, doi:10.1256/qj.04.101) is::
+
+    a(k) = η(k) × z_top_of_model
+    b(k) = (1 − η(k) / η[first_constant_r_rho_level])²
+
+The quadratic term means that b ≠ η.
+
+
+The bug in ACCESS-ESM1.5 and ACCESS-CM2 CMIP6 output
+------------------------------------------------------
+ACCESS-ESM1.5 and ACCESS-CM2 CMIP6 output incorrectly stored the raw η values
+directly as the ``sigma_theta`` (and ``sigma_rho``) coordinate variables,
+omitting the quadratic transformation.  This produces subtly wrong vertical
+coordinates that affect any analysis relying on the orography-following part
+of the hybrid height formula.
+
+ACCESS-ESM1.6 (the first model officially supported by ACCESS-MOPPy) stores
+the correctly transformed b values in its output files, so no correction is
+needed for ESM1.6 data.
+
+
+Why this utility may still be useful for ACCESS-ESM1.5 / ACCESS-CM2 users
+--------------------------------------------------------------------------
+ACCESS-MOPPy officially targets ACCESS-ESM1.6 and later models.  However,
+users who need to compare with, or re-process, archived ACCESS-ESM1.5 or
+ACCESS-CM2 data may encounter the incorrect ``sigma_theta`` values described
+above.
+
+This script can be used to:
+
+1. Verify or regenerate the correct a and b coefficients from a vertlevs file.
+2. Understand what the quadratic correction looks like numerically compared
+   with the raw η values stored in older files.
+3. Pre-process ACCESS-ESM1.5 / ACCESS-CM2 NetCDF files to replace the
+   incorrect ``sigma_theta`` / ``sigma_rho`` values with the correctly
+   computed b coefficients before feeding them into further analysis workflows.
+
+The vertlevs files for each model configuration can typically be found at paths
+like:
+
+* ESM1.5 / ESM1.6:
+  ``/g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/
+  resolution_independent/2020.05.19/vertlevs_G3``
+* CM2 / CM2.1:
+  ``~access/umdir/vn10.6/ctldata/vert/vertlevs_L85_50t_35s_85km``
+
+
+Usage
+-----
+From the command line (after installing access_moppy)::
+
+    moppy-calc-ab-coeffts /path/to/vertlevs_file
+
+Or in Python::
+
+    from access_moppy.calc_hybrid_height_coeffs import calc_ab
+    a_theta, b_theta, a_rho, b_rho = calc_ab("/path/to/vertlevs_file")
+
+
+Dependencies
+------------
+This utility requires ``f90nml`` to parse the Fortran namelist vertlevs file.
+Install it with::
+
+    pip install f90nml
+    # or, if using pixi:
+    pixi add f90nml
+
+``f90nml`` is listed as an optional dependency of access_moppy under the
+``[atmos-tools]`` extra::
+
+    pip install "access_moppy[atmos-tools]"
+
+
+References
+----------
+* UM7 setcona.F90 (height_gen_smooth option):
+  https://github.com/ACCESS-NRI/UM7/blob/b5f58fcf8487c177b0d75878bcf015102a90dc7c/umbase_hg3/src/control/top_level/setcona.F90#L503
+* Davies, T., Cullen, M. J. P., Malcolm, A. J., Mawson, M. H., Staniforth, A.,
+  White, A. A., & Wood, N. (2005). A new dynamical core for the Met Office's
+  global and regional modelling of the atmosphere. Q. J. R. Meteorol. Soc.,
+  131(608), 1759–1782. https://doi.org/10.1256/qj.04.101
+* Original script by Martin Dix:
+  https://gist.github.com/MartinDix/14d6ab8fa6997c18f5bf5456d22756d5
+"""
+
+import sys
+
+import numpy as np
+
+
+def calc_ab(vfile):
+    """Calculate the a and b hybrid-height coefficients from a UM vertlevs file.
+
+    Parameters
+    ----------
+    vfile : str or path-like
+        Path to the Fortran namelist file containing the ``&VERTLEVS``
+        namelist (e.g. ``vertlevs_G3`` for ACCESS-ESM1.5 / ESM1.6).
+
+    Returns
+    -------
+    a_theta : numpy.ndarray, shape (model_levels + 1,)
+        a coefficient (metres) for theta (full / cell-centre) levels.
+        Index 0 corresponds to the surface level (k=0 in UM convention).
+    b_theta : numpy.ndarray, shape (model_levels + 1,)
+        Correctly computed b coefficient for theta levels (dimensionless).
+        Index 0 corresponds to the surface (b = 1 there, by construction).
+    a_rho : numpy.ndarray, shape (model_levels + 1,)
+        a coefficient (metres) for rho (half / cell-interface) levels.
+        Index 0 is unused (rho levels start at k=1 in UM convention).
+    b_rho : numpy.ndarray, shape (model_levels + 1,)
+        Correctly computed b coefficient for rho levels (dimensionless).
+
+    Notes
+    -----
+    The UM stores raw η (eta) values in the vertlevs namelist, ranging from
+    0 at the surface to 1 at the model top.  The orography-following b
+    coefficient is derived via a quadratic formula:
+
+        b(k) = (1 − η(k) / η_etadot)²
+
+    where ``η_etadot = eta_rho[first_constant_r_rho_level]`` is the η value
+    of the first rho level at which the coordinate becomes purely
+    height-based (b = 0 for all levels at or above this index).
+
+    This quadratic transformation was **incorrectly omitted** in the CMIP6
+    output produced by ACCESS-ESM1.5 and ACCESS-CM2, which wrote raw η as
+    the ``sigma_theta`` coordinate variable.  ACCESS-ESM1.6 output already
+    contains the correctly transformed values.
+
+    Raises
+    ------
+    ImportError
+        If ``f90nml`` is not installed.  Install it via
+        ``pip install f90nml`` or ``pip install 'access_moppy[atmos-tools]'``.
+    """
+    try:
+        import f90nml
+    except ImportError as exc:
+        raise ImportError(
+            "The 'f90nml' package is required to read UM vertlevs files.  "
+            "Install it with:  pip install f90nml\n"
+            "  or:  pip install 'access_moppy[atmos-tools]'"
+        ) from exc
+
+    vertlevs = f90nml.read(vfile)["vertlevs"]
+
+    # eta_theta includes the surface (k=0) as its first element.
+    eta_theta_levels = np.array(vertlevs["eta_theta"])  # shape: (model_levels+1,)
+
+    # eta_rho does NOT include k=0 in the namelist; prepend a sentinel value
+    # so that array index k directly corresponds to UM level k (1-based).
+    eta_rho_levels = np.array([-1e20] + vertlevs["eta_rho"])  # shape: (model_levels+1,)
+
+    z_top_of_model = vertlevs["z_top_of_model"]
+
+    # first_constant_r_rho_level is the first rho level at which the atmosphere
+    # is fully decoupled from orography, i.e. b = 0 at and above this level.
+    first_constant_r_rho_level = vertlevs["first_constant_r_rho_level"]
+
+    # η_etadot: the reference eta value used in the quadratic formula.
+    # This is the eta_rho value at the transition level.
+    eta_etadot = eta_rho_levels[first_constant_r_rho_level]
+
+    nlev = len(eta_theta_levels)
+    a_theta = np.zeros(nlev)
+    b_theta = np.zeros(nlev)
+    a_rho = np.zeros(nlev)
+    b_rho = np.zeros(nlev)
+
+    # --- Orography-following region (levels 1 .. first_constant_r_rho_level-1) ---
+    # The quadratic transformation b = (1 − η / η_etadot)² ensures a smooth
+    # transition: b ≈ 1 near the surface (small η) and b → 0 as η → η_etadot.
+    for k in range(1, first_constant_r_rho_level):
+        a_rho[k] = eta_rho_levels[k] * z_top_of_model
+        b_rho[k] = (1.0 - eta_rho_levels[k] / eta_etadot) ** 2
+        a_theta[k] = eta_theta_levels[k] * z_top_of_model
+        b_theta[k] = (1.0 - eta_theta_levels[k] / eta_etadot) ** 2
+
+    # --- Pure height-based region (levels first_constant_r_rho_level and above) ---
+    # b = 0 here; levels are independent of orography.
+    a_theta[first_constant_r_rho_level:] = (
+        eta_theta_levels[first_constant_r_rho_level:] * z_top_of_model
+    )
+    b_theta[first_constant_r_rho_level:] = 0.0
+
+    a_rho[first_constant_r_rho_level:] = (
+        eta_rho_levels[first_constant_r_rho_level:] * z_top_of_model
+    )
+    b_rho[first_constant_r_rho_level:] = 0.0
+
+    return a_theta, b_theta, a_rho, b_rho
+
+
+def main():
+    """Command-line entry point: calculate and print a/b coefficients.
+
+    Usage::
+
+        moppy-calc-ab-coeffts <vertlevs_file>
+    """
+    if len(sys.argv) != 2:
+        print(
+            "Usage: moppy-calc-ab-coeffts <vertlevs_file>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    vertlevs_file = sys.argv[1]
+    a_theta, b_theta, a_rho, b_rho = calc_ab(vertlevs_file)
+
+    print("Theta (full) levels a, b")
+    for k in range(1, len(a_theta)):
+        print(f"{k:02d} {a_theta[k]:12.6f} {b_theta[k]:10.8f}")
+
+    print("Rho (half) levels a, b")
+    for k in range(1, len(a_rho)):
+        print(f"{k:02d} {a_rho[k]:12.6f} {b_rho[k]:10.8f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_calc_hybrid_height_coeffs.py
+++ b/tests/unit/test_calc_hybrid_height_coeffs.py
@@ -1,0 +1,220 @@
+"""Tests for access_moppy.legacy_utilities.calc_hybrid_height_coeffs.
+
+These tests exercise the calc_ab() function using synthetic vertlevs data
+rather than real files – no f90nml or actual ACCESS files are required.
+"""
+
+import textwrap
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_vertlevs(tmp_path: Path, eta_theta, eta_rho, z_top, first_const) -> Path:
+    """Write a minimal UM-style vertlevs namelist file and return its path."""
+
+    def _fmt(arr):
+        return ", ".join(f"{v:.10f}" for v in arr)
+
+    content = textwrap.dedent(f"""\
+        &VERTLEVS
+        z_top_of_model = {z_top:.6f},
+        first_constant_r_rho_level = {first_const},
+        eta_theta = {_fmt(eta_theta)},
+        eta_rho = {_fmt(eta_rho)},
+        /
+        """)
+    p = tmp_path / "test_vertlevs"
+    p.write_text(content)
+    return p
+
+
+def _make_simple_vertlevs(tmp_path, n_lev=5, transition_at=3):
+    """
+    Construct a simple synthetic vertlevs with *n_lev* levels and the rho
+    'transition' (first_constant_r_rho_level) at index *transition_at*.
+
+    Levels are equally spaced in eta from 0 to 1.
+    """
+    z_top = 85000.0
+    # eta_theta: 0, 1/n_lev, 2/n_lev, ... 1   (length n_lev+1, includes surface)
+    eta_theta = np.linspace(0.0, 1.0, n_lev + 1)
+    # eta_rho: midpoints between theta levels (length n_lev, no surface)
+    eta_rho = 0.5 * (eta_theta[:-1] + eta_theta[1:])
+    first_const = transition_at
+    return _write_vertlevs(tmp_path, eta_theta, eta_rho, z_top, first_const)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCalcAb:
+    """Tests for calc_hybrid_height_coeffs.calc_ab()."""
+
+    @pytest.fixture(autouse=True)
+    def _require_f90nml(self):
+        """Skip this test class if f90nml is not available."""
+        pytest.importorskip("f90nml")
+
+    @pytest.mark.unit
+    def test_output_shapes(self, tmp_path):
+        """a/b arrays should have length model_levels + 1."""
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+        n_lev = 5
+        vfile = _make_simple_vertlevs(tmp_path, n_lev=n_lev)
+        a_theta, b_theta, a_rho, b_rho = calc_ab(vfile)
+        assert a_theta.shape == (n_lev + 1,)
+        assert b_theta.shape == (n_lev + 1,)
+        assert a_rho.shape == (n_lev + 1,)
+        assert b_rho.shape == (n_lev + 1,)
+
+    @pytest.mark.unit
+    def test_b_surface_is_one(self, tmp_path):
+        """The lowest usable non-zero b_theta value should be close to 1."""
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+        vfile = _make_simple_vertlevs(tmp_path, n_lev=5, transition_at=3)
+        _, b_theta, _, b_rho = calc_ab(vfile)
+        # Level 1 (index 1) is just above the surface; b should be nearly 1.
+        # Exact value depends on spacing, but must be in (0, 1].
+        assert 0.0 < b_theta[1] <= 1.0
+        assert 0.0 < b_rho[1] <= 1.0
+
+    @pytest.mark.unit
+    def test_b_zero_above_transition(self, tmp_path):
+        """b must be exactly 0.0 for all levels at or above first_constant_r_rho_level."""
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+        transition = 3
+        vfile = _make_simple_vertlevs(tmp_path, n_lev=5, transition_at=transition)
+        _, b_theta, _, b_rho = calc_ab(vfile)
+        np.testing.assert_array_equal(b_theta[transition:], 0.0)
+        np.testing.assert_array_equal(b_rho[transition:], 0.0)
+
+    @pytest.mark.unit
+    def test_b_nonzero_below_transition(self, tmp_path):
+        """b must be > 0 for all levels strictly below first_constant_r_rho_level."""
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+        transition = 3
+        vfile = _make_simple_vertlevs(tmp_path, n_lev=5, transition_at=transition)
+        _, b_theta, _, b_rho = calc_ab(vfile)
+        # Indices 1 .. transition-1 should be non-zero
+        assert np.all(b_theta[1:transition] > 0.0)
+        assert np.all(b_rho[1:transition] > 0.0)
+
+    @pytest.mark.unit
+    def test_a_equals_eta_times_ztop(self, tmp_path):
+        """a(k) must equal eta(k) * z_top_of_model for all levels."""
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+        n_lev = 5
+        z_top = 85000.0
+        transition = 3
+        vfile = _make_simple_vertlevs(tmp_path, n_lev=n_lev, transition_at=transition)
+        a_theta, _, a_rho, _ = calc_ab(vfile)
+
+        eta_theta = np.linspace(0.0, 1.0, n_lev + 1)
+        eta_rho = 0.5 * (eta_theta[:-1] + eta_theta[1:])
+
+        np.testing.assert_allclose(a_theta[1:], eta_theta[1:] * z_top, rtol=1e-6)
+        np.testing.assert_allclose(a_rho[1:], eta_rho * z_top, rtol=1e-6)
+
+    @pytest.mark.unit
+    def test_quadratic_formula(self, tmp_path):
+        """b(k) must equal (1 - eta(k)/eta_etadot)^2 for the orography region."""
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+        n_lev = 5
+        transition = 3
+        vfile = _make_simple_vertlevs(tmp_path, n_lev=n_lev, transition_at=transition)
+        _, b_theta, _, b_rho = calc_ab(vfile)
+
+        eta_theta = np.linspace(0.0, 1.0, n_lev + 1)
+        eta_rho = 0.5 * (eta_theta[:-1] + eta_theta[1:])
+        # eta_etadot is eta_rho at UM level first_constant_r_rho_level (1-based).
+        # The namelist rho array is 1-based in the UM convention, so Python index
+        # is (transition - 1).
+        eta_etadot = eta_rho[transition - 1]
+
+        for k in range(1, transition):
+            expected_b_theta = (1.0 - eta_theta[k] / eta_etadot) ** 2
+            # b_rho[k] uses the k-th rho level (1-based), which is eta_rho[k-1]
+            expected_b_rho = (1.0 - eta_rho[k - 1] / eta_etadot) ** 2
+            assert b_theta[k] == pytest.approx(expected_b_theta, rel=1e-6)
+            assert b_rho[k] == pytest.approx(expected_b_rho, rel=1e-6)
+
+    @pytest.mark.unit
+    def test_b_differs_from_raw_eta(self, tmp_path):
+        """b must NOT equal the raw eta values – this is the ESM1.5 bug check."""
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+        n_lev = 5
+        transition = 3
+        vfile = _make_simple_vertlevs(tmp_path, n_lev=n_lev, transition_at=transition)
+        _, b_theta, _, _ = calc_ab(vfile)
+
+        eta_theta = np.linspace(0.0, 1.0, n_lev + 1)
+        # For the orography-following levels, b ≠ η (raw).
+        for k in range(1, transition):
+            assert b_theta[k] != pytest.approx(eta_theta[k], rel=1e-6), (
+                f"Level {k}: b_theta ({b_theta[k]}) must not equal raw eta ({eta_theta[k]}). "
+                "This would be the ACCESS-ESM1.5 bug."
+            )
+
+
+class TestCalcAbMissingF90nml:
+    """calc_ab should raise a clear ImportError if f90nml is missing."""
+
+    @pytest.mark.unit
+    def test_import_error_without_f90nml(self, tmp_path):
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab
+
+        vfile = tmp_path / "dummy"
+        vfile.write_text("&VERTLEVS /\n")
+
+        with mock.patch.dict("sys.modules", {"f90nml": None}):
+            with pytest.raises(ImportError, match="f90nml"):
+                calc_ab(vfile)
+
+
+class TestMainEntryPoint:
+    """Smoke tests for the CLI entry point."""
+
+    @pytest.fixture(autouse=True)
+    def _require_f90nml(self):
+        pytest.importorskip("f90nml")
+
+    @pytest.mark.unit
+    def test_main_prints_output(self, tmp_path, capsys):
+        import sys
+
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import main
+
+        vfile = _make_simple_vertlevs(tmp_path, n_lev=5, transition_at=3)
+        with mock.patch.object(sys, "argv", ["moppy-calc-ab-coeffts", str(vfile)]):
+            main()
+
+        captured = capsys.readouterr()
+        assert "Theta (full) levels a, b" in captured.out
+        assert "Rho (half) levels a, b" in captured.out
+
+    @pytest.mark.unit
+    def test_main_exits_without_args(self, capsys):
+        import sys
+
+        from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import main
+
+        with mock.patch.object(sys, "argv", ["moppy-calc-ab-coeffts"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

Adds Martin Dix's diagnostic script as `access_moppy.legacy_utilities.calc_hybrid_height_coeffs`, a documented utility for computing the correct a/b coefficients for the UM hybrid-height vertical coordinate scheme from a `vertlevs` namelist file.

Closes #164

---

## Background

The UM uses a hybrid-height vertical coordinate where the orography-following `b` coefficient must be computed from raw η (eta) values via a quadratic formula:

```
b(k) = (1 − η(k) / η_etadot)²
```

**ACCESS-ESM1.5 and ACCESS-CM2 CMIP6 output incorrectly stored the raw η values directly as `sigma_theta`**, omitting this transformation. ACCESS-ESM1.6 (the first officially supported model) already stores the correctly transformed values, so no correction is needed for current data.

This utility is provided for users who need to verify or work with legacy ESM1.5/CM2 data, despite those models not being officially supported by ACCESS-MOPPy.

---

## Changes

| File | Description |
|------|-------------|
| `src/access_moppy/legacy_utilities/calc_hybrid_height_coeffs.py` | New utility module: `calc_ab()` function + `moppy-calc-ab-coeffts` CLI entry point, with full docstring covering the background, the ESM1.5 bug, usage examples, vertlevs file paths, and references |
| `src/access_moppy/legacy_utilities/__init__.py` | Package init |
| `pyproject.toml` | `atmos-tools` optional dep (`f90nml`), `moppy-calc-ab-coeffts` console script, `f90nml` added to `test` extras so CI exercises the utility |
| `tests/unit/test_calc_hybrid_height_coeffs.py` | 10 unit tests covering output shapes, surface b≈1, b=0 above transition, quadratic formula correctness, and the ESM1.5 bug regression check |
| `docs/source/index.rst` | "Legacy model utilities" section with CLI and Python usage examples |

---

## Usage

Install the optional dependency:
```bash
pip install "access_moppy[atmos-tools]"
```

CLI:
```bash
moppy-calc-ab-coeffts /path/to/vertlevs_G3
```

Python:
```python
from access_moppy.legacy_utilities.calc_hybrid_height_coeffs import calc_ab

a_theta, b_theta, a_rho, b_rho = calc_ab("/path/to/vertlevs_G3")
```

---

## References

- Original script: https://gist.github.com/MartinDix/14d6ab8fa6997c18f5bf5456d22756d5
- UM setcona.F90: https://github.com/ACCESS-NRI/UM7/blob/b5f58fcf8487c177b0d75878bcf015102a90dc7c/umbase_hg3/src/control/top_level/setcona.F90#L503
- Davies et al. (2005): https://doi.org/10.1256/qj.04.101