### PR TITLE
refactor: remove calc_ocean_depth_integral function and update mappin…

### DIFF
--- a/src/access_moppy/derivations/__init__.py
+++ b/src/access_moppy/derivations/__init__.py
@@ -26,7 +26,6 @@ from access_moppy.derivations.calc_land import (
 from access_moppy.derivations.calc_ocean import (
     calc_areacello,
     calc_global_ave_ocean,
-    calc_ocean_depth_integral,
     calc_rsdoabsorb,
     calc_total_mass_transport,
     calc_umo_corrected,
@@ -90,7 +89,6 @@ custom_functions = {
     "calc_tsl": calc_tsl,
     "calc_rsdoabsorb": calc_rsdoabsorb,
     "calc_zostoga": calc_zostoga,
-    "calc_ocean_depth_integral": calc_ocean_depth_integral,
     "calc_global_ave_ocean": calc_global_ave_ocean,
     "calc_total_mass_transport": calc_total_mass_transport,
     "calc_umo_corrected": calc_umo_corrected,

--- a/src/access_moppy/derivations/calc_ocean.py
+++ b/src/access_moppy/derivations/calc_ocean.py
@@ -139,53 +139,6 @@ def calc_zostoga(pot_temp, dzt, areacello, depth_coord="st_ocean"):
     return zostoga
 
 
-def calc_ocean_depth_integral(var, rho, dzt, depth_coord="st_ocean"):
-    """Calculate depth integral of product of sea water density and ocean variable.
-
-    This function computes the depth-integrated product of density and any
-    ocean variable. Commonly used for calculating column-integrated properties
-    like salt content, heat content, etc.
-
-    Parameters
-    ----------
-    var : xarray.DataArray
-        Ocean variable to integrate (e.g., salinity, temperature, tracers)
-        Dimensions: (time, depth, lat, lon)
-    rho : xarray.DataArray
-        Sea water density with same dimensions as var
-        Units: kg/m³
-    dzt : xarray.DataArray
-        Model level thickness with same dimensions as var
-        Units: m
-    depth_coord : str, optional
-        Name of the depth coordinate, default 'st_ocean'
-
-    Returns
-    -------
-    integral : xarray.DataArray
-        Depth-integrated product of density and variable
-        Dimensions: (time, lat, lon)
-        Units: [var_units] × kg/m²
-
-    Examples
-    --------
-    # For salinity content (somint):
-    somint = calc_ocean_depth_integral(salinity, density, dzt)
-
-    # For heat content:
-    heat_content = calc_ocean_depth_integral(temperature, density, dzt)
-    """
-    # Calculate product of variable, density, and layer thickness
-    # This gives the "content" per layer: var × ρ × Δz
-    layer_content = var * rho * dzt
-
-    # Integrate over depth by summing all layers
-    # skipna=True handles any missing values gracefully
-    integral = layer_content.sum(dim=depth_coord, skipna=True)
-
-    return integral
-
-
 def calc_overturning_streamfunction(
     ty_trans,
     gm_trans=None,

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -3982,17 +3982,18 @@
             "positive": null,
             "model_variables": [
                 "temp",
-                "pot_rho_0",
-                "dzt"
+                "rho_dzt"
             ],
             "calculation": {
                 "type": "formula",
-                "operation": "calc_ocean_depth_integral",
+                "operation": "sum",
                 "args": [
-                    "temp",
-                    "pot_rho_0",
-                    "dzt"
-                ]
+                    {
+                        "operation": "multiply",
+                        "args": ["temp", "rho_dzt"]
+                    }
+                ],
+                "kwargs": {"dim": {"literal": "st_ocean"}, "skipna": true}
             },
             "CF standard Name": "tendency_of_sea_water_conservative_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing"
         },
@@ -4289,20 +4290,27 @@
                 "yt_ocean": "latitude",
                 "xt_ocean": "longitude"
             },
-            "units": "psu",
+            "units": "kg m-2",
             "positive": null,
             "model_variables": [
                 "salt",
-                "pot_rho_0",
-                "dzt"
+                "rho_dzt"
             ],
             "calculation": {
                 "type": "formula",
-                "operation": "calc_ocean_depth_integral",
+                "operation": "multiply",
                 "args": [
-                    "salt",
-                    "pot_rho_0",
-                    "dzt"
+                    {
+                        "operation": "sum",
+                        "args": [
+                            {
+                                "operation": "multiply",
+                                "args": ["salt", "rho_dzt"]
+                            }
+                        ],
+                        "kwargs": {"dim": {"literal": "st_ocean"}, "skipna": true}
+                    },
+                    1e-3
                 ]
             },
             "CF standard Name": ""

--- a/tests/unit/test_derivations_calc_ocean.py
+++ b/tests/unit/test_derivations_calc_ocean.py
@@ -7,7 +7,6 @@ import xarray as xr
 from access_moppy.derivations.calc_ocean import (
     calc_areacello,
     calc_global_ave_ocean,
-    calc_ocean_depth_integral,
     calc_overturning_streamfunction,
     calc_rsdoabsorb,
     calc_total_mass_transport,
@@ -210,53 +209,6 @@ class TestCalcZostoga:
         )
         result = calc_zostoga(pot_temp, dzt, areacello)
         np.testing.assert_allclose(result.values, 0.0, atol=1e-10)
-
-
-# ---------------------------------------------------------------------------
-# calc_ocean_depth_integral
-# ---------------------------------------------------------------------------
-
-
-class TestCalcOceanDepthIntegral:
-    @pytest.mark.unit
-    def test_returns_dataarray(self):
-        var = _make_3d_ocean_da()
-        rho = _make_3d_ocean_da()
-        dzt = _make_3d_ocean_da()
-        result = calc_ocean_depth_integral(var, rho, dzt)
-        assert isinstance(result, xr.DataArray)
-
-    @pytest.mark.unit
-    def test_depth_dim_removed(self):
-        var = _make_3d_ocean_da()
-        rho = _make_3d_ocean_da()
-        dzt = _make_3d_ocean_da()
-        result = calc_ocean_depth_integral(var, rho, dzt)
-        assert "st_ocean" not in result.dims
-
-    @pytest.mark.unit
-    def test_horizontal_dims_preserved(self):
-        var = _make_3d_ocean_da()
-        rho = _make_3d_ocean_da()
-        dzt = _make_3d_ocean_da()
-        result = calc_ocean_depth_integral(var, rho, dzt)
-        assert "yt_ocean" in result.dims
-        assert "xt_ocean" in result.dims
-
-    @pytest.mark.unit
-    def test_unit_thickness_and_density_gives_sum_over_depth(self):
-        """With ρ=1 and Δz=1, integral equals sum of var over depth."""
-        data = np.arange(float(NT * NZ * NY * NX)).reshape(NT, NZ, NY, NX)
-        var = xr.DataArray(data, dims=["time", "st_ocean", "yt_ocean", "xt_ocean"])
-        rho = xr.DataArray(
-            np.ones((NT, NZ, NY, NX)), dims=["time", "st_ocean", "yt_ocean", "xt_ocean"]
-        )
-        dzt = xr.DataArray(
-            np.ones((NT, NZ, NY, NX)), dims=["time", "st_ocean", "yt_ocean", "xt_ocean"]
-        )
-        result = calc_ocean_depth_integral(var, rho, dzt)
-        expected = var.sum(dim="st_ocean")
-        np.testing.assert_allclose(result.values, expected.values)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request removes the `calc_ocean_depth_integral` function and its usage throughout the codebase, shifting the calculation logic for depth integrals from a custom Python function to explicit formula operations in the mapping configuration. The change simplifies both the code and the mappings, and updates related tests accordingly.

Fix #197


**API and Codebase Simplification:**

* Removed the `calc_ocean_depth_integral` function from `calc_ocean.py`, its import and export in `__init__.py`, and all related references in the codebase. [[1]](diffhunk://#diff-11cb94a5443e31423ff5e7e940e1fb1451f2deb5de3a15e7dd5571e8968247b1L142-L188) [[2]](diffhunk://#diff-ad0c9fe958956dd9591237ff4ffa0bf3f8ecc6f61a5fed913450f16535f4b8e5L29) [[3]](diffhunk://#diff-ad0c9fe958956dd9591237ff4ffa0bf3f8ecc6f61a5fed913450f16535f4b8e5L93) [[4]](diffhunk://#diff-eec8b0163e77bd14857487d940093f5deb55846e71ed2053c871d9e2972e4840L10)
* Deleted all unit tests for `calc_ocean_depth_integral` from `test_derivations_calc_ocean.py`.

**Mapping and Calculation Updates:**

* Refactored relevant entries in `ACCESS-ESM1.6_mappings.json` to replace use of `calc_ocean_depth_integral` with explicit formula operations using `multiply` and `sum`, and updated model variable lists to use `rho_dzt` instead of separate `pot_rho_0` and `dzt` variables. [[1]](diffhunk://#diff-1cc8b148ac309e70af764897258c8a03695524b9e0f98a24d550d5a0de751706L3985-R3996) [[2]](diffhunk://#diff-1cc8b148ac309e70af764897258c8a03695524b9e0f98a24d550d5a0de751706L4292-R4313)
* Updated units in the mapping for salt content from `"psu"` to `"kg m-2"` to reflect the new calculation approach.…gs to use new calculations