### PR TITLE
feat(seaice): add derivations for sisnconc and sisnthick

### DIFF
--- a/src/access_moppy/derivations/__init__.py
+++ b/src/access_moppy/derivations/__init__.py
@@ -45,8 +45,10 @@ from access_moppy.derivations.calc_seaice import (
     calc_siareas,
     calc_siextentn,
     calc_siextents,
+    calc_sisnconc,
     calc_sisnmassn,
     calc_sisnmasss,
+    calc_sisnthick,
     calc_sivoln,
     calc_sivols,
 )
@@ -111,8 +113,10 @@ custom_functions = {
     "calc_siareas": calc_siareas,
     "calc_sivoln": calc_sivoln,
     "calc_sivols": calc_sivols,
+    "calc_sisnconc": calc_sisnconc,
     "calc_sisnmassn": calc_sisnmassn,
     "calc_sisnmasss": calc_sisnmasss,
+    "calc_sisnthick": calc_sisnthick,
     "calc_siextentn": calc_siextentn,
     "calc_siextents": calc_siextents,
 }

--- a/src/access_moppy/derivations/calc_seaice.py
+++ b/src/access_moppy/derivations/calc_seaice.py
@@ -378,7 +378,7 @@ def calc_sisnconc(siconc):
     Returns
     -------
     xarray.DataArray
-        Snow area fraction as a dimensionless fraction (0 or 1).
+        Snow area fraction in percent (0 or 100).
 
     References
     ----------
@@ -391,7 +391,7 @@ def calc_sisnconc(siconc):
     --------
     >>> snc = calc_sisnconc(siconc)
     """
-    return (siconc > 0) * 1.0
+    return (siconc > 0) * 100.0
 
 
 def calc_sisnthick(sisnmass, siconc):

--- a/src/access_moppy/derivations/calc_seaice.py
+++ b/src/access_moppy/derivations/calc_seaice.py
@@ -362,6 +362,73 @@ def calc_sisnmasss(sisnmass, tarea):
     return (sisnmass * tarea).isel(nj=slice(0, len(sisnmass.nj) // 2)).sum(["ni", "nj"])
 
 
+def calc_sisnconc(siconc):
+    """
+    Calculate Snow Area Fraction on Sea Ice (binary approximation).
+
+    For ESM1.6/CICE, snow concentration is not a prognostic variable.
+    Following Notz et al. (2016), this returns a binary value: 1 (100%)
+    where sea ice is present and 0 where it is absent.
+
+    Parameters
+    ----------
+    siconc : xarray.DataArray
+        Sea ice concentration in % (0-100).
+
+    Returns
+    -------
+    xarray.DataArray
+        Snow area fraction as a dimensionless fraction (0 or 1).
+
+    References
+    ----------
+    Notz et al. (2016): "D1.5 Snow area fraction (sisnconc) Area fraction of
+    the sea-ice surface that is covered by snow. In many models that do not
+    explicitly resolve an areal fraction of snow, this variable will always
+    be either 0 or 1."
+
+    Examples
+    --------
+    >>> snc = calc_sisnconc(siconc)
+    """
+    return (siconc > 0) * 1.0
+
+
+def calc_sisnthick(sisnmass, siconc):
+    """
+    Calculate Snow Thickness on Sea Ice.
+
+    For ESM1.6/CICE, true snow thickness (averaged over the snow-covered
+    fraction of sea ice) is not prognostic. It is derived from snow mass
+    and ice concentration using a fixed snow density, following the
+    convention agreed for CMIP6/CMIP7 ESM1.6 submissions.
+
+    Formula: sisnthick = sisnmass / (rho_snow * siconc/100)
+    where rho_snow = 317 kg/m³ (fixed snow density in CICE ESM1.6).
+    Result is set to 0 where sea ice is absent.
+
+    Parameters
+    ----------
+    sisnmass : xarray.DataArray
+        Snow mass per unit area on sea ice (kg m-2), averaged over the
+        full grid cell.
+    siconc : xarray.DataArray
+        Sea ice concentration in % (0-100).
+
+    Returns
+    -------
+    xarray.DataArray
+        Snow thickness in metres (m), averaged over the snow-covered area.
+
+    Examples
+    --------
+    >>> snd = calc_sisnthick(sisnmass, siconc)
+    """
+    SNOW_DENSITY = 317.0  # kg/m³, fixed snow density in CICE for ESM1.6
+    siconc_frac = siconc / 100.0
+    return (sisnmass / (SNOW_DENSITY * siconc_frac)).where(siconc > 0, 0.0)
+
+
 def calc_siextentn(siconc, tarea):
     """
     Calculate Sea-Ice Extent North.

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -7231,7 +7231,7 @@
                 "TLAT": "lat",
                 "TLON": "lon"
             },
