### PR TITLE
Fix mrfso mapping issue

### DIFF
--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -1387,8 +1387,7 @@
             "positive": null,
             "model_variables": [
                 "fld_s08i223",
-                "fld_s08i230",
-                "depth"
+                "fld_s08i230"
             ],
             "calculation": {
                 "type": "formula",
@@ -1403,7 +1402,9 @@
                     }
                 ],
                 "kwargs": {
-                    "dim": "depth"
+                    "dim": {
+                        "literal": "soil_model_level_number"
+                    }
                 }
             },
             "CF standard Name": "soil_frozen_water_content"
@@ -3753,8 +3754,12 @@
                     "sfc_hflux_pme"
                 ],
                 "kwargs": {
-                    "frazil_3d_int_z": {"optional": "frazil_3d_int_z"},
-                    "frazil_2d": {"optional": "frazil_2d"}
+                    "frazil_3d_int_z": {
+                        "optional": "frazil_3d_int_z"
+                    },
+                    "frazil_2d": {
+                        "optional": "frazil_2d"
+                    }
                 }
             },
             "CF standard Name": ""

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -1379,7 +1379,6 @@
         "mrfso": {
             "dimensions": {
                 "time": "time",
-                "depth": "depth",
                 "lat": "lat",
                 "lon": "lon"
             },


### PR DESCRIPTION
fix #299 , `mrfso` mapping has following issue:

1. `depth` shouldn't be in `model_variables`.
2. `depth` shouldn't be in `dimensions`, `mrfso` only have 3 dimensions.
3. in kwargs section, dim should be "soil_model_level_number" in stead of "depth". meanwhile, "soil_model_level_number" should be a `literal` expr in calculate, so should add `literal` as a key in kwargs.