### PR TITLE
fix: multiple performance and correctness fixes

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -489,7 +489,11 @@ class CMORiser:
             # Check if coordinate contains cftime objects
             if coord.size > 0:
                 # Get first value to check type
-                first_val = coord.values.flat[0] if coord.values.size > 0 else None
+                first_val = (
+                    coord.isel({coord.dims[0]: 0}).values.item()
+                    if coord.size > 0
+                    else None
+                )
 
                 if first_val is not None and isinstance(first_val, cftime.datetime):
                     # Extract time encoding attributes
@@ -964,6 +968,8 @@ class CMORiser:
             # Combined with our chunking strategy (at least 4MB chunks), this optimizes
             # both file layout and chunk size for efficient I/O operations.
             created_vars = {}
+            # Cache decoded-time flag per variable so PHASE 2 never re-materialises.
+            decoded_time_vars = {}
             for var in self.ds.variables:
                 vdat = self.ds[var]
 
@@ -984,11 +990,17 @@ class CMORiser:
 
                     # Decoded time coordinates (datetime64 or cftime) must be stored
                     # as float64 in netCDF4; use "f8" instead of str(vdat.dtype).
+                    # For object-dtype arrays peek at a single element to avoid a
+                    # full .compute() on potentially large dask arrays.
                     _is_decoded_time = np.issubdtype(vdat.dtype, np.datetime64) or (
                         vdat.dtype == object
                         and vdat.size > 0
-                        and hasattr(vdat.values.flat[0], "year")
+                        and hasattr(
+                            vdat.isel({d: 0 for d in vdat.dims}).values.flat[0],
+                            "year",
+                        )
                     )
+                    decoded_time_vars[var] = _is_decoded_time
                     nc_dtype = "f8" if _is_decoded_time else str(vdat.dtype)
 
                     # Apply HDF5 optimization features for chunked variables:
@@ -1118,11 +1130,8 @@ class CMORiser:
                     else:
                         # Direct write for small/non-Dask/non-time variables
                         # Encode decoded time back to numeric float64 for netCDF4
