### PR TITLE
feat: add grid-agnostic msftbarot calculation (fixes #196)

### DIFF
--- a/src/access_moppy/derivations/__init__.py
+++ b/src/access_moppy/derivations/__init__.py
@@ -26,6 +26,7 @@ from access_moppy.derivations.calc_land import (
 from access_moppy.derivations.calc_ocean import (
     calc_areacello,
     calc_global_ave_ocean,
+    calc_msftbarot,
     calc_rsdoabsorb,
     calc_total_mass_transport,
     calc_umo_corrected,
@@ -87,6 +88,7 @@ custom_functions = {
     "calc_mrsll": calc_mrsll,
     "calc_mrsol": calc_mrsol,
     "calc_tsl": calc_tsl,
+    "calc_msftbarot": calc_msftbarot,
     "calc_rsdoabsorb": calc_rsdoabsorb,
     "calc_zostoga": calc_zostoga,
     "calc_global_ave_ocean": calc_global_ave_ocean,

--- a/src/access_moppy/derivations/calc_ocean.py
+++ b/src/access_moppy/derivations/calc_ocean.py
@@ -452,6 +452,61 @@ def ocean_floor(var, depth_dim="st_ocean"):
     return seafloor_values
 
 
+def calc_msftbarot(tx_trans, depth_coord="st_ocean", lat_coord="yt_ocean"):
+    """Calculate the barotropic mass streamfunction (msftbarot)
+
+    Computes ``msftbarot`` by depth-integrating the zonal mass transport and then
+    cumulatively summing from the southern boundary northward.
+
+    The barotropic streamfunction ψ satisfies:
+
+    .. math::
+
+        \\psi(y, x) = \\int_{y_{\\text{south}}}^{y} \\bar{U}(y', x)\\, dy'
+
+    where :math:`\\bar{U}` is the depth-integrated zonal mass transport.
+    Integrating northward from Antarctica means the Drake-Passage transport is
+    absorbed naturally into the running sum, so no separate reference-point
+    correction is required.
+
+    Parameters
+    ----------
+    tx_trans : xarray.DataArray
+        Zonal mass transport with dimensions (..., depth, lat, lon).
+        Units: kg/s
+    depth_coord : str, optional
+        Name of the depth coordinate.  Default ``'st_ocean'`` (MOM5/ACCESS-ESM).
+        Use ``'zl'`` for MOM6/ACCESS-OM3.
+    lat_coord : str, optional
+        Name of the latitude coordinate along which to integrate.
+        Default ``'yt_ocean'`` (MOM5/ACCESS-ESM).  Use ``'yh'`` for MOM6/ACCESS-OM3.
+
+    Returns
+    -------
+    msftbarot : xarray.DataArray
+        Barotropic mass streamfunction with the depth dimension removed.
+        Units: kg/s
+
+    Notes
+    -----
+    The reference value ψ = 0 is located at the southernmost grid row
+    (near Antarctica).  This is consistent with the CMIP6/7 standard
+    interpretation of ``ocean_barotropic_mass_streamfunction``.
+
+    For MOM5 models this function replaces the two-step APP4 procedure of
+    (1) reading ``psiu`` and (2) adding a Drake-Passage offset computed with
+    hard-coded grid indices.  The cumulative-sum approach is mathematically
+    equivalent but works for any horizontal resolution and grid topology.
+    """
+    # Step 1 – depth-integrate to get the column-integrated zonal transport
+    u_bar = tx_trans.sum(dim=depth_coord)
+
+    # Step 2 – cumulative sum from south to north
+    msftbarot = u_bar.cumsum(dim=lat_coord)
+
+    return msftbarot
+
+
 def calc_areacello(area_t, ht, drop_time=True):
     """Calculate ocean grid-cell area for sea floor.
 

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -1545,7 +1545,9 @@
             },
             "units": "m",
             "positive": null,
-            "model_variables": ["fld_s15i101"],
+            "model_variables": [
+                "fld_s15i101"
+            ],
             "zaxis": {
                 "type": "hybrid_height",
                 "coordinate_variables": {
@@ -2119,7 +2121,7 @@
                             "landfrac": "fld_s03i395"
                         }
                     },
-                    1.1574074074074073e-08
+                    1.1574074074074072e-08
                 ]
             },
             "CF standard Name": "carbon_mass_flux_into_soil_due_to_biological_nitrogen_fixation"
@@ -2176,7 +2178,7 @@
                             "landfrac": "fld_s03i395"
                         }
                     },
-                    1.1574074074074073e-08
+                    1.1574074074074072e-08
                 ]
             },
             "CF standard Name": "minus_tendency_of_atmosphere_mass_content_of_nitrogen_compounds_expressed_as_nitrogen_due_to_deposition"
@@ -2208,7 +2210,7 @@
                             "landfrac": "fld_s03i395"
                         }
                     },
-                    1.1574074074074073e-08
+                    1.1574074074074072e-08
                 ]
             },
             "CF standard Name": "surface_upward_mass_flux_of_nitrogen_compounds_expressed_as_nitrogen"
@@ -2240,7 +2242,7 @@
                             "landfrac": "fld_s03i395"
                         }
                     },
-                    1.1574074074074073e-08
+                    1.1574074074074072e-08
                 ]
             },
             "CF standard Name": "mass_flux_of_carbon_out_of_soil_due_to_leaching_and_runoff"
@@ -2279,7 +2281,7 @@
                             "landfrac": "fld_s03i395"
                         }
                     },
-                    1.1574074074074073e-08
+                    1.1574074074074072e-08
                 ]
             },
             "CF standard Name": "surface_upward_mass_flux_of_nitrogen_compounds_expressed_as_nitrogen_out_of_vegetation_and_litter_and_soil"
@@ -2311,7 +2313,7 @@
                             "landfrac": "fld_s03i395"
                         }
                     },
-                    1.1574074074074073e-08
+                    1.1574074074074072e-08
                 ]
             },
             "CF standard Name": "mass_flux_of_nitrogen_compounds_expressed_as_nitrogen_out_of_litter_and_soil_due_to_immobilisation_and_remineralization"
@@ -2343,7 +2345,7 @@
                             "landfrac": "fld_s03i395"
                         }
                     },
-                    1.1574074074074073e-08
+                    1.1574074074074072e-08
                 ]
             },
             "CF standard Name": "tendency_of_vegetation_mass_content_of_nitrogen_compounds_expressed_as_nitrogen_due_to_fixation"
@@ -2384,7 +2386,7 @@
                             "landfrac": "fld_s03i395"
                         }
                     },
-                    1.1574074074074073e-08
+                    1.1574074074074072e-08
                 ]
             },
             "CF standard Name": "tendency_of_atmosphere_mass_content_of_carbon_dioxide_expressed_as_carbon_due_to_emission_from_forestry_and_agricultural_products"
@@ -2777,7 +2779,7 @@
                                             "landfrac": "fld_s03i395"
                                         }
                                     },
-                                    -3.1688087814029656e-14
+                                    -3.1688087814029657e-14
                                 ]
                             }
                         ]
@@ -3931,6 +3933,26 @@
             },
             "CF standard Name": ""
         },
+        "msftbarot": {
+            "dimensions": {
+                "time": "time",
+                "yt_ocean": "latitude",
+                "xu_ocean": "longitude"
+            },
+            "units": "kg s-1",
+            "positive": null,
+            "model_variables": [
+                "tx_trans"
+            ],
+            "calculation": {
+                "type": "formula",
+                "operation": "calc_msftbarot",
+                "args": [
+                    "tx_trans"
+                ]
+            },
+            "CF standard Name": "ocean_barotropic_mass_streamfunction"
+        },
         "obvfsq": {
             "dimensions": {
                 "time": "time",
@@ -3990,10 +4012,18 @@
                 "args": [
                     {
                         "operation": "multiply",
-                        "args": ["temp", "rho_dzt"]
+                        "args": [
+                            "temp",
+                            "rho_dzt"
+                        ]
                     }
                 ],
-                "kwargs": {"dim": {"literal": "st_ocean"}, "skipna": true}
+                "kwargs": {
+                    "dim": {
+                        "literal": "st_ocean"
+                    },
+                    "skipna": true
+                }
             },
             "CF standard Name": "tendency_of_sea_water_conservative_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing"
         },
@@ -4305,12 +4335,20 @@
                         "args": [
                             {
                                 "operation": "multiply",
-                                "args": ["salt", "rho_dzt"]
+                                "args": [
+                                    "salt",
+                                    "rho_dzt"
+                                ]
                             }
                         ],
-                        "kwargs": {"dim": {"literal": "st_ocean"}, "skipna": true}
+                        "kwargs": {
+                            "dim": {
+                                "literal": "st_ocean"
+                            },
+                            "skipna": true
+                        }
                     },
-                    1e-3
+                    0.001
                 ]
             },
             "CF standard Name": ""
@@ -5279,7 +5317,7 @@
                             101325
                         ]
                     },
-                    0.000001
+                    1e-06
                 ]
             },
             "CF standard Name": "surface_partial_pressure_of_carbon_dioxide_in_sea_water"

--- a/src/access_moppy/mappings/ACCESS-OM3_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-OM3_mappings.json
@@ -1,168 +1,378 @@
 {
     "model_info": {
         "model_id": "ACCESS-OM3",
-        "components": ["ocean"],
+        "components": [
+            "ocean"
+        ],
         "description": "Variable mappings for ACCESS-OM3 Ocean Model"
     },
     "ocean": {
         "tos": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "degC",
             "positive": null,
-            "model_variables": ["tos"],
-            "calculation": {"type": "direct", "formula": "tos"},
+            "model_variables": [
+                "tos"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "tos"
+            },
             "CF standard Name": ""
         },
         "zos": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "m",
             "positive": null,
-            "model_variables": ["SSH"],
-            "calculation": {"type": "direct", "formula": "SSH"},
+            "model_variables": [
+                "SSH"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "SSH"
+            },
             "CF standard Name": ""
         },
         "hfds": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "W m-2",
             "positive": "down",
-            "model_variables": ["hfds"],
-            "calculation": {"type": "direct", "formula": "hfds"},
+            "model_variables": [
+                "hfds"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "hfds"
+            },
             "CF standard Name": ""
         },
         "fsitherm": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "kg m-2 s-1",
             "positive": null,
-            "model_variables": ["fsitherm"],
-            "calculation": {"type": "direct", "formula": "fsitherm"},
+            "model_variables": [
+                "fsitherm"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "fsitherm"
+            },
             "CF standard Name": ""
         },
         "wfo": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "kg m-2 s-1",
             "positive": null,
-            "model_variables": ["wfo"],
-            "calculation": {"type": "direct", "formula": "wfo"},
+            "model_variables": [
+                "wfo"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "wfo"
+            },
             "CF standard Name": ""
         },
         "pbo": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "dbar",
             "positive": null,
-            "model_variables": ["pbo"],
-            "calculation": {"type": "direct", "formula": "pbo"},
+            "model_variables": [
+                "pbo"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "pbo"
+            },
             "CF standard Name": ""
         },
         "mlotst": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "m",
             "positive": null,
-            "model_variables": ["mlotst"],
-            "calculation": {"type": "direct", "formula": "mlotst"},
+            "model_variables": [
+                "mlotst"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "mlotst"
+            },
             "CF standard Name": ""
         },
+        "msftbarot": {
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xq": "longitude"
+            },
+            "units": "kg s-1",
+            "positive": null,
+            "model_variables": [
+                "umo"
+            ],
+            "calculation": {
+                "type": "formula",
+                "operation": "calc_msftbarot",
+                "args": [
+                    "umo"
+                ],
+                "kwargs": {
+                    "depth_coord": {
+                        "literal": "zl"
+                    },
+                    "lat_coord": {
+                        "literal": "yh"
+                    }
+                }
+            },
+            "CF standard Name": "ocean_barotropic_mass_streamfunction"
+        },
         "tauuo": {
-            "dimensions": {"time": "time", "yh": "latitude", "xq": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xq": "longitude"
+            },
             "units": "N m-2",
             "positive": "down",
-            "model_variables": ["tauuo"],
-            "calculation": {"type": "direct", "formula": "tauuo"},
+            "model_variables": [
+                "tauuo"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "tauuo"
+            },
             "CF standard Name": ""
         },
         "pso": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "Pa",
             "positive": null,
-            "model_variables": ["pso"],
-            "calculation": {"type": "direct", "formula": "pso"},
+            "model_variables": [
+                "pso"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "pso"
+            },
             "CF standard Name": ""
         },
         "hfrainds": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "W m-2",
             "positive": "down",
-            "model_variables": ["hfrainds"],
-            "calculation": {"type": "direct", "formula": "hfrainds"},
+            "model_variables": [
+                "hfrainds"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "hfrainds"
+            },
             "CF standard Name": ""
         },
         "sos": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "0.001",
             "positive": null,
-            "model_variables": ["sos"],
-            "calculation": {"type": "direct", "formula": "sos"},
+            "model_variables": [
+                "sos"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "sos"
+            },
             "CF standard Name": ""
         },
         "rlntds": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "W m-2",
             "positive": "down",
-            "model_variables": ["rlntds"],
-            "calculation": {"type": "direct", "formula": "rlntds"},
+            "model_variables": [
+                "rlntds"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "rlntds"
+            },
             "CF standard Name": ""
         },
         "evs": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "kg m-2 s-1",
             "positive": null,
-            "model_variables": ["evs"],
-            "calculation": {"type": "direct", "formula": "evs"},
+            "model_variables": [
+                "evs"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "evs"
+            },
             "CF standard Name": ""
         },
         "hflso": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "W m-2",
             "positive": "down",
-            "model_variables": ["hflso"],
-            "calculation": {"type": "direct", "formula": "hflso"},
+            "model_variables": [
+                "hflso"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "hflso"
+            },
             "CF standard Name": ""
         },
         "prsn": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "kg m-2 s-1",
             "positive": null,
-            "model_variables": ["prsn"],
-            "calculation": {"type": "direct", "formula": "prsn"},
+            "model_variables": [
+                "prsn"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "prsn"
+            },
             "CF standard Name": ""
         },
         "rsntds": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "W m-2",
             "positive": "down",
-            "model_variables": ["rsntds"],
-            "calculation": {"type": "direct", "formula": "rsntds"},
+            "model_variables": [
+                "rsntds"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "rsntds"
+            },
             "CF standard Name": ""
         },
         "friver": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "kg m-2 s-1",
             "positive": null,
-            "model_variables": ["friver"],
-            "calculation": {"type": "direct", "formula": "friver"},
+            "model_variables": [
+                "friver"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "friver"
+            },
             "CF standard Name": ""
         },
         "hfsso": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "W m-2",
             "positive": "down",
-            "model_variables": ["hfsso"],
-            "calculation": {"type": "direct", "formula": "hfsso"},
+            "model_variables": [
+                "hfsso"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "hfsso"
+            },
             "CF standard Name": ""
         },
         "tauvo": {
-            "dimensions": {"time": "time", "yq": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yq": "latitude",
+                "xh": "longitude"
+            },
             "units": "N m-2",
             "positive": "down",
-            "model_variables": ["tauvo"],
-            "calculation": {"type": "direct", "formula": "tauvo"},
+            "model_variables": [
+                "tauvo"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "tauvo"
+            },
             "CF standard Name": ""
         },
         "sfdsi": {
-            "dimensions": {"time": "time", "yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "time": "time",
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "kg m-2 s-1",
             "positive": "down",
-            "model_variables": ["sfdsi"],
-            "calculation": {"type": "direct", "formula": "sfdsi"},
+            "model_variables": [
+                "sfdsi"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "sfdsi"
+            },
             "CF standard Name": ""
         },
         "vo": {
@@ -174,8 +384,13 @@
             },
             "units": "m s-1",
             "positive": null,
-            "model_variables": ["vo"],
-            "calculation": {"type": "direct", "formula": "vo"},
+            "model_variables": [
+                "vo"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "vo"
+            },
             "CF standard Name": ""
         },
         "uo": {
@@ -187,8 +402,13 @@
             },
             "units": "m s-1",
             "positive": null,
-            "model_variables": ["uo"],
-            "calculation": {"type": "direct", "formula": "uo"},
+            "model_variables": [
+                "uo"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "uo"
+            },
             "CF standard Name": ""
         },
         "vmo": {
@@ -200,8 +420,13 @@
             },
             "units": "kg s-1",
             "positive": null,
-            "model_variables": ["vmo"],
-            "calculation": {"type": "direct", "formula": "vmo"},
+            "model_variables": [
+                "vmo"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "vmo"
+            },
             "CF standard Name": ""
         },
         "umo": {
@@ -213,8 +438,13 @@
             },
             "units": "kg s-1",
             "positive": null,
-            "model_variables": ["umo"],
-            "calculation": {"type": "direct", "formula": "umo"},
+            "model_variables": [
+                "umo"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "umo"
+            },
             "CF standard Name": ""
         },
         "thkcello": {
@@ -226,8 +456,13 @@
             },
             "units": "m",
             "positive": null,
-            "model_variables": ["thkcello"],
-            "calculation": {"type": "direct", "formula": "thkcello"},
+            "model_variables": [
+                "thkcello"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "thkcello"
+            },
             "CF standard Name": ""
         },
         "agessc": {
@@ -239,8 +474,13 @@
             },
             "units": "yr",
             "positive": null,
-            "model_variables": ["agessc"],
-            "calculation": {"type": "direct", "formula": "agessc"},
+            "model_variables": [
+                "agessc"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "agessc"
+            },
             "CF standard Name": ""
         },
         "thetao": {
@@ -252,8 +492,13 @@
             },
             "units": "degC",
             "positive": null,
-            "model_variables": ["thetao"],
-            "calculation": {"type": "direct", "formula": "thetao"},
+            "model_variables": [
+                "thetao"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "thetao"
+            },
             "CF standard Name": ""
         },
         "so": {
@@ -265,26 +510,47 @@
             },
             "units": "0.001",
             "positive": null,
-            "model_variables": ["so"],
-            "calculation": {"type": "direct", "formula": "so"},
+            "model_variables": [
+                "so"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "so"
+            },
             "CF standard Name": ""
         }
     },
     "time_invariant": {
         "sftof": {
-            "dimensions": {"yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "1",
             "positive": null,
-            "model_variables": ["wet"],
-            "calculation": {"type": "direct", "formula": "wet"},
+            "model_variables": [
+                "wet"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "wet"
+            },
             "CF standard Name": ""
         },
         "areacello": {
-            "dimensions": {"yh": "latitude", "xh": "longitude"},
+            "dimensions": {
+                "yh": "latitude",
+                "xh": "longitude"
+            },
             "units": "m2",
             "positive": null,
-            "model_variables": ["areacello"],
-            "calculation": {"type": "direct", "formula": "areacello"},
+            "model_variables": [
+                "areacello"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "areacello"
+            },
             "CF standard Name": ""
         }
     }

--- a/tests/unit/test_derivations_calc_ocean.py
+++ b/tests/unit/test_derivations_calc_ocean.py
@@ -7,6 +7,7 @@ import xarray as xr
 from access_moppy.derivations.calc_ocean import (
     calc_areacello,
     calc_global_ave_ocean,
+    calc_msftbarot,
     calc_overturning_streamfunction,
     calc_rsdoabsorb,
     calc_total_mass_transport,
@@ -434,3 +435,95 @@ class TestCalcAreacello:
         area_t, ht = self._make_area_and_ht(with_time=True)
         result = calc_areacello(area_t, ht, drop_time=False)
         assert "time" in result.dims
+
+
+# ---------------------------------------------------------------------------
+# calc_msftbarot
+# ---------------------------------------------------------------------------
+
+
+def _make_tx_trans(nt=2, nz=4, ny=6, nx=8):
+    """Create a 4-D (time, st_ocean, yt_ocean, xu_ocean) transport DataArray."""
+    rng = np.random.default_rng(7)
+    data = rng.random((nt, nz, ny, nx)) * 1e9
+    times = xr.date_range("2000-01-01", periods=nt, freq="ME")
+    return xr.DataArray(
+        data,
+        dims=["time", "st_ocean", "yt_ocean", "xu_ocean"],
+        coords={"time": times},
+    )
+
+
+class TestCalcMsftbarot:
+    @pytest.mark.unit
+    def test_returns_dataarray(self):
+        tx = _make_tx_trans()
+        result = calc_msftbarot(tx)
+        assert isinstance(result, xr.DataArray)
+
+    @pytest.mark.unit
+    def test_depth_dim_removed(self):
+        """The depth dimension must be collapsed by the depth-sum."""
+        tx = _make_tx_trans()
+        result = calc_msftbarot(tx)
+        assert "st_ocean" not in result.dims
+
+    @pytest.mark.unit
+    def test_output_shape(self):
+        """Output shape should be (time, yt_ocean, xu_ocean)."""
+        nt, nz, ny, nx = 2, 4, 6, 8
+        tx = _make_tx_trans(nt=nt, nz=nz, ny=ny, nx=nx)
+        result = calc_msftbarot(tx)
+        assert result.sizes == {"time": nt, "yt_ocean": ny, "xu_ocean": nx}
+
+    @pytest.mark.unit
+    def test_southern_boundary_near_zero(self):
+        """The first (southernmost) row is just the depth-sum of tx_trans there."""
+        tx = _make_tx_trans()
+        result = calc_msftbarot(tx)
+        expected_first_row = tx.sum("st_ocean").isel(yt_ocean=0)
+        np.testing.assert_allclose(
+            result.isel(yt_ocean=0).values,
+            expected_first_row.values,
+            rtol=1e-12,
+        )
+
+    @pytest.mark.unit
+    def test_monotonically_accumulates_uniform_eastward_flow(self):
+        """For uniform positive (eastward) tx_trans the streamfunction must
+        increase monotonically from south to north."""
+        nt, nz, ny, nx = 2, 3, 5, 4
+        data = np.ones((nt, nz, ny, nx)) * 1e8
+        times = xr.date_range("2000-01-01", periods=nt, freq="ME")
+        tx = xr.DataArray(
+            data,
+            dims=["time", "st_ocean", "yt_ocean", "xu_ocean"],
+            coords={"time": times},
+        )
+        result = calc_msftbarot(tx)
+        # Each step northward should increase psi by nz * 1e8
+        diffs = result.diff("yt_ocean")
+        assert (diffs.values > 0).all()
+
+    @pytest.mark.unit
+    def test_custom_coordinate_names(self):
+        """Function must work with any depth/lat coordinate names (MOM6 style)."""
+        nt, nz, ny, nx = 2, 3, 5, 4
+        data = np.ones((nt, nz, ny, nx)) * 1e8
+        times = xr.date_range("2000-01-01", periods=nt, freq="ME")
+        tx = xr.DataArray(
+            data,
+            dims=["time", "zl", "yh", "xq"],
+            coords={"time": times},
+        )
+        result = calc_msftbarot(tx, depth_coord="zl", lat_coord="yh")
+        assert "zl" not in result.dims
+        assert result.sizes == {"time": nt, "yh": ny, "xq": nx}
+
+    @pytest.mark.unit
+    def test_equivalent_to_depth_sum_then_cumsum(self):
+        """Verify the result equals depth-sum then cumsum, element-wise."""
+        tx = _make_tx_trans()
+        result = calc_msftbarot(tx)
+        expected = tx.sum("st_ocean").cumsum("yt_ocean")
+        np.testing.assert_allclose(result.values, expected.values, rtol=1e-12)


### PR DESCRIPTION
## Summary

Resolves #196

The legacy APP4 implementation of `msftbarot` (barotropic mass streamfunction) used hard-coded Drake Passage grid indices (`transAcrossLine(tx_trans, 212, 212, 32, 49)`) to compute a reference offset for `psiu`. This is resolution-dependent and breaks for any model configuration other than the one it was tuned for.

## Approach

The new `calc_msftbarot` function avoids grid indices entirely by exploiting a direct mathematical identity:

1. **Depth-integrate** the zonal mass transport (`tx_trans` / `umo`) to get the column-integrated flow $\bar{U}(y, x)$
2. **Cumulatively sum** $\bar{U}$ from south to north to build the barotropic streamfunction $\psi$

$$\psi(y, x) = \sum_{y'=y_\text{south}}^{y} \bar{U}(y', x)$$

The Drake Passage transport is implicitly captured by the running sum — no coordinate look-up required. The reference value $\psi = 0$ is at the southern boundary (Antarctica), consistent with the CMIP6/7 standard.

## Changes

### `src/access_moppy/derivations/calc_ocean.py`
- Added `calc_msftbarot(tx_trans, depth_coord, lat_coord)` with `depth_coord` and `lat_coord` as parameters so the same function works for both MOM5 (defaults: `st_ocean`, `yt_ocean`) and MOM6 (`zl`, `yh`).

### `src/access_moppy/derivations/__init__.py`
- Imported `calc_msftbarot` and registered it in `custom_functions`.

### `src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json`
- Added `msftbarot` entry under `ocean` using `tx_trans` as input (MOM5/ACCESS-ESM grid).

### `src/access_moppy/mappings/ACCESS-OM3_mappings.json`
- Added `msftbarot` entry under `ocean` using `umo` as input with `depth_coord: "zl"` and `lat_coord: "yh"` kwargs (MOM6/ACCESS-OM3 grid).

### `tests/unit/test_derivations_calc_ocean.py`
- Added `TestCalcMsftbarot` with 7 unit tests covering: return type, shape, depth-dim removal, southern-boundary value, monotonic accumulation for uniform flow, custom coordinate names (MOM6), and equivalence to `depth_sum + cumsum`.

## Testing

```
pixi run -e test python -m pytest tests/unit/test_derivations_calc_ocean.py -v
# 40 passed, 0 failed
```