### PR TITLE
feat: add LImon.snc mapping via tile-based snow fraction derivation

### DIFF
--- a/src/access_moppy/derivations/calc_land.py
+++ b/src/access_moppy/derivations/calc_land.py
@@ -1,6 +1,40 @@
 #!/usr/bin/env python
 
 
+def calc_snc(tilefrac, snow_tile, landfrac):
+    """
+    Calculate snow area fraction (snc) as a percentage of grid-cell area.
+
+    Sums the tile fractions for tiles that have any snow present during the
+    month, then scales by land fraction to express as a fraction of total
+    grid-cell area.  Equivalent to the approach discussed in issue #323:
+    ``100 * sum(tilefrac where snow_tile > 0) * landfrac``.
+
+    Parameters
+    ----------
+    tilefrac : xarray.DataArray
+        Tile fraction variable (fractional, 0-1) with a pseudo-level dimension.
+        Corresponds to STASH ``fld_s03i317``.
+    snow_tile : xarray.DataArray
+        Monthly snow amount on tiles (kg m-2) with the same pseudo-level
+        dimension.  Corresponds to STASH ``fld_s08i236``.
+    landfrac : xarray.DataArray
+        Land area fraction (fractional, 0-1).  Corresponds to STASH
+        ``fld_s03i395``.
+
+    Returns
+    -------
+    xarray.DataArray
+        Snow area fraction as a percentage (0-100 %).
+    """
+    pseudo_level = tilefrac.dims[1]
+    snow_tile = snow_tile.rename({snow_tile.dims[1]: pseudo_level})
+    # mask tile fractions to tiles with snow present then sum over tiles
+    snc = tilefrac.where(snow_tile > 0.0, other=0.0).sum(dim=pseudo_level)
+    # scale by land fraction and convert to percentage
+    return (snc * landfrac * 100.0).fillna(0)
+
+
 def extract_tilefrac(tilefrac, tilenum, landfrac=None, lev=None):
     """
     Calculates the land fraction of a specific tile type as a percentage.

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -3828,6 +3828,37 @@
         }
     },
     "landIce": {
+        "snc": {
+            "dimensions": {
+                "time": "time",
+                "lat": "lat",
+                "lon": "lon"
+            },
+            "units": "%",
+            "positive": null,
+            "model_variables": [
+                "fld_s03i317",
+                "fld_s08i236",
+                "fld_s03i395"
+            ],
+            "calculation": {
+                "type": "formula",
+                "operation": "calc_snc",
+                "args": [
+                    "fld_s03i317",
+                    "fld_s08i236"
+                ],
+                "kwargs": {
+                    "landfrac": "fld_s03i395"
+                }
+            },
+            "CF standard Name": "surface_snow_area_fraction",
+            "model_variable_units": {
+                "fld_s03i317": "1",
+                "fld_s08i236": "kg m-2",
+                "fld_s03i395": "1"
+            }
+        },
         "snw": {
             "dimensions": {
                 "time": "time",

--- a/tests/unit/test_derivations_calc_land.py
+++ b/tests/unit/test_derivations_calc_land.py
@@ -1,0 +1,163 @@
+"""Tests for access_moppy.derivations.calc_land."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from access_moppy.derivations.calc_land import calc_snc
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NT = 3  # time steps
+NTILES = 4  # pseudo-level (tile) dimension
+NJ = 4  # lat
+NI = 6  # lon
+
+
+def _make_inputs(tilefrac_data, snow_data, landfrac_data=None):
+    """Build (tilefrac, snow_tile, landfrac) DataArrays from numpy arrays."""
+    times = xr.date_range("2000-01-01", periods=NT, freq="ME")
+
+    tilefrac = xr.DataArray(
+        tilefrac_data,
+        dims=["time", "pseudo_level_0", "lat", "lon"],
+        coords={"time": times},
+        attrs={"units": "1"},
+    )
+    snow_tile = xr.DataArray(
+        snow_data,
+        dims=["time", "pseudo_level_0", "lat", "lon"],
+        coords={"time": times},
+        attrs={"units": "kg m-2"},
+    )
+    if landfrac_data is None:
+        landfrac_data = np.ones((NJ, NI))
+    landfrac = xr.DataArray(
+        landfrac_data,
+        dims=["lat", "lon"],
+        attrs={"units": "1"},
+    )
+    return tilefrac, snow_tile, landfrac
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCalcSnc:
+    """Tests for calc_snc()."""
+
+    def test_all_tiles_snowy_equals_tilefrac_sum(self):
+        """When all tiles have snow, snc == 100 * sum(tilefrac) * landfrac."""
+        tf = np.full((NT, NTILES, NJ, NI), 0.25)  # each tile = 0.25, sum = 1.0
+        sn = np.ones((NT, NTILES, NJ, NI))  # all tiles have snow
+        tilefrac, snow_tile, landfrac = _make_inputs(tf, sn)
+
+        result = calc_snc(tilefrac, snow_tile, landfrac)
+
+        assert result.dims == ("time", "lat", "lon")
+        np.testing.assert_allclose(result.values, 100.0)
+
+    def test_no_snow_returns_zero(self):
+        """When no tile has snow, snc == 0."""
+        tf = np.full((NT, NTILES, NJ, NI), 0.25)
+        sn = np.zeros((NT, NTILES, NJ, NI))  # no snow anywhere
+        tilefrac, snow_tile, landfrac = _make_inputs(tf, sn)
+
+        result = calc_snc(tilefrac, snow_tile, landfrac)
+
+        np.testing.assert_allclose(result.values, 0.0)
+
+    def test_partial_snow_coverage(self):
+        """Only tiles with snow > 0 contribute to snc."""
+        # 4 tiles of equal fraction 0.25; only tile index 0 has snow
+        tf = np.full((NT, NTILES, NJ, NI), 0.25)
+        sn = np.zeros((NT, NTILES, NJ, NI))
+        sn[:, 0, :, :] = 1.0  # only tile 0 has snow
+        tilefrac, snow_tile, landfrac = _make_inputs(tf, sn)
+
+        result = calc_snc(tilefrac, snow_tile, landfrac)
+
+        # Only tile 0 (frac=0.25) contributes; landfrac=1 → 25 %
+        np.testing.assert_allclose(result.values, 25.0)
+
+    def test_landfrac_scaling(self):
+        """snc is scaled by land fraction."""
+        tf = np.full((NT, NTILES, NJ, NI), 0.25)
+        sn = np.ones((NT, NTILES, NJ, NI))  # all tiles have snow
+        lf = np.full((NJ, NI), 0.5)  # 50 % land
+        tilefrac, snow_tile, landfrac = _make_inputs(tf, sn, lf)
+
+        result = calc_snc(tilefrac, snow_tile, landfrac)
+
+        # sum(tilefrac) = 1.0; * 0.5 landfrac * 100 = 50 %
+        np.testing.assert_allclose(result.values, 50.0)
+
+    def test_no_nan_in_output(self):
+        """fillna(0) ensures output contains no NaN values."""
+        tf = np.full((NT, NTILES, NJ, NI), 0.25)
+        sn = np.ones((NT, NTILES, NJ, NI))
+        lf = np.full((NJ, NI), 1.0)
+        lf[0, 0] = np.nan  # inject NaN into land fraction
+        tilefrac, snow_tile, landfrac = _make_inputs(tf, sn, lf)
+
+        result = calc_snc(tilefrac, snow_tile, landfrac)
+
+        assert not np.any(np.isnan(result.values))
+
+    def test_output_bounds(self):
+        """snc values must lie within [0, 100]."""
+        rng = np.random.default_rng(0)
+        tf = rng.uniform(0, 1, size=(NT, NTILES, NJ, NI))
+        # normalise so tile fractions sum to ≤ 1
+        tf /= tf.sum(axis=1, keepdims=True).clip(min=1)
+        sn = rng.uniform(0, 10, size=(NT, NTILES, NJ, NI))
+        lf = rng.uniform(0, 1, size=(NJ, NI))
+        tilefrac, snow_tile, landfrac = _make_inputs(tf, sn, lf)
+
+        result = calc_snc(tilefrac, snow_tile, landfrac)
+
+        assert float(result.min()) >= 0.0
+        assert float(result.max()) <= 100.0 + 1e-6
+
+    def test_dask_compatible(self):
+        """Result can be computed lazily with dask-backed arrays."""
+        pytest.importorskip("dask")  # skip if dask not installed
+
+        tf = np.full((NT, NTILES, NJ, NI), 0.25)
+        sn = np.ones((NT, NTILES, NJ, NI))
+        tilefrac, snow_tile, landfrac = _make_inputs(tf, sn)
+
+        # chunk along the tile dimension
+        tilefrac = tilefrac.chunk({"time": 1})
+        snow_tile = snow_tile.chunk({"time": 1})
+
+        result = calc_snc(tilefrac, snow_tile, landfrac)
+
+        # result should still be a dask-backed DataArray (lazy)
+        assert result.chunks is not None, "result should be dask-backed"
+        # and it should compute to the correct value
+        np.testing.assert_allclose(result.compute().values, 100.0)
+
+    def test_mismatched_pseudo_level_name_handled(self):
+        """snow_tile with a different pseudo-level dim name is handled correctly."""
+        times = xr.date_range("2000-01-01", periods=NT, freq="ME")
+        tf = xr.DataArray(
+            np.full((NT, NTILES, NJ, NI), 0.25),
+            dims=["time", "pseudo_level_0", "lat", "lon"],
+            coords={"time": times},
+        )
+        # snow_tile uses a different internal name for the tile dimension
+        sn = xr.DataArray(
+            np.ones((NT, NTILES, NJ, NI)),
+            dims=["time", "tile", "lat", "lon"],
+            coords={"time": times},
+        )
+        lf = xr.DataArray(np.ones((NJ, NI)), dims=["lat", "lon"])
+
+        result = calc_snc(tf, sn, lf)
+
+        np.testing.assert_allclose(result.values, 100.0)


### PR DESCRIPTION
## Summary

Implements the `LImon.snc` (snow area fraction) variable mapping for ACCESS-ESM1.6, resolving #323.

## Approach

Uses **option 1** from the issue discussion: sum the tile fractions for all tiles that have any monthly snow present, then scale by land fraction:

```
snc = 100 * sum(tilefrac where fld_s08i236 > 0) * landfrac
```

| STASH code | Description |
|---|---|
| `fld_s03i317` | Tile fractions |
| `fld_s08i236` | Monthly snow amount per tile (kg m⁻²) |
| `fld_s03i395` | Land area fraction |

This is the most physically grounded CABLE-native approach — it captures which tiles have snow cover and weights by their fractional area.

## Changes

- **`src/access_moppy/derivations/calc_land.py`** — new `calc_snc()` function (lazy/dask-compatible)
- **`src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json`** — new `snc` entry in the `landIce` section
- **`tests/unit/test_derivations_calc_land.py`** — 8 unit tests covering full/no/partial snow, land fraction scaling, NaN handling, value bounds, dask laziness, and mismatched dimension names

Closes #323