### PR TITLE
fix: divide ra, rh, nbp by land fraction for CMIP land-mean compliance

### DIFF
--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -2961,7 +2961,7 @@
             ],
             "calculation": {
                 "type": "formula",
-                "operation": "multiply",
+                "operation": "divide",
                 "args": [
                     {
                         "operation": "add",
@@ -3348,19 +3348,27 @@
             "positive": "up",
             "model_variables": [
                 "fld_s03i261",
-                "fld_s03i262"
+                "fld_s03i262",
+                "fld_s03i395"
             ],
             "calculation": {
                 "type": "formula",
-                "operation": "subtract",
-                "operands": [
-                    "fld_s03i261",
-                    "fld_s03i262"
+                "operation": "divide",
+                "args": [
+                    {
+                        "operation": "subtract",
+                        "operands": [
+                            "fld_s03i261",
+                            "fld_s03i262"
+                        ]
+                    },
+                    "fld_s03i395"
                 ]
             },
             "model_variable_units": {
                 "fld_s03i261": "kg m-2 s-1",
-                "fld_s03i262": "kg m-2 s-1"
+                "fld_s03i262": "kg m-2 s-1",
+                "fld_s03i395": "1"
             }
         },
         "rh": {
@@ -3372,15 +3380,21 @@
             "units": "kg m-2 s-1",
             "positive": "up",
             "model_variables": [
-                "fld_s03i293"
+                "fld_s03i293",
+                "fld_s03i395"
             ],
             "calculation": {
-                "type": "direct",
-                "formula": "fld_s03i293"
+                "type": "formula",
+                "operation": "divide",
+                "args": [
+                    "fld_s03i293",
+                    "fld_s03i395"
+                ]
             },
             "CF standard Name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon_due_to_heterotrophic_respiration",
             "model_variable_units": {
-                "fld_s03i293": "kg m-2 s-1"
+                "fld_s03i293": "kg m-2 s-1",
+                "fld_s03i395": "1"
             }
         },
         "sftgif": {


### PR DESCRIPTION
## Summary

Fixes the land-fraction weighting bug for carbon flux variables in `ACCESS-ESM1.6_mappings.json`.

ESM1.5/1.6 applies land-fraction weighting to its grid-box mean productivity and respiration outputs. CMIP6/7 requires land-mean values (`cell_methods = "area: mean where land time: mean"`), which means the model grid-box output must be **divided** by the land fraction (`fld_s03i395`) before publishing.

## Changes

| Variable | Before | After |
|---|---|---|
| `ra` | `fld_s03i261 - fld_s03i262` (grid-box mean) | `(fld_s03i261 - fld_s03i262) / fld_s03i395` |
| `rh` | direct passthrough of `fld_s03i293` | `fld_s03i293 / fld_s03i395` |
| `nbp` | complex formula **× `fld_s03i395`** | same formula **÷ `fld_s03i395`** |

`gpp` and `npp` were already correctly dividing by `fld_s03i395`.

The `nbp` bug was particularly severe: the outermost operation was **multiplying** by land fraction instead of dividing, meaning published values were proportional to `land_fraction²` in coastal regions.

## Related Issues

Closes #115
Partially addresses #153 (LUC case now correct; emissions-driven case with `fld_s03i100` is a separate follow-up)