### PR TITLE
Fix inconsistencies in ACCESS-ESM1.6 mappings

### DIFF
--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -7,6 +7,7 @@
             "land",
             "landIce",
             "ocean",
+            "oceanBgchem",
             "sea_ice"
         ],
         "description": "Variable mappings for ACCESS-ESM1.6 Earth System Model"

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -2998,7 +2998,7 @@
                     "landfrac": "fld_s03i395"
                 }
             },
-            "CF standard Name": "land_area_fraction"
+            "CF standard Name": "land_ice_area_fraction"
         },
         "residualFrac": {
             "dimensions": {

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -6041,7 +6041,7 @@
             }
         },
         "sidmassevapsubl": {
-            "CF standard Name": "water_evapotranspiration_flux",
+            "CF standard Name": "tendency_of_sea_ice_amount_due_to_sublimation_and_evaporation",
             "dimensions": {
                 "time": "time",
                 "TLAT": "lat",

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -1208,40 +1208,6 @@
             },
             "CF standard Name": ""
         },
-        "tauuo": {
-            "dimensions": {
-                "time": "time",
-                "yu_ocean": "yu_ocean",
-                "xu_ocean": "xu_ocean"
-            },
-            "units": "N m-2",
-            "positive": null,
-            "model_variables": [
-                "tau_x"
-            ],
-            "calculation": {
-                "type": "direct",
-                "formula": "tau_x"
-            },
-            "CF standard Name": ""
-        },
-        "tauvo": {
-            "dimensions": {
-                "time": "time",
-                "yu_ocean": "yu_ocean",
-                "xu_ocean": "xu_ocean"
-            },
-            "units": "N m-2",
-            "positive": null,
-            "model_variables": [
-                "tau_y"
-            ],
-            "calculation": {
-                "type": "direct",
-                "formula": "tau_y"
-            },
-            "CF standard Name": ""
-        },
         "areacella": {
             "dimensions": {
                 "lat": "lat",

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -4462,7 +4462,7 @@
                 "type": "direct",
                 "formula": "tau_y"
             },
-            "CF standard Name": "downward_y_stress_at_sea_water_surface"
+            "CF standard Name": "surface_downward_y_stress"
         },
         "thetao": {
             "dimensions": {

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -6647,7 +6647,7 @@
             }
         },
         "sivol": {
-            "CF standard Name": "sea_ice_thickness",
+            "CF standard Name": "sea_ice_volume",
             "dimensions": {
                 "time": "time",
                 "TLAT": "lat",

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -4445,7 +4445,7 @@
                 "type": "direct",
                 "formula": "tau_x"
             },
-            "CF standard Name": "downward_x_stress_at_sea_water_surface"
+            "CF standard Name": "surface_downward_x_stress"
         },
         "tauvo": {
             "dimensions": {

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -6467,7 +6467,7 @@
             }
         },
         "sistryubot": {
-            "CF standard Name": "sea_ice_y_stress_at_bottom",
+            "CF standard Name": "upward_y_stress_at_sea_ice_base",
             "dimensions": {
                 "time": "time",
                 "ULAT": "lat",

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -3662,7 +3662,7 @@
                 "yt_ocean": "latitude",
                 "xt_ocean": "longitude"
             },
-            "units": "W m-2",
+            "units": "kg m-2 s-1",
             "positive": null,
             "model_variables": [
                 "wfimelt",

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -1208,108 +1208,6 @@
             },
             "CF standard Name": ""
         },
