### PR TITLE
Fix landCoverFrac CMORisation: signature, mapping, and write pipeline

### DIFF
--- a/src/access_moppy/atmosphere.py
+++ b/src/access_moppy/atmosphere.py
@@ -357,11 +357,15 @@ class Atmosphere_CMORiser(CMORiser):
                     "units"
                 ) == "days since ?" and original_units.lower().startswith("days since"):
                     coord_attrs["units"] = original_units
-                # Skip astype for time coordinates containing datetime/cftime objects
-                if meta.get("standard_name") == "time" and (
-                    self.ds[name].dtype == object
-                    or np.issubdtype(self.ds[name].dtype, np.datetime64)
-                ):
+                # Skip astype for time coordinates containing datetime/cftime objects,
+                # and for character-type coordinates (string arrays like vegtype)
+                if (
+                    meta.get("standard_name") == "time"
+                    and (
+                        self.ds[name].dtype == object
+                        or np.issubdtype(self.ds[name].dtype, np.datetime64)
+                    )
+                ) or meta.get("type") == "character":
                     updated = self.ds[name].copy()
                 else:
                     updated = self.ds[name].astype(dtype)

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -1218,7 +1218,9 @@ class CMORiser:
                         # iterator is not exhausted by max() before encode step
                         str_values = [str(s) for s in coord.values.flat]
 
-                        max_len = max((len(s) for s in str_values), default=1)
+                        # NetCDF fixed-width byte strings must have a width of at
+                        # least 1, including when all values are empty strings.
+                        max_len = max(1, max((len(s) for s in str_values), default=0))
                         values = np.array(
                             [s.encode("utf-8") for s in str_values], dtype=f"S{max_len}"
                         )

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -1214,13 +1214,11 @@ class CMORiser:
                         max_len = len(str_val)
                         values = str_val.encode("utf-8")
                     else:
-                        # Handle array of strings
-                        if coord.dtype.kind == "O":
-                            str_values = np.array([str(s) for s in coord.values.flat])
-                        else:
-                            str_values = coord.values.astype(str).flat
+                        # Handle array of strings — materialise as a list so the
+                        # iterator is not exhausted by max() before encode step
+                        str_values = [str(s) for s in coord.values.flat]
 
-                        max_len = max(len(s) for s in str_values)
+                        max_len = max((len(s) for s in str_values), default=1)
                         values = np.array(
                             [s.encode("utf-8") for s in str_values], dtype=f"S{max_len}"
                         )

--- a/src/access_moppy/derivations/calc_land.py
+++ b/src/access_moppy/derivations/calc_land.py
@@ -252,7 +252,7 @@ def calc_topsoil(soilvar):
     return topsoil
 
 
