### PR TITLE
fix: update zg mapping to use fld_s30i207 on pressure levels

### DIFF
--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -1282,21 +1282,21 @@
             "CF standard Name": "geopotential_height",
             "dimensions": {
                 "time": "time",
-                "model_theta_level_number": "plev",
-                "lat": "lat",
-                "lon": "lon"
+                "pressure": "plev",
+                "lat_v": "lat",
+                "lon_u": "lon"
             },
             "units": "m",
             "positive": null,
             "model_variables": [
-                "fld_s16i201"
+                "fld_s30i207"
             ],
             "calculation": {
                 "type": "direct",
-                "formula": "fld_s16i201"
+                "formula": "fld_s30i207"
             },
             "model_variable_units": {
-                "fld_s16i201": "m"
+                "fld_s30i207": "m"
             }
         },
         "co23D": {


### PR DESCRIPTION
## What

Updates the `zg` mapping in `ACCESS-ESM1.6_mappings.json` to use `fld_s30i207` (GEOPOTENTIAL HEIGHT ON P LEV/UV GRID) instead of `fld_s16i201`.

## Why

Daily raw ACCESS-ESM1.6 output doesn't include `fld_s16i201`, which is geopotential height on the 38 model theta levels. This makes it impossible to CMORise `day.zg` from daily data.

Per @blimlim, `fld_s30i207` is the right field — it's interpolated onto the 19 standard pressure levels and is available in both daily and monthly output.

Dimensions updated from `model_theta_level_number`/`lat`/`lon` to `pressure`/`lat_v`/`lon_u` to match the UV pressure-level grid convention used by the other `fld_s30i*` variables (`ta`, `ua`, `va`, `wap`).

Closes #325