-                        _is_decoded_time = np.issubdtype(vdat.dtype, np.datetime64) or (
-                            vdat.dtype == object
-                            and vdat.size > 0
-                            and hasattr(vdat.values.flat[0], "year")
-                        )
+                        # Reuse the flag cached during PHASE 1 — no extra compute.
+                        _is_decoded_time = decoded_time_vars.get(var, False)
                         if _is_decoded_time:
                             units = vdat.attrs.get("units") or vdat.encoding.get(
                                 "units"

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -21,6 +21,19 @@ from access_moppy.utilities import (
     validate_cmip6_frequency_compatibility,
 )
 
+# Module-level pint registry singleton — constructing UnitRegistry is O(100 ms)
+# so it must never be called inside a per-variable loop.
+_PINT_REGISTRY = None
+
+
+def _get_ureg():
+    global _PINT_REGISTRY
+    if _PINT_REGISTRY is None:
+        import pint
+
+        _PINT_REGISTRY = pint.UnitRegistry()
+    return _PINT_REGISTRY
+
 
 class DatasetChunker:
     """
@@ -581,7 +594,7 @@ class CMORiser:
         try:
             import pint
 
-            ureg = pint.UnitRegistry()
+            ureg = _get_ureg()
 
             # Handle empty/None units
             if not actual and not expected:

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -671,8 +671,9 @@ class CMORiser:
     def _check_range(self, var: str, vmin: float, vmax: float):
         arr = self.ds[var]
         if hasattr(arr.data, "map_blocks"):
-            too_small = (arr < vmin).any().compute()
-            too_large = (arr > vmax).any().compute()
+            # Fuse both comparisons into one scheduler pass instead of two
+            # separate .compute() calls.
+            too_small, too_large = da.compute((arr < vmin).any(), (arr > vmax).any())
         else:
             too_small = (arr < vmin).any().item()
             too_large = (arr > vmax).any().item()

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -10,7 +10,6 @@ import numpy as np
 import psutil
 import xarray as xr
 from cftime import date2num
-from dask.distributed import get_client
 
 from access_moppy.utilities import (
     FrequencyMismatchError,
@@ -869,78 +868,31 @@ class CMORiser:
                 "   Some attributes may be required for CMIP compliance but file will still be written."
             )
 
-        # ========== Memory Check ==========
-        # This section estimates the data size and compares it against available memory
-        # to prevent out-of-memory errors during the write operation.
-
-        def estimate_data_size(ds, cmor_name):
-            total_size = 0
-            for var in ds.variables:
-                vdat = ds[var]
-                # Start with the size of a single element (e.g., 4 bytes for float32)
-                var_size = vdat.dtype.itemsize
-                # Multiply by the size of each dimension to get total elements
-                for dim in vdat.dims:
-                    var_size *= ds.sizes[dim]
-                total_size += var_size
-            # Apply 1.5x overhead factor for safe memory estimation
-            return int(total_size * 1.5)
-
-        # Calculate the estimated data size for this dataset
-        data_size = estimate_data_size(self.ds, self.cmor_name)
-
-        # Get system memory information using psutil
-        available_memory = psutil.virtual_memory().available
-
-        # ========== Dask Client Detection ==========
-        # Check if a Dask distributed client exists, as this affects how we handle
-        # memory management. Dask clusters have their own memory limits separate
-        # from system memory.
-
-        client = None
-        worker_memory = None  # Memory limit of a single worker
-
-        try:
-            # Attempt to get an existing Dask client
-            client = get_client()
-
-            # Retrieve information about all workers in the cluster
-            worker_info = client.scheduler_info()["workers"]
-
-            if worker_info:
-                # Get the minimum memory_limit across all workers
-                worker_memory = min(w["memory_limit"] for w in worker_info.values())
-
-        except ValueError:
-            # No Dask client exists - we'll use local/system memory for writing
-            pass
-
-        # ========== Memory Validation Logic ==========
-        # This section implements a decision tree based on data size vs available memory:
-
-        if client is not None:
-            # Dask client exists - check against cluster memory limits
-            if data_size > worker_memory:
-                # WARNING: Data fits in total cluster memory but exceeds single worker capacity
-                print(
-                    f"Warning: Data size ({data_size / 1024**3:.2f} GB) exceeds single worker memory "
-                    f"({worker_memory / 1024**3:.2f} GB)."
-                )
-                print("Closing Dask client to use local memory for writing...")
-                client.close()
-                client = None
-                # Refresh available memory after closing client
-                available_memory = psutil.virtual_memory().available
-
-        # Check if chunked writing is needed
+        # ========== Chunked vs Eager Write Decision ==========
+        # Use chunked writing only when the main variable is dask-backed and a
+        # chunker is configured.  For dask arrays, memory is managed by the
+        # dask scheduler; a system-level psutil check is not meaningful there.
         main_var = self.ds[self.cmor_name]
         is_dask_array = isinstance(main_var.data, da.Array)
         use_chunked_write = is_dask_array and self.chunker is not None
 
         if use_chunked_write:
-            print(f"📦 Dataset size: {data_size / 1024**3:.2f} GB")
-            print("   Using chunked writing with DatasetChunker")
+            print("📦 Using chunked writing with DatasetChunker")
         else:
+            # Eager write: estimate size and guard against OOM before starting.
+            def estimate_data_size(ds):
+                total_size = 0
+                for var in ds.variables:
+                    vdat = ds[var]
+                    var_size = vdat.dtype.itemsize
+                    for dim in vdat.dims:
+                        var_size *= ds.sizes[dim]
+                    total_size += var_size
+                return int(total_size * 1.5)
+
+            data_size = estimate_data_size(self.ds)
+            available_memory = psutil.virtual_memory().available
+
             if data_size > available_memory:
                 raise MemoryError(
                     f"Data size ({data_size / 1024**3:.2f} GB) exceeds available system memory "

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -126,7 +126,8 @@ class DatasetChunker:
         print("  - Time bounds: single chunk")
         print(f"  - Data variables: at least {self.target_chunk_size_mb}MB chunks")
 
-        rechunked_vars = {}
+        rechunked_coords = {}
+        rechunked_data_vars = {}
 
         for var_name in ds.variables:
             var = ds[var_name]
@@ -166,13 +167,19 @@ class DatasetChunker:
                 print(f"  {var_name}: data variable → {chunk_info}")
 
             try:
-                rechunked_vars[var_name] = var.chunk(chunks)
+                rechunked_var = var.chunk(chunks)
             except Exception as e:
                 print(f"Warning: Could not rechunk variable '{var_name}': {e}")
-                rechunked_vars[var_name] = var
+                rechunked_var = var
 
-        # Reconstruct dataset with rechunked variables
-        rechunked_ds = xr.Dataset(rechunked_vars, attrs=ds.attrs)
+            if var_name in ds.coords:
+                rechunked_coords[var_name] = rechunked_var
+            else:
+                rechunked_data_vars[var_name] = rechunked_var
+
+        # Use assign_coords + assign to preserve all dataset metadata
+        # (coordinate attributes, encoding, and dataset structure)
+        rechunked_ds = ds.assign_coords(rechunked_coords).assign(rechunked_data_vars)
         print("✅ Dataset rechunking completed")
 
         return rechunked_ds

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -347,6 +347,19 @@ class CMORiser:
                     ds = ds.drop_vars(aux_time_coords)
                 return ds
 
+            # Open the first file once to probe its structure.  This single handle
+            # is reused for both the frequency-validation time-independence check
+            # and the _has_time check below, avoiding a duplicate open and the
+            # file-handle leak that an unguarded open_dataset would cause.
+            with xr.open_dataset(self.input_paths[0], decode_cf=False) as _probe:
+                _probe_dims = set(_probe.dims)
+                _probe_target_vars = (
+                    [v for v in required_vars if v in _probe.data_vars]
+                    if required_vars
+                    else list(_probe.data_vars)
+                )
+                _has_time = any("time" in _probe[v].dims for v in _probe_target_vars)
+
             # Validate frequency consistency and CMIP6 compatibility before concatenation
             # Skip validation for time-independent variables (e.g., areacello, static grids)
             if self.validate_frequency and len(self.input_paths) > 0:
@@ -354,12 +367,7 @@ class CMORiser:
                 # Time-independent variables typically have "fx" (fixed) in their table ID
                 is_time_independent = (
                     self.compound_name and "fx" in self.compound_name.lower()
-                ) or (
-                    # Also check if any input file has no time dimension
-                    len(self.input_paths) > 0
-                    and "time"
-                    not in xr.open_dataset(self.input_paths[0], decode_cf=False).dims
-                )
+                ) or "time" not in _probe_dims
 
                 if is_time_independent:
                     print(
@@ -402,20 +410,6 @@ class CMORiser:
                             f"Could not validate temporal frequency: {e}. "
                             f"Proceeding with concatenation but results may be inconsistent."
                         )
-
-            # Check whether the first file has a time dimension before concatenating.
-            # We check that at least one *data variable* uses the time dimension,
-            # not merely that a bare time coordinate/dimension exists in the file
-            # (e.g. a static grid file like ocean-2d-ht.nc carries time: 1 as a
-            # dimension coordinate but no variable is dimensioned along it).
-            _probe = xr.open_dataset(self.input_paths[0], decode_cf=False)
-            _probe_target_vars = (
-                [v for v in required_vars if v in _probe.data_vars]
-                if required_vars
-                else list(_probe.data_vars)
-            )
-            _has_time = any("time" in _probe[v].dims for v in _probe_target_vars)
-            _probe.close()
 
             if _has_time:
                 self.ds = xr.open_mfdataset(

--- a/src/access_moppy/ocean_supergrid.py
+++ b/src/access_moppy/ocean_supergrid.py
@@ -85,13 +85,21 @@ class Supergrid:
 
     def load_supergrid(self, supergrid_file: str):
         """
-        Load the grid cell quantities following C-grid conventions in
-        https://gist.github.com/adcroft/c1e207024fe1189b43dddc5f1fe7dd6c
-
-        With these we can easily get the grid metrics for any Arakawa grid
-        type
+        Open the supergrid file lazily.  The coordinate arrays are large (especially
+        for the 10 km grid), so actual computation is deferred until the first call
+        to :meth:`extract_grid` via :meth:`_compute_grid`.
         """
-        self.supergrid = xr.open_dataset(supergrid_file)
+        self.supergrid = xr.open_dataset(supergrid_file, chunks={})
+        self._grid_computed = False
+
+    def _compute_grid(self):
+        """
+        Materialise the supergrid arrays and derive all cell-centre / corner arrays.
+        Called once (lazily) by :meth:`extract_grid`.  Follows C-grid conventions from
+        https://gist.github.com/adcroft/c1e207024fe1189b43dddc5f1fe7dd6c
+        """
+        if self._grid_computed:
+            return
 
         x = self.supergrid["x"].values
         y = self.supergrid["y"].values
@@ -215,6 +223,8 @@ class Supergrid:
         self.vcell_corners_x = vcell_corners_x
         self.vcell_corners_y = vcell_corners_y
 
+        self._grid_computed = True
+
     def extract_grid(self, grid_type: str, arakawa: str, symmetric=None):
         """
         Extract grid coordinates and bounds based on the specified grid type.
@@ -230,6 +240,8 @@ class Supergrid:
             If true, return grid for MOM6 symmetric memory mode. Only used if
             arakawa="C"
         """
+
+        self._compute_grid()
 
         if (arakawa == "C") & (symmetric is None):
             raise ValueError("Must specify symmetric as True or False when arakawa='C'")

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -2049,8 +2049,10 @@ def calculate_time_bounds(
     if n_times < 2:
         raise ValueError("Need at least 2 time points to infer time bounds")
 
-    # Get time values and attributes
-    time_values = time.values
+    # Compute only the 1-D time coordinate.  Using .compute().values (rather than
+    # plain .values) ensures that only the time coordinate's dask graph is
+    # triggered, not any larger graph that happens to reference the same chunks.
+    time_values = time.compute().values
     calendar = time.attrs.get("calendar", "proleptic_gregorian")
     units = time.attrs.get("units")
 

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -1011,14 +1011,6 @@ def validate_cmip6_frequency_compatibility(
             file_paths, time_coord, tolerance_seconds
         )
 
-    # Parse target frequency from compound name
-    try:
-        target_freq = parse_cmip6_table_frequency(compound_name)
-    except ValueError as e:
-        raise ValueError(
-            f"Cannot determine target frequency from compound name '{compound_name}': {e}"
-        )
-
     # Check compatibility
     is_compatible, reason = is_frequency_compatible(detected_freq, target_freq)
 

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -62,10 +62,9 @@ def _get_cmip7_to_cmip6_mapping(cmip7_compound_name: str) -> Optional[str]:
         mapping_file = "cmip7_to_cmip6_compound_name_mapping.json"
 
         cmip7_to_cmip6_mapping = {}
-        for entry in mapping_dir.iterdir():
-            if entry.name == mapping_file:
-                cmip7_to_cmip6_mapping = json.loads(entry.read_text(encoding="utf-8"))
-                break
+        entry = mapping_dir / mapping_file
+        if entry.is_file():
+            cmip7_to_cmip6_mapping = json.loads(entry.read_text(encoding="utf-8"))
 
         if not cmip7_to_cmip6_mapping:
             print(f"❌ CMIP7 to CMIP6 mapping file '{mapping_file}' not found")
@@ -133,28 +132,28 @@ def load_model_mappings(compound_name: str, model_id: str = None) -> Dict:
     # Load model-specific consolidated mapping
     model_file = f"{model_id}_mappings.json"
 
-    for entry in mapping_dir.iterdir():
-        if entry.name == model_file:
-            all_mappings = json.loads(entry.read_text(encoding="utf-8"))
+    entry = mapping_dir / model_file
+    if entry.is_file():
+        all_mappings = json.loads(entry.read_text(encoding="utf-8"))
 
-            # Search in component-organized structure
-            for component in [
-                "aerosol",
-                "atmosphere",
-                "land",
-                "landIce",
-                "ocean",
-                "oceanBgchem",
-                "time_invariant",
-                "sea_ice",
-            ]:
-                if component in all_mappings and cmor_name in all_mappings[component]:
-                    return {cmor_name: all_mappings[component][cmor_name]}
+        # Search in component-organized structure
+        for component in [
+            "aerosol",
+            "atmosphere",
+            "land",
+            "landIce",
+            "ocean",
+            "oceanBgchem",
+            "time_invariant",
+            "sea_ice",
+        ]:
+            if component in all_mappings and cmor_name in all_mappings[component]:
+                return {cmor_name: all_mappings[component][cmor_name]}
 
-            # Fallback: search in flat "variables" structure (for backward compatibility)
-            variables = all_mappings.get("variables", {})
-            if cmor_name in variables:
-                return {cmor_name: variables[cmor_name]}
+        # Fallback: search in flat "variables" structure (for backward compatibility)
+        variables = all_mappings.get("variables", {})
+        if cmor_name in variables:
+            return {cmor_name: variables[cmor_name]}
 
     # If model file not found or variable not found, return empty dict
     return {}
@@ -172,10 +171,7 @@ def _model_mapping_file_exists(model_id: str) -> bool:
     """
     model_file = f"{model_id}_mappings.json"
     mapping_dir = files("access_moppy.mappings")
-    for entry in mapping_dir.iterdir():
-        if entry.name == model_file:
-            return True
-    return False
+    return (mapping_dir / model_file).is_file()
 
 
 def get_monthly_ocean_files(

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -552,7 +552,9 @@ class CMIP6Vocabulary:
                 try:
                     current_missing = float(current_missing)
                     if not np.isnan(current_missing):  # Don't double-convert NaN
-                        nan_conditions.append(var == current_missing)
+                        nan_conditions.append(
+                            np.isclose(var, current_missing, rtol=0, atol=1e-3)
+                        )
                 except (ValueError, TypeError):
                     pass
 
@@ -561,7 +563,9 @@ class CMIP6Vocabulary:
                 try:
                     current_fill = float(current_fill)
                     if not np.isnan(current_fill):  # Don't double-convert NaN
-                        nan_conditions.append(var == current_fill)
+                        nan_conditions.append(
+                            np.isclose(var, current_fill, rtol=0, atol=1e-3)
+                        )
                 except (ValueError, TypeError):
                     pass
 

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -11,6 +11,10 @@ import xarray as xr
 
 from access_moppy import _creator
 
+# Module-level cache so that controlled-vocabulary JSON files are read from disk
+# only once per cv_dir, regardless of how many vocabulary objects are created.
+_CV_CACHE: Dict[str, Dict[str, Any]] = {}
+
 
 class VariableNotFoundError(ValueError):
     """
@@ -72,13 +76,15 @@ class CMIP6Vocabulary:
         self.cmip_table: Dict[str, Any] = self._load_table()
 
     def _load_controlled_vocab(self) -> Dict[str, Any]:
-        vocab = {}
-        for entry in files(self.cv_dir).iterdir():
-            if entry.name.endswith(".json"):
-                with as_file(entry) as path:
-                    with open(path, "r", encoding="utf-8") as jf:
-                        vocab.update(json.load(jf))
-        return vocab
+        if self.cv_dir not in _CV_CACHE:
+            vocab: Dict[str, Any] = {}
+            for entry in files(self.cv_dir).iterdir():
+                if entry.name.endswith(".json"):
+                    with as_file(entry) as path:
+                        with open(path, "r", encoding="utf-8") as jf:
+                            vocab.update(json.load(jf))
+            _CV_CACHE[self.cv_dir] = vocab
+        return _CV_CACHE[self.cv_dir]
 
     def _get_experiment(self) -> Dict[str, Any]:
         try:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -764,68 +764,48 @@ class TestCMIP6CMORiserWrite:
         self, cmoriser_with_dask_dataset, temp_dir, capsys
     ):
         """Test that write() uses chunked writing for Dask arrays."""
-        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
-            mock_mem.return_value = MagicMock(
-                total=32 * 1024**3,
-                available=16 * 1024**3,
-            )
+        cmoriser_with_dask_dataset.write()
 
-            cmoriser_with_dask_dataset.write()
+        captured = capsys.readouterr()
 
-            captured = capsys.readouterr()
-
-            # Should indicate chunked writing
-            assert "Using chunked writing" in captured.out
-            assert "timesteps/chunk" in captured.out
+        # Should indicate chunked writing
+        assert "Using chunked writing" in captured.out
+        assert "timesteps/chunk" in captured.out
 
     @pytest.mark.unit
     def test_write_chunked_creates_valid_file(
         self, cmoriser_with_dask_dataset, temp_dir
     ):
         """Test that chunked write creates a valid NetCDF file."""
-        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
-            mock_mem.return_value = MagicMock(
-                total=32 * 1024**3,
-                available=16 * 1024**3,
-            )
+        cmoriser_with_dask_dataset.write()
 
-            cmoriser_with_dask_dataset.write()
+        output_files = list(Path(temp_dir).glob("*.nc"))
+        assert len(output_files) == 1
 
-            output_files = list(Path(temp_dir).glob("*.nc"))
-            assert len(output_files) == 1
-
-            ds_out = xr.open_dataset(output_files[0])
-            try:
-                assert "tos" in ds_out.data_vars
-                assert ds_out.sizes["time"] == 24  # All timesteps written
-            finally:
-                ds_out.close()
+        ds_out = xr.open_dataset(output_files[0])
+        try:
+            assert "tos" in ds_out.data_vars
+            assert ds_out.sizes["time"] == 24  # All timesteps written
+        finally:
+            ds_out.close()
 
     @pytest.mark.unit
     def test_write_chunked_preserves_data_values(
         self, cmoriser_with_dask_dataset, temp_dir
     ):
         """Test that chunked write preserves data values correctly."""
-        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
-            mock_mem.return_value = MagicMock(
-                total=32 * 1024**3,
-                available=16 * 1024**3,
-            )
+        # Compute original data before write
+        original_data = cmoriser_with_dask_dataset.ds["tos"].values.copy()
 
-            # Compute original data before write
-            original_data = cmoriser_with_dask_dataset.ds["tos"].values.copy()
+        cmoriser_with_dask_dataset.write()
 
-            cmoriser_with_dask_dataset.write()
+        output_files = list(Path(temp_dir).glob("*.nc"))
+        ds_out = xr.open_dataset(output_files[0])
 
-            output_files = list(Path(temp_dir).glob("*.nc"))
-            ds_out = xr.open_dataset(output_files[0])
-
-            try:
-                np.testing.assert_array_almost_equal(
-                    ds_out["tos"].values, original_data
-                )
-            finally:
-                ds_out.close()
+        try:
+            np.testing.assert_array_almost_equal(ds_out["tos"].values, original_data)
+        finally:
+            ds_out.close()
 
     # ==================== System Memory Check Tests ====================
 
@@ -836,7 +816,7 @@ class TestCMIP6CMORiserWrite:
         """
         Test that write() proceeds normally when system memory is sufficient.
 
-        Scenario: No Dask client, plenty of system memory available.
+        Scenario: Non-dask (eager) dataset, plenty of system memory available.
         Expected: File is created successfully.
         """
         with patch("psutil.virtual_memory") as mock_mem:
@@ -846,42 +826,31 @@ class TestCMIP6CMORiserWrite:
                 available=16 * 1024**3,
             )
 
-            with patch(
-                "dask.distributed.get_client", side_effect=ValueError("No client")
-            ):
-                cmoriser_with_dataset.write()
+            cmoriser_with_dataset.write()
 
-                # Verify output file was created
-                output_files = list(Path(temp_dir).glob("*.nc"))
-                assert len(output_files) == 1
+            # Verify output file was created
+            output_files = list(Path(temp_dir).glob("*.nc"))
+            assert len(output_files) == 1
 
     # ==================== Import Error Handling Tests ====================
 
     @pytest.mark.unit
-    def test_write_handles_distributed_not_installed(
+    def test_write_eager_raises_memory_error_when_oom(
         self, cmoriser_with_dataset, temp_dir
     ):
         """
-        Test graceful handling when dask.distributed is not installed.
-
-        Scenario: dask.distributed import raises ImportError.
-        Expected: Falls back to system memory check and proceeds.
+        Test that the eager (non-dask) write path raises MemoryError when the
+        estimated data size exceeds available system memory.
         """
         with patch("psutil.virtual_memory") as mock_mem:
+            # Report only 1 byte available — guaranteed to trigger OOM
             mock_mem.return_value = MagicMock(
                 total=32 * 1024**3,
-                available=16 * 1024**3,
+                available=1,
             )
 
-            # Mock ImportError when trying to import dask.distributed
-            with patch(
-                "dask.distributed.get_client",
-                side_effect=ImportError("No module named 'distributed'"),
-            ):
+            with pytest.raises(MemoryError, match="exceeds available system memory"):
                 cmoriser_with_dataset.write()
-
-                output_files = list(Path(temp_dir).glob("*.nc"))
-                assert len(output_files) == 1
 
     # ==================== Output File Tests ====================
 
@@ -901,24 +870,21 @@ class TestCMIP6CMORiserWrite:
                 available=16 * 1024**3,
             )
 
-            with patch(
-                "dask.distributed.get_client", side_effect=ValueError("No client")
-            ):
-                cmoriser_with_dataset.write()
+            cmoriser_with_dataset.write()
 
-                output_files = list(Path(temp_dir).glob("*.nc"))
-                assert len(output_files) == 1
+            output_files = list(Path(temp_dir).glob("*.nc"))
+            assert len(output_files) == 1
 
-                filename = output_files[0].name
+            filename = output_files[0].name
 
-                # Check filename components
-                assert filename.startswith("tas_")
-                assert "_Amon_" in filename
-                assert "_ACCESS-ESM1-5_" in filename
-                assert "_historical_" in filename
-                assert "_r1i1p1f1_" in filename
-                assert "_gn_" in filename
-                assert filename.endswith(".nc")
+            # Check filename components
+            assert filename.startswith("tas_")
+            assert "_Amon_" in filename
+            assert "_ACCESS-ESM1-5_" in filename
+            assert "_historical_" in filename
+            assert "_r1i1p1f1_" in filename
+            assert "_gn_" in filename
+            assert filename.endswith(".nc")
 
     # ==================== Logging Tests ====================
 
@@ -933,15 +899,12 @@ class TestCMIP6CMORiserWrite:
                 available=16 * 1024**3,
             )
 
-            with patch(
-                "dask.distributed.get_client", side_effect=ValueError("No client")
-            ):
-                cmoriser_with_dataset.write()
+            cmoriser_with_dataset.write()
 
-                captured = capsys.readouterr()
+            captured = capsys.readouterr()
 
-                assert "CMORised output written to" in captured.out
-                assert str(temp_dir) in captured.out
+            assert "CMORised output written to" in captured.out
+            assert str(temp_dir) in captured.out
 
     # ==================== String Coordinate Preparation Tests ====================
 

--- a/tests/unit/test_base_loading_chunker.py
+++ b/tests/unit/test_base_loading_chunker.py
@@ -8,7 +8,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from access_moppy.base import CMORiser, DatasetChunker
+import access_moppy.base as base_module
+from access_moppy.base import CMORiser, DatasetChunker, _get_ureg
 
 
 @pytest.fixture
@@ -217,3 +218,126 @@ def test_rechunk_dataset_method_handles_disabled_and_no_dataset(
     cmoriser.rechunk_dataset()
     captured = capsys.readouterr()
     assert "Chunking is disabled" in captured.out
+
+
+# ==================== _get_ureg singleton ====================
+
+
+@pytest.mark.unit
+def test_get_ureg_initializes_pint_registry_on_first_call(monkeypatch):
+    """When _PINT_REGISTRY is None _get_ureg() creates and caches a UnitRegistry."""
+    monkeypatch.setattr(base_module, "_PINT_REGISTRY", None)
+    ureg = _get_ureg()
+    import pint
+
+    assert isinstance(ureg, pint.UnitRegistry)
+    # Singleton should now be set on the module
+    assert base_module._PINT_REGISTRY is ureg
+
+
+@pytest.mark.unit
+def test_get_ureg_returns_cached_registry_on_subsequent_calls(monkeypatch):
+    """Second call returns the same object without re-creating it."""
+    monkeypatch.setattr(base_module, "_PINT_REGISTRY", None)
+    first = _get_ureg()
+    second = _get_ureg()
+    assert first is second
+
+
+# ==================== DatasetChunker — coordinate rechunking ====================
+
+
+@pytest.mark.unit
+def test_dataset_chunker_rechunk_dataset_splits_coords_and_data_vars():
+    """Dask coordinates must land in rechunked_coords, data vars in rechunked_data_vars."""
+    chunker = DatasetChunker(target_chunk_size_mb=0.000001)
+
+    data = da.from_array(np.ones((6, 4), dtype=np.float32), chunks=(2, 4))
+    time_coord = da.from_array(np.arange(6, dtype=np.float64), chunks=(6,))
+
+    ds = xr.Dataset(
+        {"tas": xr.DataArray(data, dims=("time", "x"))},
+        coords={"time": xr.DataArray(time_coord, dims=("time",))},
+    )
+
+    out = chunker.rechunk_dataset(ds)
+
+    assert "time" in out.coords
+    assert "tas" in out.data_vars
+
+
+# ==================== CMORiser._are_units_equivalent ====================
+
+
+@pytest.mark.unit
+def test_are_units_equivalent_identical_units(mock_vocab, mock_mapping, temp_dir):
+    """Same units are always equivalent."""
+    cmoriser = CMORiser(
+        input_data=xr.Dataset({"tas": xr.DataArray(np.ones((2,)), dims=("time",))}),
+        output_path=str(temp_dir),
+        vocab=mock_vocab,
+        variable_mapping=mock_mapping,
+        compound_name="Amon.tas",
+        enable_chunking=False,
+    )
+    assert cmoriser._are_units_equivalent("K", "kelvin") is True
+
+
+@pytest.mark.unit
+def test_are_units_equivalent_incompatible_units(mock_vocab, mock_mapping, temp_dir):
+    """Dimensionally different units are not equivalent."""
+    cmoriser = CMORiser(
+        input_data=xr.Dataset({"tas": xr.DataArray(np.ones((2,)), dims=("time",))}),
+        output_path=str(temp_dir),
+        vocab=mock_vocab,
+        variable_mapping=mock_mapping,
+        compound_name="Amon.tas",
+        enable_chunking=False,
+    )
+    assert cmoriser._are_units_equivalent("K", "m/s") is False
+
+
+# ==================== CMORiser._check_range with dask ====================
+
+
+@pytest.mark.unit
+def test_check_range_dask_raises_for_out_of_range_values(
+    mock_vocab, mock_mapping, temp_dir
+):
+    """_check_range fused-compute path raises ValueError when values are out of range."""
+    data = da.from_array(np.array([1.0, 2.0, 300.0]), chunks=(3,))
+    ds = xr.Dataset({"tas": xr.DataArray(data, dims=("time",))})
+
+    cmoriser = CMORiser(
+        input_data=ds,
+        output_path=str(temp_dir),
+        vocab=mock_vocab,
+        variable_mapping=mock_mapping,
+        compound_name="Amon.tas",
+        enable_chunking=False,
+    )
+    cmoriser.ds = ds
+
+    with pytest.raises(ValueError, match="above valid_max"):
+        cmoriser._check_range("tas", vmin=0.0, vmax=100.0)
+
+
+@pytest.mark.unit
+def test_check_range_dask_passes_for_in_range_values(
+    mock_vocab, mock_mapping, temp_dir
+):
+    """_check_range fused-compute path does not raise when all values are in range."""
+    data = da.from_array(np.array([10.0, 20.0, 30.0]), chunks=(3,))
+    ds = xr.Dataset({"tas": xr.DataArray(data, dims=("time",))})
+
+    cmoriser = CMORiser(
+        input_data=ds,
+        output_path=str(temp_dir),
+        vocab=mock_vocab,
+        variable_mapping=mock_mapping,
+        compound_name="Amon.tas",
+        enable_chunking=False,
+    )
+    cmoriser.ds = ds
+
+    cmoriser._check_range("tas", vmin=0.0, vmax=100.0)  # Should not raise

--- a/tests/unit/test_supergrid.py
+++ b/tests/unit/test_supergrid.py
@@ -100,6 +100,7 @@ class TestSupergrid:
     def test_load_supergrid_creates_cell_arrays(self, supergrid_instance, cell_type):
         """Test that load_supergrid creates all cell type arrays with correct structure."""
         sg = supergrid_instance
+        sg._compute_grid()
 
         # Check centres exist
         assert hasattr(sg, f"{cell_type}_centres_x")
@@ -115,6 +116,7 @@ class TestSupergrid:
     def test_load_supergrid_cell_dimensions_relationship(self, supergrid_instance):
         """Test that q-cell has one more point than h-cell in each direction."""
         sg = supergrid_instance
+        sg._compute_grid()
 
         h_shape = sg.hcell_centres_x.shape
         q_shape = sg.qcell_centres_x.shape

--- a/tests/unit/test_utilities_mappings.py
+++ b/tests/unit/test_utilities_mappings.py
@@ -77,7 +77,7 @@ def test_load_model_mappings_component_organised_structure():
     }
     mock_entry = _make_mock_entry("MY-MODEL_mappings.json", mapping_content)
     mock_dir = MagicMock()
-    mock_dir.iterdir.return_value = [mock_entry]
+    mock_dir.__truediv__.return_value = mock_entry
 
     with patch("access_moppy.utilities.files", return_value=mock_dir):
         result = load_model_mappings("Amon.tas", model_id="MY-MODEL")
@@ -93,7 +93,7 @@ def test_load_model_mappings_flat_variables_fallback():
     }
     mock_entry = _make_mock_entry("MY-MODEL_mappings.json", mapping_content)
     mock_dir = MagicMock()
-    mock_dir.iterdir.return_value = [mock_entry]
+    mock_dir.__truediv__.return_value = mock_entry
 
     with patch("access_moppy.utilities.files", return_value=mock_dir):
         result = load_model_mappings("Amon.tas", model_id="MY-MODEL")
@@ -107,7 +107,7 @@ def test_load_model_mappings_variable_absent_in_found_file_returns_empty():
     mapping_content = {"atmosphere": {"pr": {"model_variables": ["precip"]}}}
     mock_entry = _make_mock_entry("MY-MODEL_mappings.json", mapping_content)
     mock_dir = MagicMock()
-    mock_dir.iterdir.return_value = [mock_entry]
+    mock_dir.__truediv__.return_value = mock_entry
 
     with patch("access_moppy.utilities.files", return_value=mock_dir):
         result = load_model_mappings("Amon.tas", model_id="MY-MODEL")


### PR DESCRIPTION
## Summary

This PR bundles a series of targeted fixes improving performance, correctness, and resource-management across the codebase.

## Changes

- **fix: optimize frequency validation in CMORiser** — reuse dataset probe to prevent file-handle leaks
- **fix: remove redundant target frequency parsing** in `validate_cmip6_frequency_compatibility`
- **fix: streamline CMORiser `write` method** — remove redundant memory checks and simplify chunked writing logic
- **fix: enhance dataset rechunking** — separate coordinates and data variables for better metadata preservation
- **fix: optimize file loading in CMIP7 and vocabulary processors** — improved performance
- **fix: implement singleton pattern for `pint` `UnitRegistry`** — avoid repeated instantiation and improve performance
- **fix: improve NaN condition checks** — use `np.isclose` for better floating-point precision
- **fix: optimize range checking in `_check_range`** — fuse compute calls
- **fix: optimize time coordinate computation** in `calculate_time_bounds`
- **fix: optimize supergrid loading and computation** for lazy evaluation
- **fix: improve handling of `cftime` objects** and optimize decoded time variable caching