-            "units": "1",
+            "units": "%",
             "positive": null,
             "model_variables": [
                 "siconc"

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -7234,13 +7234,13 @@
             "units": "1",
             "positive": null,
             "model_variables": [
-                "sisnthick"
+                "siconc"
             ],
             "calculation": {
                 "type": "formula",
-                "formula": "sisnconc",
+                "operation": "calc_sisnconc",
                 "args": [
-                    "sisnthick"
+                    "siconc"
                 ]
             }
         },
@@ -7274,11 +7274,16 @@
             "units": "m",
             "positive": null,
             "model_variables": [
-                "sisnthick"
+                "sisnmass",
+                "siconc"
             ],
             "calculation": {
-                "type": "direct",
-                "formula": "sisnthick"
+                "type": "formula",
+                "operation": "calc_sisnthick",
+                "args": [
+                    "sisnmass",
+                    "siconc"
+                ]
             }
         },
         "sispeed": {

--- a/tests/unit/test_derivations_calc_seaice.py
+++ b/tests/unit/test_derivations_calc_seaice.py
@@ -515,11 +515,11 @@ class TestCalcSisnconc:
 
     @pytest.mark.unit
     def test_binary_output(self):
-        """Result must contain only 0.0 or 1.0."""
+        """Result must contain only 0.0 or 100.0."""
         _, siconc = _make_snow_grid()
         result = calc_sisnconc(siconc)
         unique = np.unique(result.values)
-        assert set(unique).issubset({0.0, 1.0})
+        assert set(unique).issubset({0.0, 100.0})
 
     @pytest.mark.unit
     def test_one_where_ice_present(self):
@@ -530,7 +530,7 @@ class TestCalcSisnconc:
             coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
         )
         result = calc_sisnconc(siconc)
-        np.testing.assert_array_equal(result.values, [[[1.0, 1.0]]])
+        np.testing.assert_array_equal(result.values, [[[100.0, 100.0]]])
 
     @pytest.mark.unit
     def test_zero_where_no_ice(self):
@@ -552,7 +552,7 @@ class TestCalcSisnconc:
             coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
         )
         result = calc_sisnconc(siconc)
-        np.testing.assert_array_equal(result.values, [[[0.0, 1.0]]])
+        np.testing.assert_array_equal(result.values, [[[0.0, 100.0]]])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_derivations_calc_seaice.py
+++ b/tests/unit/test_derivations_calc_seaice.py
@@ -11,8 +11,10 @@ from access_moppy.derivations.calc_seaice import (
     calc_siareas,
     calc_siextentn,
     calc_siextents,
+    calc_sisnconc,
     calc_sisnmassn,
     calc_sisnmasss,
+    calc_sisnthick,
     calc_sivoln,
     calc_sivols,
 )