-def calc_landcover(var, model):
+def calc_landcover(tilefrac, landfrac, model):
     """
     Calculate land cover fraction variable as percentage with vegetation type labels.
 
@@ -262,11 +262,12 @@ def calc_landcover(var, model):
 
     Parameters
     ----------
-    var : list of xarray.DataArray
-        List containing exactly 2 input variables:
-        - var[0]: Tile fraction variable (fractional, 0-1)
-        - var[1]: Land fraction variable (fractional, 0-1)
-        Both must have compatible dimensions for multiplication.
+    tilefrac : xarray.DataArray
+        Tile fraction variable (fractional, 0-1) with a pseudo-level dimension
+        representing the different vegetation/land cover types.
+    landfrac : xarray.DataArray
+        Land fraction variable (fractional, 0-1) representing the proportion
+        of each grid cell that is land.
     model : str
         Name of land surface model to retrieve vegetation type definitions:
         - "cable": CABLE land surface model (17 vegetation types)
@@ -277,7 +278,7 @@ def calc_landcover(var, model):
     xarray.DataArray
         Land cover fraction variable as percentage (0-100%).
         - Units: % (percentage)
-        - Coordinates: Includes 'vegtype' dimension with descriptive names
+        - Coordinates: Includes 'type' dimension with descriptive names
         - Missing values filled with 0
         - Represents land cover relative to total grid cell area
 
@@ -285,11 +286,11 @@ def calc_landcover(var, model):
     --------
     Calculate CABLE vegetation fractions as percentage:
 
-    >>> landcover_pct = calc_landcover([tilefrac, landfrac], "cable")
+    >>> landcover_pct = calc_landcover(tilefrac, landfrac, model="cable")
 
     Calculate CMIP6 land categories as percentage:
 
-    >>> landcover_pct = calc_landcover([tilefrac, landfrac], "cmip6")
+    >>> landcover_pct = calc_landcover(tilefrac, landfrac, model="cmip6")
 
     Notes
     -----
@@ -328,12 +329,14 @@ def calc_landcover(var, model):
     }
 
     vegtype = land_tiles[model]
-    pseudo_level = var[0].dims[1]
+    pseudo_level = tilefrac.dims[1]
     # convert to percentage
-    vout = (var[0] * var[1]).fillna(0) * 100.0
-    vout = vout.rename({pseudo_level: "vegtype"})
-    vout["vegtype"] = vegtype
-    vout["vegtype"].attrs["units"] = ""
+    vout = (tilefrac * landfrac).fillna(0) * 100.0
+    # Rename to "type" — the CMIP out_name for the vegtype axis — so the
+    # transpose logic in the CMORiser finds the dimension by its expected name.
+    vout = vout.rename({pseudo_level: "type"})
+    vout["type"] = vegtype
+    vout["type"].attrs["units"] = ""
     return vout
 
 

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -2511,7 +2511,7 @@
         "landCoverFrac": {
             "dimensions": {
                 "time": "time",
-                "vegtype": "type",
+                "type": "type",
                 "lat": "lat",
                 "lon": "lon"
             },

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -2511,6 +2511,7 @@
         "landCoverFrac": {
             "dimensions": {
                 "time": "time",
+                "vegtype": "type",
                 "lat": "lat",
                 "lon": "lon"
             },
@@ -2524,14 +2525,14 @@
                 "type": "formula",
                 "operation": "calc_landcover",
                 "args": [
-                    [
-                        "fld_s03i317",
-                        "fld_s03i395"
-                    ],
-                    {
+                    "fld_s03i317",
+                    "fld_s03i395"
+                ],
+                "kwargs": {
+                    "model": {
                         "literal": "cable"
                     }
-                ]
+                }
             },
             "CF standard Name": "area_fraction"
         },

--- a/tests/unit/test_atmosphere.py
+++ b/tests/unit/test_atmosphere.py
@@ -854,6 +854,69 @@ class TestUpdateAttributesDecodedTime:
 
         assert np.issubdtype(cmoriser.ds["time"].dtype, np.floating)
 
+    @pytest.mark.unit
+    def test_character_coord_not_cast_to_float(self):
+        """Character-type coordinates (e.g. vegtype) must NOT be cast to float."""
+        veg_types = np.array(
+            ["Evergreen_Needleleaf", "Evergreen_Broadleaf", "", "Shrub"],
+            dtype=str,
+        )
+        ds = xr.Dataset(
+            {
+                "landCoverFrac": xr.DataArray(
+                    np.ones((1, 4), dtype=np.float32),
+                    dims=["time", "type"],
+                    coords={
+                        "time": xr.Variable(
+                            "time",
+                            np.array([0.0]),
+                            attrs={
+                                "units": "days since 1850-01-01",
+                                "calendar": "standard",
+                            },
+                        ),
+                        "type": ("type", veg_types),
+                    },
+                    attrs={"units": "%"},
+                )
+            }
+        )
+
+        cmoriser = object.__new__(Atmosphere_CMORiser)
+        cmoriser.cmor_name = "landCoverFrac"
+        cmoriser.type_mapping = CMORiser.type_mapping
+        cmoriser.ds = ds
+
+        vocab = MagicMock()
+        vocab.get_required_global_attributes.return_value = {}
+        vocab.axes = {
+            "time": {
+                "out_name": "time",
+                "standard_name": "time",
+                "units": "days since 1850-01-01",
+                "type": "double",
+                "axis": "T",
+            },
+            "vegtype": {
+                "out_name": "type",
+                "standard_name": "area_type",
+                "type": "character",
+            },
+        }
+        vocab.variable = {"units": "%", "type": "real"}
+        cmoriser.vocab = vocab
+        cmoriser._check_units = MagicMock()
+        cmoriser._check_calendar = MagicMock()
+        cmoriser._check_range = MagicMock()
+
+        original_dtype = ds["type"].dtype
+
+        cmoriser.update_attributes()
+
+        # dtype must remain unchanged (string/unicode, NOT float64)
+        assert not np.issubdtype(cmoriser.ds["type"].dtype, np.floating)
+        assert cmoriser.ds["type"].dtype == original_dtype
+
 
 # ---------------------------------------------------------------------------
 # Tests: select_and_process_variables – time resolution change path

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -479,6 +479,56 @@ class TestCMIP6CMORiserWrite:
         return ds
 
     @pytest.fixture
+    def dataset_with_array_unicode_string_coord(self):
+        """
+        Create dataset with an *array* Unicode string coordinate (dtype kind 'U').
+
+        Mimics the landCoverFrac 'type' coordinate produced by calc_landcover
+        (17 CABLE vegetation types, with empty strings at indices 11 & 12).
+        """
+        time = np.arange(3)
+        lat = np.linspace(-90, 90, 4)
+        lon = np.linspace(0, 360, 5)
+        n_types = 5
+
+        data = np.random.rand(3, n_types, 4, 5).astype(np.float32)
+
+        # Unicode array (dtype kind 'U') with two empty-string slots
+        veg_types = np.array(
+            ["Evergreen_Needleleaf", "Evergreen_Broadleaf", "", "", "Shrub"],
+            dtype=str,  # dtype=str gives kind 'U'
+        )
+
+        ds = xr.Dataset(
+            {
+                "landCoverFrac": (
+                    ["time", "type", "lat", "lon"],
+                    data,
+                    {"_FillValue": 1e20, "units": "%"},
+                ),
+            },
+            coords={
+                "time": (
+                    "time",
+                    time,
+                    {"units": "days since 2000-01-01", "calendar": "standard"},
+                ),
+                "lat": ("lat", lat),
+                "lon": ("lon", lon),
+                "type": ("type", veg_types),
+            },
+            attrs={
+                "variable_id": "landCoverFrac",
+                "table_id": "Lmon",
+                "source_id": "ACCESS-ESM1-5",
+                "experiment_id": "historical",
+                "variant_label": "r1i1p1f1",
+                "grid_label": "gn",
+            },
+        )
+        return ds
+
+    @pytest.fixture
     def dataset_with_multiple_string_coords(self):
         """
         Create dataset with multiple string coordinates.