-        "msftmrho": {
-            "dimensions": {
-                "time": "time",
-                "potrho": "potrho",
-                "yu_ocean": "latitude"
-            },
-            "units": "kg s-1",
-            "positive": null,
-            "model_variables": [
-                "ty_trans_rho",
-                "ty_trans_rho_gm"
-            ],
-            "calculation": {
-                "type": "formula",
-                "operation": "calc_overturning_streamfunction",
-                "args": [
-                    "ty_trans_rho",
-                    "ty_trans_rho_gm"
-                ],
-                "kwargs": {
-                    "depth_coord": {
-                        "literal": "potrho"
-                    }
-                }
-            },
-            "CF standard Name": ""
-        },
-        "msftmz": {
-            "dimensions": {
-                "time": "time",
-                "st_ocean": "lev",
-                "yu_ocean": "latitude"
-            },
-            "units": "kg s-1",
-            "positive": null,
-            "model_variables": [
-                "ty_trans",
-                "ty_trans_gm",
-                "ty_trans_submeso"
-            ],
-            "calculation": {
-                "type": "formula",
-                "operation": "calc_overturning_streamfunction",
-                "args": [
-                    "ty_trans",
-                    "ty_trans_gm",
-                    "ty_trans_submeso"
-                ]
-            },
-            "CF standard Name": ""
-        },
-        "msftyrho": {
-            "dimensions": {
-                "time": "time",
-                "potrho": "potrho",
-                "yu_ocean": "latitude"
-            },
-            "units": "kg s-1",
-            "positive": null,
-            "model_variables": [
-                "ty_trans_rho",
-                "ty_trans_rho_gm"
-            ],
-            "calculation": {
-                "type": "formula",
-                "operation": "calc_overturning_streamfunction",
-                "args": [
-                    "ty_trans_rho",
-                    "ty_trans_rho_gm"
-                ],
-                "kwargs": {
-                    "depth_coord": {
-                        "literal": "potrho"
-                    }
-                }
-            },
-            "CF standard Name": ""
-        },
-        "msftyz": {
-            "dimensions": {
-                "time": "time",
-                "st_ocean": "lev",
-                "yu_ocean": "latitude"
-            },
-            "units": "kg s-1",
-            "positive": null,
-            "model_variables": [
-                "ty_trans",
-                "ty_trans_gm",
-                "ty_trans_submeso"
-            ],
-            "calculation": {
-                "type": "formula",
-                "operation": "calc_overturning_streamfunction",
-                "args": [
-                    "ty_trans",
-                    "ty_trans_gm",
-                    "ty_trans_submeso"
-                ]
-            },
-            "CF standard Name": ""
-        },
         "tauuo": {
             "dimensions": {
                 "time": "time",
@@ -3559,6 +3457,108 @@
         }
     },
     "ocean": {
+        "msftmrho": {
+            "dimensions": {
+                "time": "time",
+                "potrho": "potrho",
+                "yu_ocean": "latitude"
+            },
+            "units": "kg s-1",
+            "positive": null,
+            "model_variables": [
+                "ty_trans_rho",
+                "ty_trans_rho_gm"
+            ],
+            "calculation": {
+                "type": "formula",
+                "operation": "calc_overturning_streamfunction",
+                "args": [
+                    "ty_trans_rho",
+                    "ty_trans_rho_gm"
+                ],
+                "kwargs": {
+                    "depth_coord": {
+                        "literal": "potrho"
+                    }
+                }
+            },
+            "CF standard Name": ""
+        },
+        "msftmz": {
+            "dimensions": {
+                "time": "time",
+                "st_ocean": "lev",
+                "yu_ocean": "latitude"
+            },
+            "units": "kg s-1",
+            "positive": null,
+            "model_variables": [
+                "ty_trans",
+                "ty_trans_gm",
+                "ty_trans_submeso"
+            ],
+            "calculation": {
+                "type": "formula",
+                "operation": "calc_overturning_streamfunction",
+                "args": [
+                    "ty_trans",
+                    "ty_trans_gm",
+                    "ty_trans_submeso"
+                ]
+            },
+            "CF standard Name": ""
+        },
+        "msftyrho": {
+            "dimensions": {
+                "time": "time",
+                "potrho": "potrho",
+                "yu_ocean": "latitude"
+            },
+            "units": "kg s-1",
+            "positive": null,
+            "model_variables": [
+                "ty_trans_rho",
+                "ty_trans_rho_gm"
+            ],
+            "calculation": {
+                "type": "formula",
+                "operation": "calc_overturning_streamfunction",
+                "args": [
+                    "ty_trans_rho",
+                    "ty_trans_rho_gm"
+                ],
+                "kwargs": {
+                    "depth_coord": {
+                        "literal": "potrho"
+                    }
+                }
+            },
+            "CF standard Name": ""
+        },
+        "msftyz": {
+            "dimensions": {
+                "time": "time",
+                "st_ocean": "lev",
+                "yu_ocean": "latitude"
+            },
+            "units": "kg s-1",
+            "positive": null,
+            "model_variables": [
+                "ty_trans",
+                "ty_trans_gm",
+                "ty_trans_submeso"
+            ],
+            "calculation": {
+                "type": "formula",
+                "operation": "calc_overturning_streamfunction",
+                "args": [
+                    "ty_trans",
+                    "ty_trans_gm",
+                    "ty_trans_submeso"
+                ]
+            },
+            "CF standard Name": ""
+        },
         "areacello": {
             "dimensions": {
                 "yt_ocean": "latitude",

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -4633,7 +4633,7 @@
                 "yt_ocean": "latitude",
                 "xu_ocean": "longitude"
             },
-            "units": "kg/s",
+            "units": "kg s-1",
             "positive": null,
             "model_variables": [
                 "tx_trans",
@@ -4699,7 +4699,7 @@
                 "yu_ocean": "latitude",
                 "xt_ocean": "longitude"
             },
-            "units": "kg/s",
+            "units": "kg s-1",
             "positive": null,
             "model_variables": [
                 "ty_trans",
@@ -4777,7 +4777,7 @@
                 "yt_ocean": "latitude",
                 "xt_ocean": "longitude"
             },
-            "units": "m/sec",
+            "units": "m s-1",
             "positive": null,
             "model_variables": [
                 "wt"

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -678,7 +678,7 @@
                 "lon": "lon"
             },
             "units": "W m-2",
-            "positive": "down",
+            "positive": "up",
             "model_variables": [
                 "fld_s02i206"
             ],

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -1223,111 +1223,6 @@
             },
             "CF standard Name": ""
         },
