### PR TITLE
Replace print() with logging throughout the codebase

### DIFF
--- a/src/access_moppy/__init__.py
+++ b/src/access_moppy/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from . import _version
 from ._config import _creator
 from .driver import ACCESS_ESM_CMORiser
@@ -5,11 +7,37 @@ from .utilities import check_for_updates
 
 __version__ = _version.get_versions()["version"]
 
-# Print the configuration information
-print("\nLoaded Configuration:")
-print(f"Creator Name: {_creator.creator_name}")
-print(f"Organisation: {_creator.organisation}")
-print(f"Creator Email: {_creator.creator_email}")
-print(f"Creator URL: {_creator.creator_url}")
+# Add a NullHandler so library logs are silent unless the caller configures logging.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+
+def _is_jupyter() -> bool:
+    """Return True when running inside a Jupyter kernel."""
+    try:
+        from IPython import get_ipython
+
+        ip = get_ipython()
+        return ip is not None and "IPKernelApp" in ip.config
+    except Exception:
+        return False
+
+
+if _is_jupyter():
+    # In notebooks, show DEBUG and above on stderr so progress messages are
+    # visible without any extra configuration by the user.
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    _pkg_logger = logging.getLogger(__name__)
+    _pkg_logger.setLevel(logging.DEBUG)
+    _pkg_logger.addHandler(_handler)
+
+_logger = logging.getLogger(__name__)
+
+# Log the configuration information
+_logger.debug("Loaded Configuration:")
+_logger.debug("Creator Name: %s", _creator.creator_name)
+_logger.debug("Organisation: %s", _creator.organisation)
+_logger.debug("Creator Email: %s", _creator.creator_email)
+_logger.debug("Creator URL: %s", _creator.creator_url)
 
 check_for_updates()

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 from datetime import datetime
 from pathlib import Path
