### PR TITLE
fix: suppress xarray FutureWarnings in open_mfdataset calls

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -397,6 +397,9 @@ class CMORiser:
                     engine="netcdf4",
                     decode_cf=False,
                     chunks={},
+                    data_vars="minimal",  # Only concat variables with the time dim; avoids FutureWarning
+                    coords="minimal",  # Required when compat='override'; only concat coords along time
+                    compat="override",  # Take first file's value for non-concat vars; avoids FutureWarning
                     preprocess=_preprocess,
                     parallel=True,  # <--- enables concurrent preprocessing
                 )

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -726,15 +726,19 @@ def _detect_frequency_from_concatenated_files(
 
         # Use xr.open_mfdataset for efficient concatenation
         # decode_cf=False keeps it lazy, combine='nested' with concat_dim for proper concatenation
-        with xr.open_mfdataset(
-            sampled_files,
-            decode_cf=False,
-            chunks={},
-            concat_dim=time_coord,
-            combine="nested",
-            data_vars="minimal",  # Only load coordinate variables
-            coords="minimal",
-        ) as mf_ds:
+        with (
+            xr.open_mfdataset(
+                sampled_files,
+                decode_cf=False,
+                chunks={},
+                concat_dim=time_coord,
+                combine="nested",
+                data_vars="minimal",  # Only concat variables that have the concat dim
+                coords="minimal",
+                compat="override",  # Skip equality check for non-concat coords (e.g. surface_altitude)
+                join="override",  # Don't align indexes across files; each file has its own time slice
+            ) as mf_ds
+        ):
             # Detect frequency from the concatenated time coordinate
             detected_freq = detect_time_frequency_lazy(mf_ds, time_coord)
 

--- a/tests/unit/test_frequency_detection.py
+++ b/tests/unit/test_frequency_detection.py
@@ -342,7 +342,7 @@ class TestFrequencyDetection:
         assert detected_freq is not None
         assert abs(detected_freq.total_seconds() - 43200) < 1  # 12 hours
 
-    def test_multifile_detection_with_conflicting_static_variable_no_fallback(self):
+    def test_multifile_conflicting_static_no_fallback(self):
         """Multi-file concat should handle conflicting static vars without fallback."""
         with tempfile.TemporaryDirectory() as tmpdir:
             lat = np.array([0.0])

--- a/tests/unit/test_frequency_detection.py
+++ b/tests/unit/test_frequency_detection.py
@@ -15,6 +15,7 @@ from access_moppy.utilities import (
     FrequencyMismatchError,
     IncompatibleFrequencyError,
     _detect_frequency_from_access_metadata,
+    _detect_frequency_from_concatenated_files,
     _parse_access_frequency_metadata,
     detect_time_frequency_lazy,
     is_frequency_compatible,
@@ -340,6 +341,66 @@ class TestFrequencyDetection:
         # Should use bounds (12 hours) not coordinate differences (24 hours)
         assert detected_freq is not None
         assert abs(detected_freq.total_seconds() - 43200) < 1  # 12 hours
+
+    def test_multifile_detection_with_conflicting_static_variable_no_fallback(self):
+        """Multi-file concat should handle conflicting static vars without fallback."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lat = np.array([0.0])
+            lon = np.array([0.0])
+
+            ds1 = xr.Dataset(
+                {
+                    "tas": (
+                        ["time", "lat", "lon"],
+                        np.array([[[290.0]], [[290.5]]]),
+                    ),
+                    "surface_altitude": (["lat", "lon"], np.array([[10.0]])),
+                },
+                coords={
+                    "time": (
+                        ["time"],
+                        np.array([0.0, 1.0]),
+                        {"units": "days since 2000-01-01"},
+                    ),
+                    "lat": (["lat"], lat),
+                    "lon": (["lon"], lon),
+                },
+            )
+            ds2 = xr.Dataset(
+                {
+                    "tas": (
+                        ["time", "lat", "lon"],
+                        np.array([[[291.0]], [[291.5]]]),
+                    ),
+                    "surface_altitude": (["lat", "lon"], np.array([[20.0]])),
+                },
+                coords={
+                    "time": (
+                        ["time"],
+                        np.array([2.0, 3.0]),
+                        {"units": "days since 2000-01-01"},
+                    ),
+                    "lat": (["lat"], lat),
+                    "lon": (["lon"], lon),
+                },
+            )
+
+            file1 = Path(tmpdir) / "file_1.nc"
+            file2 = Path(tmpdir) / "file_2.nc"
+            ds1.to_netcdf(file1)
+            ds2.to_netcdf(file2)
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                detected_freq = _detect_frequency_from_concatenated_files(
+                    [str(file1), str(file2)]
+                )
+
+            assert detected_freq == pd.Timedelta(days=1)
+            assert not any(
+                "falling back to individual file analysis" in str(w.message)
+                for w in caught
+            )
 
 
 class TestACCESSFrequencyMetadata:


### PR DESCRIPTION
Fixes #283

## Summary

Several `xr.open_mfdataset` calls were emitting xarray `FutureWarning`s (and in one case a `UserWarning`) about upcoming default-value changes. These are pre-emptive fixes before those defaults change in a future xarray release.

## Changes

### `src/access_moppy/base.py`

Added explicit kwargs to the time-concatenating `open_mfdataset` call:

| Kwarg | Value | Reason |
|-------|-------|--------|
| `data_vars` | `"minimal"` | Silences `FutureWarning` about `data_vars` default changing from `'all'` to `None`; also avoids pulling static fields into the time concat |
| `coords` | `"minimal"` | Required companion to `compat='override'`; xarray raises `ValueError` if `coords='different'` (the old default) is used together with `compat='override'` |
| `compat` | `"override"` | Silences `FutureWarning` about `compat` default changing from `'no_conflicts'` to `'override'`; takes the first file's value for non-concat variables |

### `src/access_moppy/utilities.py`

Added explicit kwargs to the frequency-detection `open_mfdataset` call:

| Kwarg | Value | Reason |
|-------|-------|--------|
| `compat` | `"override"` | Prevents `UserWarning` about conflicting values for `surface_altitude` across files; avoids falling back to slow per-file analysis |
| `join` | `"override"` | Silences `FutureWarning` about `join` default changing from `'outer'` to `'exact'`; no index alignment is needed when each file contributes its own time slice |