-        "evspsblveg": {
-            "dimensions": {
-                "time": "time",
-                "lat": "lat",
-                "lon": "lon"
-            },
-            "units": "kg m-2 s-1",
-            "positive": null,
-            "model_variables": [
-                "fld_s03i297"
-            ],
-            "calculation": {
-                "type": "direct",
-                "formula": "fld_s03i297"
-            },
-            "CF standard Name": "water_evaporation_flux_from_canopy"
-        },
-        "mrfso": {
-            "dimensions": {
-                "time": "time",
-                "lat": "lat",
-                "lon": "lon"
-            },
-            "units": "kg m-2",
-            "positive": null,
-            "model_variables": [
-                "fld_s08i223",
-                "fld_s08i230"
-            ],
-            "calculation": {
-                "type": "formula",
-                "operation": "sum",
-                "args": [
-                    {
-                        "operation": "multiply",
-                        "operands": [
-                            "fld_s08i223",
-                            "fld_s08i230"
-                        ]
-                    }
-                ],
-                "kwargs": {
-                    "dim": {
-                        "literal": "soil_model_level_number"
-                    }
-                }
-            },
-            "CF standard Name": "soil_frozen_water_content"
-        },
-        "mrrob": {
-            "dimensions": {
-                "time": "time",
-                "lat": "lat",
-                "lon": "lon"
-            },
-            "units": "kg m-2 s-1",
-            "positive": null,
-            "model_variables": [
-                "fld_s08i235"
-            ],
-            "calculation": {
-                "type": "direct",
-                "formula": "fld_s08i235"
-            },
-            "CF standard Name": "subsurface_runoff_flux"
-        },
-        "mrfsli": {
-            "dimensions": {
-                "time": "time",
-                "lat": "lat",
-                "lon": "lon"
-            },
-            "units": "kg m-2",
-            "positive": null,
-            "model_variables": [
-                "fld_s08i223",
-                "fld_s08i229"
-            ],
-            "calculation": {
-                "type": "formula",
-                "formula": "multiply",
-                "operands": [
-                    "fld_s08i223",
-                    "fld_s08i229"
-                ]
-            },
-            "CF standard Name": "liquid_water_content_of_soil_layer"
-        },
-        "npp": {
-            "dimensions": {
-                "time": "time",
-                "lat": "lat",
-                "lon": "lon"
-            },
-            "units": "kg m-2 s-1",
-            "positive": "down",
-            "model_variables": [
-                "fld_s03i262"
-            ],
-            "calculation": {
-                "type": "direct",
-                "formula": "fld_s03i262"
-            },
-            "CF standard Name": "net_primary_productivity_of_biomass_expressed_as_carbon"
-        },
         "hursmax": {
             "CF standard Name": "relative_humidity",
             "dimensions": {
@@ -1443,6 +1338,94 @@
         }
     },
     "land": {
+        "evspsblveg": {
+            "dimensions": {
+                "time": "time",
+                "lat": "lat",
+                "lon": "lon"
+            },
+            "units": "kg m-2 s-1",
+            "positive": null,
+            "model_variables": [
+                "fld_s03i297"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "fld_s03i297"
+            },
+            "CF standard Name": "water_evaporation_flux_from_canopy"
+        },
+        "mrfso": {
+            "dimensions": {
+                "time": "time",
+                "lat": "lat",
+                "lon": "lon"
+            },
+            "units": "kg m-2",
+            "positive": null,
+            "model_variables": [
+                "fld_s08i223",
+                "fld_s08i230"
+            ],
+            "calculation": {
+                "type": "formula",
+                "operation": "sum",
+                "args": [
+                    {
+                        "operation": "multiply",
+                        "operands": [
+                            "fld_s08i223",
+                            "fld_s08i230"
+                        ]
+                    }
+                ],
+                "kwargs": {
+                    "dim": {
+                        "literal": "soil_model_level_number"
+                    }
+                }
+            },
+            "CF standard Name": "soil_frozen_water_content"
+        },
+        "mrrob": {
+            "dimensions": {
+                "time": "time",
+                "lat": "lat",
+                "lon": "lon"
+            },
+            "units": "kg m-2 s-1",
+            "positive": null,
+            "model_variables": [
+                "fld_s08i235"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "fld_s08i235"
+            },
+            "CF standard Name": "subsurface_runoff_flux"
+        },
+        "mrfsli": {
+            "dimensions": {
+                "time": "time",
+                "lat": "lat",
+                "lon": "lon"
+            },
+            "units": "kg m-2",
+            "positive": null,
+            "model_variables": [
+                "fld_s08i223",
+                "fld_s08i229"
+            ],
+            "calculation": {
+                "type": "formula",
+                "formula": "multiply",
+                "operands": [
+                    "fld_s08i223",
+                    "fld_s08i229"
+                ]
+            },
+            "CF standard Name": "liquid_water_content_of_soil_layer"
+        },
         "cLand": {
             "dimensions": {
                 "time": "time",

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -78,7 +78,9 @@
                     2
                 ]
             }
-        },
+        }
+    },
+    "atmosphere": {
         "zg500": {
             "CF standard Name": "geopotential_height",
             "dimensions": {
@@ -101,9 +103,7 @@
                     "pressure": 500
                 }
             }
-        }
-    },
-    "atmosphere": {
+        },
         "rldscs": {
             "CF standard Name": "surface_downwelling_longwave_flux_in_air_assuming_clear_sky",
             "dimensions": {

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -6272,7 +6272,7 @@
             }
         },
         "siflswdtop": {
-            "CF standard Name": "surface_upwelling_shortwave_flux_in_air",
+            "CF standard Name": "surface_downwelling_shortwave_flux_in_air",
             "dimensions": {
                 "time": "time",
                 "TLAT": "lat",

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -3523,7 +3523,7 @@
                 "formula": "areacello"
             },
             "ressource_file": "fx.areacello_ACCESS-ESM.nc",
-            "CF standard Name": "areacello"
+            "CF standard Name": "cell_area"
         },
         "agessc": {
             "dimensions": {

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -1424,7 +1424,7 @@
                     "fld_s08i229"
                 ]
             },