@@ -23,6 +24,8 @@ from access_moppy.utilities import (
 # Module-level pint registry singleton — constructing UnitRegistry is O(100 ms)
 # so it must never be called inside a per-variable loop.
 _PINT_REGISTRY = None
+
+logger = logging.getLogger(__name__)
 
 
 def _get_ureg():
@@ -117,13 +120,16 @@ class DatasetChunker:
         if not hasattr(ds, "chunks") or not any(
             ds.chunks.values() if ds.chunks else []
         ):
-            print("Dataset is not chunked, skipping rechunking")
+            logger.debug("Dataset is not chunked, skipping rechunking")
             return ds
 
-        print("🔧 Applying dataset rechunking with rules:")
-        print("  - Time coordinates: single chunk")
-        print("  - Time bounds: single chunk")
-        print(f"  - Data variables: at least {self.target_chunk_size_mb}MB chunks")
+        logger.debug(
+            "Applying dataset rechunking with rules: "
+            "time coordinates=single chunk, "
+            "time bounds=single chunk, "
+            "data variables=at least %sMB chunks",
+            self.target_chunk_size_mb,
+        )
 
         rechunked_coords = {}
         rechunked_data_vars = {}
@@ -135,7 +141,7 @@ class DatasetChunker:
             if var_name.endswith("_bnds") or var_name.endswith("_bounds"):
                 # Time bounds: single chunk for all dimensions
                 chunks = {dim: var.sizes[dim] for dim in var.dims}
-                print(f"  {var_name}: time bounds → single chunk")
+                logger.debug("  %s: time bounds -> single chunk", var_name)
 
             elif (
                 var_name
@@ -155,7 +161,7 @@ class DatasetChunker:
                 # Coordinate variables and scalars: single chunk
                 chunks = {dim: var.sizes[dim] for dim in var.dims}
                 if var.dims:
-                    print(f"  {var_name}: coordinate → single chunk")
+                    logger.debug("  %s: coordinate -> single chunk", var_name)
 
             else:
                 # Data variables: calculate 4MB chunks
@@ -163,12 +169,12 @@ class DatasetChunker:
                 chunk_info = ", ".join(
                     [f"{dim}:{size}" for dim, size in chunks.items()]
                 )
-                print(f"  {var_name}: data variable → {chunk_info}")
+                logger.debug("  %s: data variable -> %s", var_name, chunk_info)
 
             try:
                 rechunked_var = var.chunk(chunks)
             except Exception as e:
-                print(f"Warning: Could not rechunk variable '{var_name}': {e}")
+                logger.warning("Could not rechunk variable '%s': %s", var_name, e)
                 rechunked_var = var
 
             if var_name in ds.coords:
@@ -179,7 +185,7 @@ class DatasetChunker:
         # Use assign_coords + assign to preserve all dataset metadata
         # (coordinate attributes, encoding, and dataset structure)
         rechunked_ds = ds.assign_coords(rechunked_coords).assign(rechunked_data_vars)
-        print("✅ Dataset rechunking completed")
+        logger.debug("Dataset rechunking completed")
 
         return rechunked_ds
 
@@ -330,8 +336,10 @@ class CMORiser:
 
                 if coords_to_drop:
                     self.ds = self.ds.drop_vars(coords_to_drop)
-                    print(
-                        f"✓ Dropped {len(coords_to_drop)} unused coordinate(s): {coords_to_drop}"
+                    logger.debug(
+                        "Dropped %d unused coordinate(s): %s",
+                        len(coords_to_drop),
+                        coords_to_drop,
                     )
 
         else:
@@ -370,8 +378,8 @@ class CMORiser:
                 ) or "time" not in _probe_dims
 
                 if is_time_independent:
-                    print(
-                        "✓ Skipping frequency validation for time-independent variable"
+                    logger.debug(
+                        "Skipping frequency validation for time-independent variable"
                     )
                 else:
                     try:
@@ -390,16 +398,18 @@ class CMORiser:
                                 )
                             )
                             if resampling_required:
-                                print(
-                                    f"✓ Temporal resampling will be applied: {detected_freq} → CMIP6 target frequency"
+                                logger.debug(
+                                    "Temporal resampling will be applied: %s -> CMIP6 target frequency",
+                                    detected_freq,
                                 )
                             else:
-                                print(
-                                    f"✓ Validated compatible temporal frequency: {detected_freq}"
+                                logger.debug(
+                                    "Validated compatible temporal frequency: %s",
+                                    detected_freq,
                                 )
                         else:
-                            print(
-                                "✓ Skipping detailed frequency validation for this CMIP version"
+                            logger.debug(
+                                "Skipping detailed frequency validation for this CMIP version"
                             )
                     except (FrequencyMismatchError, IncompatibleFrequencyError) as e:
                         raise e  # Re-raise these specific errors as-is
@@ -440,8 +450,8 @@ class CMORiser:
         # Apply temporal resampling if enabled and needed
         if self.enable_resampling and self.compound_name:
             try:
-                print(
-                    f"🔍 Checking if temporal resampling is needed for {self.cmor_name}..."
+                logger.debug(
+                    "Checking if temporal resampling is needed for %s", self.cmor_name
                 )
 
                 self.ds, was_resampled = validate_and_resample_if_needed(
@@ -453,9 +463,11 @@ class CMORiser:
                 )
 
                 if was_resampled:
-                    print("✅ Applied temporal resampling to match CMIP requirements")
+                    logger.debug(
+                        "Applied temporal resampling to match CMIP requirements"
+                    )
                 else:
-                    print("✅ No resampling needed - frequency already compatible")
+                    logger.debug("No resampling needed - frequency already compatible")
 
             except (FrequencyMismatchError, IncompatibleFrequencyError) as e:
                 raise e  # Re-raise validation errors
@@ -470,9 +482,9 @@ class CMORiser:
 
         # Apply intelligent rechunking if enabled
         if self.enable_chunking and self.chunker:
-            print("🔧 Applying intelligent dataset rechunking...")
+            logger.debug("Applying intelligent dataset rechunking...")
             self.ds = self.chunker.rechunk_dataset(self.ds)
-            print("✅ Dataset rechunking completed")
+            logger.debug("Dataset rechunking completed")
 
         # Normalize missing values to NaN early for consistent processing
         self._normalize_missing_values_early()
@@ -535,8 +547,11 @@ class CMORiser:
                         # Replace coordinate with numeric values, preserving attributes
                         ds[coord_name] = (coord.dims, numeric_values, new_attrs)
 
-                        print(
-                            f"✓ Converted '{coord_name}' from cftime to numeric ({units}, {calendar})"
+                        logger.debug(
+                            "Converted '%s' from cftime to numeric (%s, %s)",
+                            coord_name,
+                            units,
+                            calendar,
                         )
 
                     except Exception as e:
@@ -562,16 +577,16 @@ class CMORiser:
         is needed at a different stage in the processing pipeline.
         """
         if self.enable_chunking and self.chunker and self.ds is not None:
-            print("🔧 Applying dataset rechunking...")
+            logger.debug("Applying dataset rechunking...")
             self.ds = self.chunker.rechunk_dataset(self.ds)
-            print("✅ Dataset rechunking completed")
+            logger.debug("Dataset rechunking completed")
         else:
             if not self.enable_chunking:
-                print("Chunking is disabled, skipping rechunking")
+                logger.debug("Chunking is disabled, skipping rechunking")
             elif not self.chunker:
-                print("No chunker available, skipping rechunking")
+                logger.debug("No chunker available, skipping rechunking")
             else:
-                print("No dataset loaded, cannot rechunk")
+                logger.debug("No dataset loaded, cannot rechunk")
 
     def select_and_process_variables(self):
         raise NotImplementedError(
@@ -712,18 +727,22 @@ class CMORiser:
         try:
             from access_moppy.vocabulary_processors import CMIP6Vocabulary
 
-            print("🔧 Normalizing missing values to NaN for consistent processing...")
+            logger.debug(
+                "Normalizing missing values to NaN for consistent processing..."
+            )
 
             # Use the static method to normalize the entire dataset
             self.ds = CMIP6Vocabulary.normalize_dataset_missing_values(self.ds)
 
-            print(
-                "✅ Missing values normalized to NaN - XArray will handle propagation correctly"
+            logger.debug(
+                "Missing values normalized to NaN - XArray will handle propagation correctly"
             )
         except ImportError:
-            print("⚠️  Could not import CMIP6Vocabulary for missing value normalization")
+            logger.warning(
+                "Could not import CMIP6Vocabulary for missing value normalization"
+            )
         except Exception as e:
-            print(f"⚠️  Warning: Could not normalize missing values early: {e}")
+            logger.warning("Could not normalize missing values early: %s", e)
 
     def standardize_missing_values(self):
         """
@@ -743,8 +762,9 @@ class CMORiser:
             and self.vocab
             and self.cmor_name in self.ds.data_vars
         ):
-            print(
-                f"🔧 Applying final CMIP6 missing value standardization for {self.cmor_name}..."
+            logger.debug(
+                "Applying final CMIP6 missing value standardization for %s",
+                self.cmor_name,
             )
 
             # Get the main data variable
@@ -762,10 +782,11 @@ class CMORiser:
 
             # Report the standardization
             missing_value = self.vocab.get_cmip_missing_value()
-            print(f"✅ Final CMIP6 missing value applied: {missing_value}")
+            logger.debug("Final CMIP6 missing value applied: %s", missing_value)
         else:
-            print(
-                f"⚠️  Cannot standardize missing values for {self.cmor_name}: vocabulary not available"
+            logger.warning(
+                "Cannot standardize missing values for %s: vocabulary not available",
+                self.cmor_name,
             )
 
     def update_attributes(self):
@@ -809,7 +830,7 @@ class CMORiser:
                 latest_link.unlink()
             latest_link.symlink_to(versioned_path.name, target_is_directory=True)
         except Exception as e:
-            print(f"Warning: Failed to update latest symlink at {latest_link}: {e}")
+            logger.warning("Failed to update latest symlink at %s: %s", latest_link, e)
 
     def write(self):
         """
@@ -857,9 +878,10 @@ class CMORiser:
 
         missing = [k for k in required_keys if k not in attrs]
         if missing:
-            print(f"⚠️  Warning: Missing required global attributes: {missing}")
-            print(
-                "   Some attributes may be required for CMIP compliance but file will still be written."
+            logger.warning(
+                "Missing required global attributes: %s. "
+                "Some attributes may be required for CMIP compliance but file will still be written.",
+                missing,
             )
 
         # ========== Chunked vs Eager Write Decision ==========
@@ -871,7 +893,7 @@ class CMORiser:
         use_chunked_write = is_dask_array and self.chunker is not None
 
         if use_chunked_write:
-            print("📦 Using chunked writing with DatasetChunker")
+            logger.debug("Using chunked writing with DatasetChunker")
         else:
             # Eager write: estimate size and guard against OOM before starting.
             def estimate_data_size(ds):
@@ -893,8 +915,10 @@ class CMORiser:
                     f"({available_memory / 1024**3:.2f} GB). "
                     f"Enable chunking or reduce dataset size."
                 )
-            print(
-                f"Data size: {data_size / 1024**3:.2f} GB, Available memory: {available_memory / 1024**3:.2f} GB"
+            logger.debug(
+                "Data size: %.2f GB, Available memory: %.2f GB",
+                data_size / 1024**3,
+                available_memory / 1024**3,
             )
 
         # Generate filename using vocabulary-specific logic
@@ -1046,8 +1070,10 @@ class CMORiser:
                                     new_coords = " ".join(coords_to_add)
 
                                 v.setncattr("coordinates", new_coords)
-                                print(
-                                    f"  Added coordinates attribute to '{var}': '{new_coords}'"
+                                logger.debug(
+                                    "  Added coordinates attribute to '%s': '%s'",
+                                    var,
+                                    new_coords,
                                 )
 
                     created_vars[var] = v
@@ -1079,7 +1105,9 @@ class CMORiser:
                         total_timesteps = self.ds.sizes["time"]
                         time_idx = vdat.dims.index("time")
 
-                        print(f"  Writing {var} ({time_chunk} timesteps/chunk)...")
+                        logger.debug(
+                            "  Writing %s (%d timesteps/chunk)...", var, time_chunk
+                        )
 
                         for t_start in range(0, total_timesteps, time_chunk):
                             t_end = min(t_start + time_chunk, total_timesteps)
@@ -1093,7 +1121,9 @@ class CMORiser:
 
                             created_vars[var][tuple(slices)] = chunk_data
 
-                        print(f"    ✓ {var}: {total_timesteps} timesteps written")
+                        logger.debug(
+                            "    %s: %d timesteps written", var, total_timesteps
+                        )
                     else:
                         # Direct write for small/non-Dask/non-time variables
                         # Encode decoded time back to numeric float64 for netCDF4
@@ -1129,18 +1159,19 @@ class CMORiser:
                         else:
                             created_vars[var][:] = vdat.values
 
-        print(f"CMORised output written to {path}")
-        print("📁 Optimized layout: metadata → data chunks")
+        logger.info("CMORised output written to %s", path)
+        logger.debug("Optimized layout: metadata -> data chunks")
         if self.enable_compression:
-            print(
-                f"🗜️ HDF5 compression: shuffle + zlib(level {self.compression_level}) + fletcher32 for data variables"
+            logger.debug(
+                "HDF5 compression: shuffle + zlib(level %d) + fletcher32 for data variables",
+                self.compression_level,
             )
         else:
-            print("🗜️ Compression disabled")
+            logger.debug("Compression disabled")
 
         if string_coords_info:
-            print(
-                f"🔤 String coordinates processed: {', '.join(string_coords_info.keys())}"
+            logger.debug(
+                "String coordinates processed: %s", ", ".join(string_coords_info.keys())
             )
 
     def _prepare_string_coordinates(self):
@@ -1227,8 +1258,12 @@ class CMORiser:
 
                 string_coords_info[coord_name] = info
 
-                print(
-                    f"🔤 Detected string coordinate '{coord_name}': max_len={max_len}, shape={coord.shape}, dims={coord.dims}"
+                logger.debug(
+                    "Detected string coordinate '%s': max_len=%d, shape=%s, dims=%s",
+                    coord_name,
+                    max_len,
+                    coord.shape,
+                    coord.dims,
                 )
 
         return string_coords_info
@@ -1270,7 +1305,7 @@ class CMORiser:
             if attr_name != "_FillValue":
                 v.setncattr(attr_name, attr_val)
 
-        print(f"  Created string variable '{var_name}' with dims: {dims}")
+        logger.debug("  Created string variable '%s' with dims: %s", var_name, dims)
 
         return v
 
@@ -1338,7 +1373,7 @@ class CMORiser:
 
             nc_var[:] = char_array
 
-        print(f"  Written string data for '{nc_var.name}'")
+        logger.debug("  Written string data for '%s'", nc_var.name)
 
     def run(self, write_output: bool = False):
         self.select_and_process_variables()

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -67,11 +67,11 @@ def _get_cmip7_to_cmip6_mapping(cmip7_compound_name: str) -> Optional[str]:
             cmip7_to_cmip6_mapping = json.loads(entry.read_text(encoding="utf-8"))
 
         if not cmip7_to_cmip6_mapping:
-            print(f"❌ CMIP7 to CMIP6 mapping file '{mapping_file}' not found")
+            logger.warning("CMIP7 to CMIP6 mapping file '%s' not found", mapping_file)
             return None
 
     except Exception as e:
-        print(f"❌ Error loading CMIP7 to CMIP6 mapping: {e}")
+        logger.warning("Error loading CMIP7 to CMIP6 mapping: %s", e)
         return None
 
     # Check for exact match first (case insensitive)
@@ -90,21 +90,23 @@ def _get_cmip7_to_cmip6_mapping(cmip7_compound_name: str) -> Optional[str]:
             ]
 
             if len(matches) == 0:
-                print(
-                    f"❌ No CMIP7 variables found matching pattern '{cmip7_compound_name}'"
+                logger.warning(
+                    "No CMIP7 variables found matching pattern '%s'",
+                    cmip7_compound_name,
                 )
                 return None
             elif len(matches) == 1:
                 return cmip7_to_cmip6_mapping[matches[0]]
             else:
-                print(f"⚠️  Pattern '{cmip7_compound_name}' matches multiple variables:")
-                for match in sorted(matches):
-                    print(f"  - {match}")
-                print("Please specify one exactly.")
+                logger.warning(
+                    "Pattern '%s' matches multiple variables: %s. Please specify one exactly.",
+                    cmip7_compound_name,
+                    sorted(matches),
+                )
                 return None
 
         except re.error as e:
-            print(f"❌ Invalid regex pattern '{cmip7_compound_name}': {e}")
+            logger.warning("Invalid regex pattern '%s': %s", cmip7_compound_name, e)
             return None
 
     # Not found
@@ -723,8 +725,10 @@ def _detect_frequency_from_concatenated_files(
 
     # For very large numbers of files, sample a subset for frequency detection
     if len(file_paths) > max_sample_files:
-        print(
-            f"🚀 Sampling {max_sample_files} files from {len(file_paths)} total for efficient frequency detection"
+        logger.debug(
+            "Sampling %d files from %d total for efficient frequency detection",
+            max_sample_files,
+            len(file_paths),
         )
         # Sample files from beginning, middle, and end to get representative coverage
         sample_indices = list(range(0, min(max_sample_files // 3, len(file_paths))))
@@ -748,8 +752,8 @@ def _detect_frequency_from_concatenated_files(
         sampled_files = file_paths
 
     try:
-        print(
-            f"📂 Opening {len(sampled_files)} files with xarray multi-file dataset..."
+        logger.debug(
+            "Opening %d files with xarray multi-file dataset...", len(sampled_files)
         )
 
         # Use xr.open_mfdataset for efficient concatenation
@@ -775,7 +779,7 @@ def _detect_frequency_from_concatenated_files(
                     "Could not detect frequency from concatenated time coordinate"
                 )
 
-            print(f"⚡ Efficiently detected frequency: {detected_freq}")
+            logger.debug("Efficiently detected frequency: %s", detected_freq)
             return detected_freq
 
     except Exception as e:
@@ -800,7 +804,7 @@ def _detect_frequency_from_individual_files(
     frequencies = []
     file_info = []
 
-    print(f"📁 Analyzing {len(file_paths)} files individually...")
+    logger.debug("Analyzing %d files individually...", len(file_paths))
 
     # Detect frequency from each file
     for file_path in file_paths:
@@ -825,7 +829,7 @@ def _detect_frequency_from_individual_files(
     freq_counts = Counter(frequencies)
     detected_freq = freq_counts.most_common(1)[0][0]
 
-    print(f"📊 Detected frequency from individual files: {detected_freq}")
+    logger.debug("Detected frequency from individual files: %s", detected_freq)
     return detected_freq
 
 
@@ -856,15 +860,17 @@ def _validate_monthly_compatibility(
 
         if not (monthly_min <= freq_seconds <= monthly_max):
             # If concatenated detection doesn't give monthly range, validate individual files
-            print(
-                f"⚠️  Concatenated frequency ({detected_freq}) not in monthly range, validating individual files..."
+            logger.debug(
+                "Concatenated frequency (%s) not in monthly range, validating individual files...",
+                detected_freq,
             )
             return _validate_monthly_files_individually(
                 file_paths, time_coord, allow_submonthly=allow_submonthly
             )
 
-        print(
-            f"📅 Validated monthly data with calendar variations (detected: {detected_freq})"
+        logger.debug(
+            "Validated monthly data with calendar variations (detected: %s)",
+            detected_freq,
         )
         return detected_freq
 
@@ -919,8 +925,8 @@ def _validate_monthly_files_individually(
         if allow_submonthly and all(
             freq.total_seconds() < monthly_min for _, freq in non_monthly_files
         ):
-            print(
-                "📆 Sub-monthly input detected - valid for monthly aggregation (tasmax/tasmin)"
+            logger.debug(
+                "Sub-monthly input detected - valid for monthly aggregation (tasmax/tasmin)"
             )
         else:
             error_msg = "Files do not appear to be monthly data:\n"
@@ -937,11 +943,11 @@ def _validate_monthly_files_individually(
     freq_counts = Counter(frequencies)
     representative_freq = freq_counts.most_common(1)[0][0]
 
-    print(f"📅 Validated {len(file_info)} monthly files with calendar variations:")
+    logger.debug("Validated %d monthly files with calendar variations:", len(file_info))
     for file_path, freq in file_info:
         days = freq.total_seconds() / 86400
-        print(f"   • {file_path}: {days:.0f} days")
-    print(f"📏 Representative monthly frequency: {representative_freq}")
+        logger.debug("   %s: %.0f days", file_path, days)
+    logger.debug("Representative monthly frequency: %s", representative_freq)
 
     return representative_freq
 
@@ -996,16 +1002,18 @@ def validate_cmip6_frequency_compatibility(
     # Check if this is monthly data
     if _is_monthly_target(compound_name):
         # Use monthly-aware validation that allows calendar variations
-        print(
-            f"🗓️  Monthly CMIP6 table detected ({compound_name}) - using calendar-aware validation"
+        logger.debug(
+            "Monthly CMIP6 table detected (%s) - using calendar-aware validation",
+            compound_name,
         )
         detected_freq = _validate_monthly_compatibility(
             file_paths, time_coord, allow_submonthly=allow_submonthly
         )
     else:
         # Use standard strict frequency validation for non-monthly data
-        print(
-            f"⏰ Non-monthly CMIP6 table ({compound_name}) - using strict frequency validation"
+        logger.debug(
+            "Non-monthly CMIP6 table (%s) - using strict frequency validation",
+            compound_name,
         )
         detected_freq = validate_consistent_frequency(
             file_paths, time_coord, tolerance_seconds
@@ -1034,8 +1042,8 @@ def validate_cmip6_frequency_compatibility(
         # For monthly CMIP6 tables, calendar month variations (28-31 days) are natural
         # and do not require resampling - the data is already at the correct temporal resolution
         resampling_required = False
-        print(
-            "📅 Monthly data detected - no resampling required (calendar variations are natural)"
+        logger.debug(
+            "Monthly data detected - no resampling required (calendar variations are natural)"
         )
     else:
         # For non-monthly data, use standard frequency comparison with 1% tolerance
@@ -1055,7 +1063,7 @@ def validate_cmip6_frequency_compatibility(
         )
 
         if interactive:
-            print(message)
+            logger.warning("%s", message)
             response = (
                 input("Do you want to continue with temporal resampling? [y/N]: ")
                 .strip()
@@ -1066,7 +1074,7 @@ def validate_cmip6_frequency_compatibility(
                     "CMORisation aborted by user due to temporal resampling requirement. "
                     "To proceed non-interactively, set interactive=False or validate_frequency=False."
                 )
-            print("✓ Proceeding with temporal resampling...")
+            logger.debug("Proceeding with temporal resampling...")
         else:
             # Non-interactive mode - just warn
             warnings.warn(message, ResamplingRequiredWarning, stacklevel=2)
@@ -1230,13 +1238,13 @@ def detect_time_frequency_lazy(
     # Method 1: Try to detect frequency from ACCESS model metadata (highest priority)
     access_freq = _detect_frequency_from_access_metadata(ds)
     if access_freq is not None:
-        print(f"🏷️  Detected frequency from ACCESS metadata: {access_freq}")
+        logger.debug("Detected frequency from ACCESS metadata: %s", access_freq)
         return access_freq
 
     # Method 2: Try to detect frequency from time bounds (CF-compliant approach)
     bounds_freq = _detect_frequency_from_bounds(ds, time_coord)
     if bounds_freq is not None:
-        print(f"🎯 Detected frequency from time bounds: {bounds_freq}")
+        logger.debug("Detected frequency from time bounds: %s", bounds_freq)
         return bounds_freq
 
     # Method 3: Fallback to time coordinate differences
@@ -1253,7 +1261,9 @@ def detect_time_frequency_lazy(
         )
         return None
 
-    print("📊 Detecting frequency from time coordinate differences (fallback method)")
+    logger.debug(
+        "Detecting frequency from time coordinate differences (fallback method)"
+    )
 
     # Sample first few time points (max 10 to keep it lightweight)
     n_sample = min(10, time_var.size)
@@ -1562,8 +1572,9 @@ def validate_consistent_frequency(
             # For non-monthly data or when detailed validation is needed,
             # we might still want to validate individual files for consistency
             if tolerance_seconds is not None:
-                print(
-                    f"🔍 Performing detailed consistency validation with tolerance {tolerance_seconds}s"
+                logger.debug(
+                    "Performing detailed consistency validation with tolerance %ds",
+                    tolerance_seconds,
                 )
                 return _validate_frequency_consistency_detailed(
                     file_paths, time_coord, tolerance_seconds, detected_freq
@@ -1574,14 +1585,15 @@ def validate_consistent_frequency(
 
             # For monthly data with large tolerance, concatenation result is likely sufficient
             if auto_tolerance >= 86400:  # >= 1 day tolerance (monthly data)
-                print(
-                    f"📅 Large tolerance detected ({auto_tolerance / 86400:.1f} days) - concatenated frequency sufficient"
+                logger.debug(
+                    "Large tolerance detected (%.1f days) - concatenated frequency sufficient",
+                    auto_tolerance / 86400,
                 )
                 return detected_freq
 
             # For sub-daily data with tight tolerance, do detailed validation
-            print(
-                f"🔍 Small tolerance ({auto_tolerance}s) - performing detailed validation"
+            logger.debug(
+                "Small tolerance (%ds) - performing detailed validation", auto_tolerance
             )
             return _validate_frequency_consistency_detailed(
                 file_paths, time_coord, auto_tolerance, detected_freq
@@ -1611,7 +1623,9 @@ def _validate_frequency_consistency_detailed(
     frequencies = []
     file_info = []
 
-    print(f"📁 Performing detailed frequency validation on {len(file_paths)} files...")
+    logger.debug(
+        "Performing detailed frequency validation on %d files...", len(file_paths)
+    )
 
     for file_path in file_paths:
         try:
@@ -1638,8 +1652,11 @@ def _validate_frequency_consistency_detailed(
     # Auto-determine tolerance if not provided
     if tolerance_seconds is None:
         tolerance_seconds = _determine_smart_tolerance(base_freq)
-        print(
-            f"📏 Auto-determined tolerance: {tolerance_seconds / 86400:.1f} days ({tolerance_seconds:.0f}s) for frequency ~{base_freq}"
+        logger.debug(
+            "Auto-determined tolerance: %.1f days (%ds) for frequency ~%s",
+            tolerance_seconds / 86400,
+            tolerance_seconds,
+            base_freq,
         )
 
     inconsistent_files = []
@@ -1673,7 +1690,9 @@ def _validate_frequency_consistency_detailed(
 
         raise FrequencyMismatchError(error_msg)
 
-    print(f"✅ Validated {len(file_info)} files with consistent frequency: {base_freq}")
+    logger.debug(
+        "Validated %d files with consistent frequency: %s", len(file_info), base_freq
+    )
     return base_freq
 
 
@@ -1835,7 +1854,9 @@ def resample_dataset_temporal(
     # Convert target frequency to resampling string
     freq_str = get_resampling_frequency_string(target_freq)
 
-    print(f"📊 Resampling dataset to {target_freq} using frequency string '{freq_str}'")
+    logger.debug(
+        "Resampling dataset to %s using frequency string '%s'", target_freq, freq_str
+    )
 
     # Use resample approach (more robust than groupby_bins)
     try:
@@ -1861,7 +1882,9 @@ def resample_dataset_temporal(
             else:
                 var_method = method
 
-            print(f"  • Variable '{var_name}': using '{var_method}' aggregation")
+            logger.debug(
+                "  Variable '%s': using '%s' aggregation", var_name, var_method
+            )
 
             # Create resampler for this specific variable
             var_resampler = ds_decoded[var_name].resample({time_coord: freq_str})
@@ -1913,8 +1936,10 @@ def resample_dataset_temporal(
             else:
                 ds_resampled[var_name].attrs["cell_methods"] = new_cell_method
 
-        print(
-            f"✓ Successfully resampled dataset from {len(ds[time_coord])} to {len(ds_resampled[time_coord])} time steps"
+        logger.debug(
+            "Successfully resampled dataset from %d to %d time steps",
+            len(ds[time_coord]),
+            len(ds_resampled[time_coord]),
         )
 
         return ds_resampled
@@ -1969,21 +1994,25 @@ def validate_and_resample_if_needed(
 
     if input_is_monthly and target_is_monthly:
         # Both are monthly - no resampling needed (calendar variations are natural)
-        print(
-            f"✓ Both frequencies are monthly (input: {detected_freq}, target: {target_freq}) - no resampling required"
+        logger.debug(
+            "Both frequencies are monthly (input: %s, target: %s) - no resampling required",
+            detected_freq,
+            target_freq,
         )
         return ds, False
 
     # Allow small tolerance for exact matches
     tolerance = 0.01
     if abs(input_seconds - target_seconds) / target_seconds < tolerance:
-        print(
-            f"✓ Dataset frequency ({detected_freq}) matches target frequency ({target_freq})"
+        logger.debug(
+            "Dataset frequency (%s) matches target frequency (%s)",
+            detected_freq,
+            target_freq,
         )
         return ds, False
 
-    print(f"Resampling required: {detected_freq} → {target_freq}")
-    print(f"Reason: {reason}")
+    logger.debug("Resampling required: %s -> %s", detected_freq, target_freq)
+    logger.debug("Reason: %s", reason)
 
     # Perform resampling
     ds_resampled = resample_dataset_temporal(
@@ -2601,7 +2630,7 @@ def load_cmip7_to_cmip6_mapping(mapping_path: Optional[str] = None) -> Dict[str,
     # Filter out metadata if present
     mapping = {k: v for k, v in data.items() if not k.startswith("_")}
 
-    print(f"✓ Loaded mapping for {len(mapping)} variables from: {mapping_path}")
+    logger.debug("Loaded mapping for %d variables from: %s", len(mapping), mapping_path)
     return mapping
 
 
@@ -2685,7 +2714,9 @@ def load_cmip6_to_cmip7_mapping(mapping_path: Optional[str] = None) -> Dict[str,
     # Filter out metadata if present
     mapping = {k: v for k, v in data.items() if not k.startswith("_")}
 
-    print(f"✓ Loaded reverse mapping for {len(mapping)} variables from: {mapping_path}")
+    logger.debug(
+        "Loaded reverse mapping for %d variables from: %s", len(mapping), mapping_path
+    )
     return mapping
 
 
@@ -2835,8 +2866,8 @@ def generate_both_cmip_mappings(
             "Install it with: pip install CMIP7-data-request-api"
         )
 
-    print("Generating both CMIP7<->CMIP6 compound name mappings...")
-    print("This may take a moment as it queries the CMIP7 data request API...")
+    logger.debug("Generating both CMIP7<->CMIP6 compound name mappings...")
+    logger.debug("This may take a moment as it queries the CMIP7 data request API...")
 
     # Use the latest_stable version of the DR content (default)
     content_dic = dt.get_transformed_content(
@@ -2939,10 +2970,10 @@ def generate_both_cmip_mappings(
     with open(reverse_output_path, "w", encoding="utf-8") as f:
         json.dump(reverse_data, f, indent=2, sort_keys=True)
 
-    print(f"✓ Generated forward mapping for {len(forward_mapping)} variables")
-    print(f"✓ Saved forward mapping to: {forward_output_path}")
-    print(f"✓ Generated reverse mapping for {len(reverse_mapping)} variables")
-    print(f"✓ Saved reverse mapping to: {reverse_output_path}")
+    logger.debug("Generated forward mapping for %d variables", len(forward_mapping))
+    logger.debug("Saved forward mapping to: %s", forward_output_path)
+    logger.debug("Generated reverse mapping for %d variables", len(reverse_mapping))
+    logger.debug("Saved reverse mapping to: %s", reverse_output_path)
 
     return forward_mapping, reverse_mapping
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -607,7 +607,7 @@ class TestCMIP6CMORiserWrite:
 
     @pytest.mark.unit
     def test_write_raises_error_when_missing_required_attributes(
-        self, mock_vocab, mock_mapping, sample_dataset_missing_attrs, temp_dir, capsys
+        self, mock_vocab, mock_mapping, sample_dataset_missing_attrs, temp_dir, caplog
     ):
         """
         Test that write() raises ValueError when required CMIP6 attributes are missing.
@@ -632,11 +632,13 @@ class TestCMIP6CMORiserWrite:
                 available=16 * 1024**3,
             )
 
-            cmoriser.write()
+            import logging
 
-            # Check that warning was printed
-            captured = capsys.readouterr()
-            assert "Warning: Missing required global attributes" in captured.out
+            with caplog.at_level(logging.WARNING, logger="access_moppy.base"):
+                cmoriser.write()
+
+            # Check that warning was logged
+            assert "Missing required global attributes" in caplog.text
 
     # ==================== Memory Estimation Tests ====================
 
@@ -761,16 +763,17 @@ class TestCMIP6CMORiserWrite:
 
     @pytest.mark.unit
     def test_write_uses_chunked_write_for_dask_array(
-        self, cmoriser_with_dask_dataset, temp_dir, capsys
+        self, cmoriser_with_dask_dataset, temp_dir, caplog
     ):
         """Test that write() uses chunked writing for Dask arrays."""
-        cmoriser_with_dask_dataset.write()
+        import logging
 
-        captured = capsys.readouterr()
+        with caplog.at_level(logging.DEBUG, logger="access_moppy.base"):
+            cmoriser_with_dask_dataset.write()
 
         # Should indicate chunked writing
-        assert "Using chunked writing" in captured.out
-        assert "timesteps/chunk" in captured.out
+        assert "Using chunked writing" in caplog.text
+        assert "timesteps/chunk" in caplog.text
 
     @pytest.mark.unit
     def test_write_chunked_creates_valid_file(
@@ -889,22 +892,23 @@ class TestCMIP6CMORiserWrite:
     # ==================== Logging Tests ====================
 
     @pytest.mark.unit
-    def test_write_prints_output_path(self, cmoriser_with_dataset, temp_dir, capsys):
+    def test_write_prints_output_path(self, cmoriser_with_dataset, temp_dir, caplog):
         """
-        Test that write() prints the output file path after completion.
+        Test that write() logs the output file path after completion.
         """
+        import logging
+
         with patch("psutil.virtual_memory") as mock_mem:
             mock_mem.return_value = MagicMock(
                 total=32 * 1024**3,
                 available=16 * 1024**3,
             )
 
-            cmoriser_with_dataset.write()
+            with caplog.at_level(logging.INFO, logger="access_moppy.base"):
+                cmoriser_with_dataset.write()
 
-            captured = capsys.readouterr()
-
-            assert "CMORised output written to" in captured.out
-            assert str(temp_dir) in captured.out
+            assert "CMORised output written to" in caplog.text
+            assert str(temp_dir) in caplog.text
 
     # ==================== String Coordinate Preparation Tests ====================
 
@@ -1316,7 +1320,7 @@ class TestCMIP6CMORiserWrite:
         mock_mapping,
         dataset_with_scalar_string_coord,
         temp_dir,
-        capsys,
+        caplog,
     ):
         """Test that string coordinate detection is logged."""
         cmoriser = CMORiser(
@@ -1329,18 +1333,19 @@ class TestCMIP6CMORiserWrite:
         cmoriser.ds = dataset_with_scalar_string_coord
         cmoriser.cmor_name = "baresoilFrac"
 
+        import logging
+
         with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
             mock_mem.return_value = MagicMock(
                 total=32 * 1024**3,
                 available=16 * 1024**3,
             )
 
-            cmoriser.write()
+            with caplog.at_level(logging.DEBUG, logger="access_moppy.base"):
+                cmoriser.write()
 
-            captured = capsys.readouterr()
-
-            assert "🔤 Detected string coordinate 'type'" in captured.out
-            assert "String coordinates processed: type" in captured.out
+            assert "Detected string coordinate 'type'" in caplog.text
+            assert "String coordinates processed: type" in caplog.text
 
     @pytest.mark.unit
     def test_write_preserves_numerical_data_with_string_coords(

--- a/tests/unit/test_base_loading_chunker.py
+++ b/tests/unit/test_base_loading_chunker.py
@@ -204,7 +204,7 @@ def test_ensure_numeric_time_coordinates_converts_cftime_without_units(
 
 @pytest.mark.unit
 def test_rechunk_dataset_method_handles_disabled_and_no_dataset(
-    mock_vocab, mock_mapping, temp_dir, capsys
+    mock_vocab, mock_mapping, temp_dir, caplog
 ):
     cmoriser = CMORiser(
         input_paths=["file.nc"],
@@ -215,9 +215,11 @@ def test_rechunk_dataset_method_handles_disabled_and_no_dataset(
         enable_chunking=False,
     )
 
-    cmoriser.rechunk_dataset()
-    captured = capsys.readouterr()
-    assert "Chunking is disabled" in captured.out
+    import logging
+
+    with caplog.at_level(logging.DEBUG, logger="access_moppy.base"):
+        cmoriser.rechunk_dataset()
+    assert "Chunking is disabled" in caplog.text
 
 
 # ==================== _get_ureg singleton ====================


### PR DESCRIPTION
## Summary

Replaces all `print()` calls in `base.py`, `utilities.py`, and `__init__.py` with Python's standard `logging` module, so users can control verbosity via the logging system rather than having output printed unconditionally.

## Changes

### `src/access_moppy/base.py`
- Added `import logging` and `logger = logging.getLogger(__name__)`
- Replaced ~35 `print()` calls with `logger.debug()` / `logger.info()` / `logger.warning()` as appropriate
- `"CMORised output written to …"` is now `logger.info()`; warnings (missing attributes, symlink failures, normalisation errors) are `logger.warning()`; all other operational messages are `logger.debug()`

### `src/access_moppy/utilities.py`
- Already had `logger = logging.getLogger(__name__)`; replaced ~40 remaining `print()` calls with `logger.debug()` / `logger.warning()`

### `src/access_moppy/__init__.py`
- Added `logging.NullHandler` on the `access_moppy` root logger (library best practice — keeps the library silent unless the calling application configures logging)
- Auto-detects Jupyter notebook environment (`IPKernelApp`); if running in a notebook, adds a `StreamHandler` at `DEBUG` level so all progress messages are visible out-of-the-box without any extra configuration
- Converted the four configuration `print()` calls to `logger.debug()`

### `tests/unit/test_base.py` & `tests/unit/test_base_loading_chunker.py`
- Updated five tests that were asserting `capsys.readouterr().out` to instead assert on `caplog.text` using `caplog.at_level(logging.DEBUG/WARNING, logger="access_moppy.base")`

## Testing

All 591 unit and integration tests pass.