@@ -467,3 +469,169 @@ class TestCalcSiextents:
         south = calc_siextents(siconc, tarea)
         total = ((siconc > 0.15) * tarea).sum(["ni", "nj"]) / 1e12
         np.testing.assert_allclose((north + south).values, total.values, rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for sisnconc / sisnthick (siconc in %, sisnmass in kg m-2)
+# ---------------------------------------------------------------------------
+
+
+def _make_snow_grid():
+    """Return (sisnmass, siconc) with siconc in % (0-100) and some zero-ice cells."""
+    times = xr.date_range("2000-01-01", periods=NT, freq="ME")
+
+    # siconc in %: some cells at 0 (no ice)
+    siconc_data = np.array(
+        [[[0.0, 50.0, 100.0], [25.0, 75.0, 0.0]]] * NT, dtype=float
+    )  # shape (NT, 2, 3)
+    sisnmass_data = np.full((NT, 2, 3), 31.7, dtype=float)  # kg m-2
+
+    siconc = xr.DataArray(
+        siconc_data, dims=["time", "nj", "ni"], coords={"time": times}
+    )
+    sisnmass = xr.DataArray(
+        sisnmass_data, dims=["time", "nj", "ni"], coords={"time": times}
+    )
+    return sisnmass, siconc
+
+
+# ---------------------------------------------------------------------------
+# calc_sisnconc
+# ---------------------------------------------------------------------------
+
+
+class TestCalcSisnconc:
+    @pytest.mark.unit
+    def test_returns_dataarray(self):
+        _, siconc = _make_snow_grid()
+        result = calc_sisnconc(siconc)
+        assert isinstance(result, xr.DataArray)
+
+    @pytest.mark.unit
+    def test_preserves_dims(self):
+        _, siconc = _make_snow_grid()
+        result = calc_sisnconc(siconc)
+        assert result.dims == siconc.dims
+
+    @pytest.mark.unit
+    def test_binary_output(self):
+        """Result must contain only 0.0 or 1.0."""
+        _, siconc = _make_snow_grid()
+        result = calc_sisnconc(siconc)
+        unique = np.unique(result.values)
+        assert set(unique).issubset({0.0, 1.0})
+
+    @pytest.mark.unit
+    def test_one_where_ice_present(self):
+        """Cells with siconc > 0 should return 1.0."""
+        siconc = xr.DataArray(
+            [[[50.0, 100.0]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        result = calc_sisnconc(siconc)
+        np.testing.assert_array_equal(result.values, [[[1.0, 1.0]]])
+
+    @pytest.mark.unit
+    def test_zero_where_no_ice(self):
+        """Cells with siconc == 0 should return 0.0."""
+        siconc = xr.DataArray(
+            [[[0.0, 0.0]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        result = calc_sisnconc(siconc)
+        np.testing.assert_array_equal(result.values, [[[0.0, 0.0]]])
+
+    @pytest.mark.unit
+    def test_mixed_ice_no_ice(self):
+        """Mixed grid: ice-present cells → 1, no-ice cells → 0."""
+        siconc = xr.DataArray(
+            [[[0.0, 30.0]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        result = calc_sisnconc(siconc)
+        np.testing.assert_array_equal(result.values, [[[0.0, 1.0]]])
+
+
+# ---------------------------------------------------------------------------
+# calc_sisnthick
+# ---------------------------------------------------------------------------
+
+
+class TestCalcSisnthick:
+    @pytest.mark.unit
+    def test_returns_dataarray(self):
+        sisnmass, siconc = _make_snow_grid()
+        result = calc_sisnthick(sisnmass, siconc)
+        assert isinstance(result, xr.DataArray)
+
+    @pytest.mark.unit
+    def test_preserves_dims(self):
+        sisnmass, siconc = _make_snow_grid()
+        result = calc_sisnthick(sisnmass, siconc)
+        assert result.dims == sisnmass.dims
+
+    @pytest.mark.unit
+    def test_zero_where_no_ice(self):
+        """Cells with siconc == 0 should return 0.0, not NaN."""
+        siconc = xr.DataArray(
+            [[[0.0]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        sisnmass = xr.DataArray(
+            [[[10.0]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        result = calc_sisnthick(sisnmass, siconc)
+        assert float(result.squeeze().values) == pytest.approx(0.0)
+        assert not np.isnan(float(result.squeeze().values))
+
+    @pytest.mark.unit
+    def test_known_value_full_ice_cover(self):
+        """sisnmass=317 kg m-2, siconc=100% → sisnthick = 317/(317*1.0) = 1.0 m."""
+        siconc = xr.DataArray(
+            [[[100.0]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        sisnmass = xr.DataArray(
+            [[[317.0]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        result = calc_sisnthick(sisnmass, siconc)
+        assert float(result.squeeze().values) == pytest.approx(1.0)
+
+    @pytest.mark.unit
+    def test_known_value_partial_ice_cover(self):
+        """sisnmass=31.7 kg m-2, siconc=50% → sisnthick = 31.7/(317*0.5) = 0.2 m."""
+        siconc = xr.DataArray(
+            [[[50.0]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        sisnmass = xr.DataArray(
+            [[[31.7]]],
+            dims=["time", "nj", "ni"],
+            coords={"time": xr.date_range("2000-01-01", periods=1, freq="ME")},
+        )
+        result = calc_sisnthick(sisnmass, siconc)
+        assert float(result.squeeze().values) == pytest.approx(0.2)
+
+    @pytest.mark.unit
+    def test_non_negative(self):
+        sisnmass, siconc = _make_snow_grid()
+        result = calc_sisnthick(sisnmass, siconc)
+        assert float(result.min()) >= 0.0
+
+    @pytest.mark.unit
+    def test_no_nan_where_ice_present(self):
+        """No NaN values should appear where sea ice is present."""
+        sisnmass, siconc = _make_snow_grid()
+        result = calc_sisnthick(sisnmass, siconc)
+        ice_present = siconc > 0
+        assert not np.any(np.isnan(result.values[ice_present.values]))


### PR DESCRIPTION
Closes #152

`sisnconc` (snow area fraction) and `sisnthick` (snow thickness) are required CMIP7 sea-ice variables but are not prognostic in CICE for ESM1.6. This PR adds derived calculations for both, following the approach agreed in the issue discussion.

## Solution

**`sisnconc`** — Following Notz et al. (2016), snow concentration is reported as a binary value: `1` where sea ice is present, `0` where absent. This is the accepted approach for models where snow fraction is not explicitly resolved.

**`sisnthick`** — Derived from snow mass and ice concentration using a fixed snow density (317 kg/m³, as used in CICE for ESM1.6):

$$\text{sisnthick} = \frac{\text{sisnmass}}{317.0 \times \text{siconc}/100}$$

Set to `0` where no sea ice is present.

## Changes

- `calc_seaice.py`: add `calc_sisnconc(siconc)` and `calc_sisnthick(sisnmass, siconc)`
- `derivations/__init__.py`: import and register both functions in `custom_functions`
- `ACCESS-ESM1.6_mappings.json`: fix `sisnconc` and `sisnthick` entries to use the correct model variables (`siconc`, `sisnmass`) and call the new derivation functions instead of direct pass-throughs of the non-prognostic `sisnthick` variable