-            "CF standard Name": "liquid_water_content_of_soil_layer"
+            "CF standard Name": "frozen_water_content_of_soil_layer"
         },
         "cLand": {
             "dimensions": {


### PR DESCRIPTION
## Summary

This PR corrects a series of inconsistencies found in `ACCESS-ESM1.6_mappings.json`:

### Variables moved to the correct section
- `msftmrho`, `msftmz`, `msftyrho`, `msftyz` — ocean overturning streamfunction variables mistakenly placed in `atmosphere` → moved to `ocean`
- `tauuo`, `tauvo` — ocean surface stress variables duplicated in `atmosphere` → duplicate entries removed (kept in `ocean`)
- `mrfso`, `mrrob`, `mrfsli`, `npp`, `evspsblveg` — land surface variables misplaced in `atmosphere` → moved to `land`
- `zg500` — geopotential height at 500 hPa misclassified under `aerosol` → moved to `atmosphere`

### CF standard name fixes
- `ocean.tauuo`: `downward_x_stress_at_sea_water_surface` → `surface_downward_x_stress`
- `ocean.tauvo`: `downward_y_stress_at_sea_water_surface` → `surface_downward_y_stress`
- `ocean.areacello`: `areacello` (CMIP variable name, not a CF name) → `cell_area`
- `sea_ice.siflswdtop`: `surface_upwelling_shortwave_flux_in_air` → `surface_downwelling_shortwave_flux_in_air` (the `d` in `siflswdtop` stands for downwelling)
- `sea_ice.sivol`: `sea_ice_thickness` → `sea_ice_volume`
- `sea_ice.sidmassevapsubl`: `water_evapotranspiration_flux` → `tendency_of_sea_ice_amount_due_to_sublimation_and_evaporation`
- `sea_ice.sistryubot`: `sea_ice_y_stress_at_bottom` → `upward_y_stress_at_sea_ice_base` (consistent with `sistrxubot`)
- `land.sftgif`: `land_area_fraction` → `land_ice_area_fraction`
- `land.mrfsli`: `liquid_water_content_of_soil_layer` → `frozen_water_content_of_soil_layer`

### Positive convention fix
- `atmosphere.rluscs`: `positive: down` → `positive: up` (upwelling flux)

### Units fixes
- `ocean.umo`, `ocean.vmo`: `kg/s` → `kg s-1`
- `ocean.wo`: `m/sec` → `m s-1`
- `ocean.fsitherm`: `W m-2` → `kg m-2 s-1` (CF name describes a mass flux, not a heat flux)