### PR TITLE
Add sitimefrac mapping for ACCESS-ESM1.6 sea ice

### DIFF
--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -7536,6 +7536,26 @@
                 "sithick": "m"
             }
         },
+        "sitimefrac": {
+            "CF standard Name": "fraction_of_time_with_sea_ice_area_fraction_above_threshold",
+            "dimensions": {
+                "time": "time",
+                "TLAT": "lat",
+                "TLON": "lon"
+            },
+            "units": "1",
+            "positive": null,
+            "model_variables": [
+                "sitimefrac"
+            ],
+            "calculation": {
+                "type": "direct",
+                "formula": "sitimefrac"
+            },
+            "model_variable_units": {
+                "sitimefrac": "1"
+            }
+        },
         "siv": {
             "CF standard Name": "sea_ice_y_velocity",
             "dimensions": {


### PR DESCRIPTION
## Description

Adds the missing `sitimefrac` CMIP mapping for the ACCESS-ESM1.6 sea ice component.

## Changes

Added a `sitimefrac` entry to the `sea_ice` section of `ACCESS-ESM1.6_mappings.json`:

- **CF standard name**: `fraction_of_time_with_sea_ice_area_fraction_above_threshold`
- **Units**: `1` (dimensionless — matches the raw ESM1.6 model output directly)
- **Calculation**: `direct` — no unit conversion or formula needed
- **Dimensions**: T-grid (`TLON`/`TLAT`), consistent with other scalar sea-ice variables like `siconc`

## Notes

The `sitimefrac` variable exists in ESM1.6 raw output (units `"1"`) and maps directly to the CMIP variable. No extra calculation is required.

Fixes #304