### PR TITLE
Fix recursive error

### DIFF
--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -235,6 +235,7 @@ class ACCESS_ESM_CMORiser:
         if table in (
             "Amon",
             "Lmon",
+            "LImon",
             "Emon",
             "AERmon",
             "AERday",

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -304,6 +304,11 @@ class ACCESS_ESM_CMORiser:
         return self.cmoriser.ds[key]
 
     def __getattr__(self, attr):
+        # Guard against infinite recursion when cmoriser itself is not yet set
+        if attr == "cmoriser":
+            raise AttributeError(
+                "'ACCESS_ESM_CMORiser' has no 'cmoriser' — the table may not be supported"
+            )
         # This is only called if the attr is not found on CMORiser itself
         return getattr(self.cmoriser.ds, attr)
 

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -135,6 +135,7 @@ def load_model_mappings(compound_name: str, model_id: str = None) -> Dict:
                 "aerosol",
                 "atmosphere",
                 "land",
+                "landIce",
                 "ocean",
                 "oceanBgchem",
                 "time_invariant",

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -933,6 +933,22 @@ class TestACCESSESMCMORiserContextManager:
             cmoriser.close()  # must not raise
 
     @pytest.mark.unit
+    def test_getattr_cmoriser_missing_raises_attribute_error_not_recursion(self):
+        """Accessing 'cmoriser' on an instance where it was never set must raise
+        AttributeError, not RecursionError."""
+        driver = ACCESS_ESM_CMORiser.__new__(ACCESS_ESM_CMORiser)
+        with pytest.raises(AttributeError, match="table may not be supported"):
+            _ = driver.cmoriser
+
+    @pytest.mark.unit
+    def test_getattr_other_attr_when_cmoriser_missing_raises_attribute_error(self):
+        """Accessing any delegated attribute when cmoriser is unset must raise
+        AttributeError rather than triggering infinite recursion."""
+        driver = ACCESS_ESM_CMORiser.__new__(ACCESS_ESM_CMORiser)
+        with pytest.raises(AttributeError):
+            _ = driver.ds
+
+    @pytest.mark.unit
     def test_context_manager_enter_and_exit(self, valid_config, temp_dir):
         """__enter__ returns self; __exit__ calls close() without error."""
         with patch("access_moppy.driver.load_model_mappings") as mock_load:


### PR DESCRIPTION
fix error mentioned in #294

Add a guard in __getattr__(), make sure there is no `recursive error` while can not fin target table, and output more clear error message.