@@ -960,6 +1010,44 @@ class TestCMIP6CMORiserWrite:
         assert "type" in string_coords_info
         values = string_coords_info["type"]["values"]
         assert isinstance(values, (bytes, np.ndarray))
+
+    @pytest.mark.unit
+    def test_prepare_string_coordinates_handles_unicode_array_with_empty_strings(
+        self,
+        mock_vocab,
+        mock_mapping,
+        dataset_with_array_unicode_string_coord,
+        temp_dir,
+    ):
+        """Array unicode coord (dtype kind 'U') with empty-string slots is handled.
+
+        Exercises the materialise-as-list branch in _prepare_string_coordinates so
+        that max() does not exhaust the iterator before the encode step, and verifies
+        that max_len is at least 1 even when some entries are empty strings.
+        """
+        cmoriser = CMORiser(
+            input_paths=["test.nc"],
+            output_path=str(temp_dir),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="Lmon.landCoverFrac",
+        )
+        cmoriser.ds = dataset_with_array_unicode_string_coord
+        cmoriser.cmor_name = "landCoverFrac"
+
+        string_coords_info = cmoriser._prepare_string_coordinates()
+
+        assert "type" in string_coords_info
+        info = string_coords_info["type"]
+        assert info["is_scalar"] is False
+        # max_len must be >= 1 (not 0) even though some slots are empty strings
+        assert info["strlen_size"] >= 1
+        # The longest non-empty label is "Evergreen_Needleleaf" (20 chars)
+        assert info["strlen_size"] == 20
+        # values must be a byte-string array with the correct shape
+        assert isinstance(info["values"], np.ndarray)
+        assert info["values"].dtype.kind == "S"
+        assert info["values"].shape == (5,)
 
     @pytest.mark.unit
     def test_prepare_string_coordinates_empty_when_no_strings(

--- a/tests/unit/test_derivations.py
+++ b/tests/unit/test_derivations.py
@@ -117,3 +117,102 @@ class TestCalculateMonthlyMaximum:
         mn = calculate_monthly_minimum(da)
         mx = calculate_monthly_maximum(da)
         assert (mx.values >= mn.values).all()
+
+
+class TestCalcLandcover:
+    """Tests for calc_landcover() — covers the refactored explicit-args signature."""
+
+    def _make_inputs(self, n_tiles=17, nlat=3, nlon=4):
+        """Return (tilefrac, landfrac) DataArrays compatible with calc_landcover."""
+        rng = np.random.default_rng(0)
+        tilefrac = xr.DataArray(
+            rng.uniform(0, 1, (nlat, n_tiles, nlon)).astype(np.float32),
+            dims=["lat", "pseudo_level_0", "lon"],
+        )
+        landfrac = xr.DataArray(
+            rng.uniform(0, 1, (nlat, nlon)).astype(np.float32),
+            dims=["lat", "lon"],
+        )
+        return tilefrac, landfrac
+
+    @pytest.mark.unit
+    def test_cable_output_dimension_named_type(self):
+        """calc_landcover renames the pseudo-level dim to 'type' (CMIP out_name)."""
+        from access_moppy.derivations.calc_land import calc_landcover
+
+        tilefrac, landfrac = self._make_inputs(n_tiles=17)
+        result = calc_landcover(tilefrac, landfrac, model="cable")
+        assert "type" in result.dims
+        assert "pseudo_level_0" not in result.dims
+
+    @pytest.mark.unit
+    def test_cable_output_is_percentage(self):
+        """Values must be 0–100 (percentage, not fraction)."""
+        from access_moppy.derivations.calc_land import calc_landcover
+
+        tilefrac = xr.DataArray(
+            np.full((2, 17, 3), 0.5, dtype=np.float32),
+            dims=["lat", "pseudo_level_0", "lon"],
+        )
+        landfrac = xr.DataArray(
+            np.full((2, 3), 0.5, dtype=np.float32), dims=["lat", "lon"]
+        )
+        result = calc_landcover(tilefrac, landfrac, model="cable")
+        # 0.5 * 0.5 * 100 = 25 %
+        np.testing.assert_allclose(result.values, 25.0, rtol=1e-5)
+
+    @pytest.mark.unit
+    def test_cable_vegtype_coordinate_has_17_entries(self):
+        """CABLE model must produce exactly 17 vegetation-type labels."""
+        from access_moppy.derivations.calc_land import calc_landcover
+
+        tilefrac, landfrac = self._make_inputs(n_tiles=17)
+        result = calc_landcover(tilefrac, landfrac, model="cable")
+        assert result.sizes["type"] == 17
+
+    @pytest.mark.unit
+    def test_cable_vegtype_coordinate_values(self):
+        """Spot-check a few known CABLE vegetation-type labels."""
+        from access_moppy.derivations.calc_land import calc_landcover
+
+        tilefrac, landfrac = self._make_inputs(n_tiles=17)
+        result = calc_landcover(tilefrac, landfrac, model="cable")
+        type_values = result["type"].values.tolist()
+        assert type_values[0] == "Evergreen_Needleleaf"
+        assert type_values[4] == "Shrub"
+        assert type_values[16] == "Ice"
+
+    @pytest.mark.unit
+    def test_cmip6_output_dimension_named_type(self):
+        """CMIP6 model path also renames the pseudo-level dim to 'type'."""
+        from access_moppy.derivations.calc_land import calc_landcover
+
+        tilefrac, landfrac = self._make_inputs(n_tiles=4)
+        result = calc_landcover(tilefrac, landfrac, model="cmip6")
+        assert "type" in result.dims
+        assert result.sizes["type"] == 4
+
+    @pytest.mark.unit
+    def test_nan_values_are_filled_with_zero(self):
+        """NaN inputs must be replaced by 0.0 in the output."""
+        from access_moppy.derivations.calc_land import calc_landcover
+
+        tilefrac = xr.DataArray(
+            np.array([[[np.nan, 1.0]]], dtype=np.float32),
+            dims=["lat", "pseudo_level_0", "lon"],
+        )
+        landfrac = xr.DataArray(
+            np.array([[1.0, 1.0]], dtype=np.float32), dims=["lat", "lon"]
+        )
+        result = calc_landcover(tilefrac, landfrac, model="cmip6")
+        # NaN * anything = NaN, then fillna(0) → 0
+        assert float(result.isel(lat=0, type=0, lon=0)) == pytest.approx(0.0)
+
+    @pytest.mark.unit
+    def test_type_coord_units_are_empty(self):
+        """The 'type' coordinate must carry an empty-string units attribute."""
+        from access_moppy.derivations.calc_land import calc_landcover
+
+        tilefrac, landfrac = self._make_inputs(n_tiles=17)
+        result = calc_landcover(tilefrac, landfrac, model="cable")
+        assert result["type"].attrs.get("units") == ""

--- a/tests/unit/test_derivations.py
+++ b/tests/unit/test_derivations.py
@@ -197,8 +197,11 @@ class TestCalcLandcover:
         """NaN inputs must be replaced by 0.0 in the output."""
         from access_moppy.derivations.calc_land import calc_landcover
 
+        # cmip6 has 4 vegetation types — pseudo_level_0 must match
         tilefrac = xr.DataArray(
-            np.array([[[np.nan, 1.0]]], dtype=np.float32),
+            np.array(
+                [[[np.nan, 1.0], [0.5, 0.5], [0.3, 0.3], [0.2, 0.2]]], dtype=np.float32
+            ),
             dims=["lat", "pseudo_level_0", "lon"],
         )
         landfrac = xr.DataArray(


### PR DESCRIPTION
Resolves #159 

## Summary

Fixes CMORisation of `landCoverFrac` (Lmon), which was broken in several places.

## Changes

### `calc_landcover` signature refactor (`calc_land.py`)
- Changed `calc_landcover(var, model)` where `var` was an opaque list of two arrays to `calc_landcover(tilefrac, landfrac, model)` with named parameters — consistent with the `extract_tilefrac` convention.

### Mapping update (`ACCESS-ESM1.6_mappings.json`)
- Updated `landCoverFrac` calculation to pass `fld_s03i317` and `fld_s03i395` as individual positional args, with `model` as an explicit kwarg `{"literal": "cable"}`.
- Makes the intent of each argument clear at a glance.

### `update_attributes` fix (`atmosphere.py`)
- The `vegtype` coordinate holds string values (`'Evergreen_Needleleaf'`, etc.) and has vocabulary type `"character"`. The `astype(float)` path was being applied to it, causing `ValueError: could not convert string to float`.
- Added a guard to skip `astype` for any coordinate whose vocabulary type is `"character"`, mirroring the existing guard for time coordinates.

### `_prepare_string_coordinates` fix (`base.py`)
- `coord.values.astype(str).flat` returns a `numpy.flatiter` which is exhausted by `max()`, leaving nothing to encode → empty array → `reshape` fails with `ValueError: cannot reshape array of size 0 into shape (17,)`.
- Fixed by materialising the flat iterator as a `list` before `max()`, and added `default=1` guard for empty-string values (CABLE types 12 & 13 are unused empty slots).