### PR TITLE
Add integration tests for Ofx variables

### DIFF
--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -4149,6 +4149,7 @@
                 ]
             },
             "CF standard Name": "sea_floor_depth_below_geoid",
+            "ressource_file": "ocean-2d-ht.nc",
             "model_variable_units": {
                 "ht": "m"
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,7 @@ def load_filtered_variables(model_id="ACCESS-ESM1.6", component=None, table_name
             "Lmon": "land",
             "Lday": "land",
             "Omon": "ocean",
+            "Ofx": "ocean",
             "Oday": "ocean",
             "Oyr": "ocean",
             "SImon": "sea_ice",
@@ -396,10 +397,11 @@ def _filter_variables_by_test_data(variables, table_name):
             "wo",  # Sea Water Vertical Velocity
         ],
         "Ofx": [
-            "areacello",  # Ocean Grid-Cell Area
-            "deptho",  # Ocean Depth
-            "masscello",  # Ocean Mass
-            "thkcello",  # Cell Thickness
+            # Only resource-backed variables that don't require external ocean data
+            "areacello",  # Ocean Grid-Cell Area (uses bundled fx.areacello_ACCESS-ESM.nc)
+            "sftof",  # Sea Area Fraction (uses bundled land_ocean_mask_ACCESS-ESM.nc)
+            "hfgeou",  # Upward Geothermal Heat Flux (uses bundled ocean-2d-ht.nc)
+            "deptho",  # Sea Floor Depth (uses bundled ocean-2d-ht.nc)
         ],
         "CFmon": [
             "hur",

--- a/tests/integration/test_full_cmorisation.py
+++ b/tests/integration/test_full_cmorisation.py
@@ -78,6 +78,7 @@ CMOR_TABLES = [
     ("Eday", "ACCESS-ESM1.6", "CMIP6_Eday.json"),
     ("CFday", "ACCESS-ESM1.6", "CMIP6_CFday.json"),
     ("SImon", "ACCESS-ESM1.6", "CMIP6_SImon.json"),
+    ("Ofx", "ACCESS-ESM1.6", "CMIP6_Ofx.json"),
 ]
 
 
@@ -97,6 +98,12 @@ class TestFullCMORIntegration:
             List of Path objects for the appropriate test files
         """
         table_name, _ = compound_name.split(".")
+
+        if table_name == "Ofx":
+            # Ofx variables are fixed (no time dimension). Variables backed by
+            # bundled resource files (areacello, sftof, hfgeou) need no external
+            # input — returning None signals the CMORiser to use its resource file.
+            return None
 
         if table_name == "Omon":
             # For ocean variables, try to get real ocean files first, fallback to test files
@@ -183,8 +190,12 @@ class TestFullCMORIntegration:
                     compound_name, model_id=model_id
                 )
 
-                # Skip if required files don't exist
-                if not input_files or not all(f.exists() for f in input_files):
+                # Skip if required files don't exist.
+                # input_files=None means the variable uses a bundled resource file
+                # and no external input is needed.
+                if input_files is not None and (
+                    not input_files or not all(f.exists() for f in input_files)
+                ):
                     pytest.skip(
                         f"Required input files not available for {compound_name}"
                     )
@@ -203,7 +214,7 @@ class TestFullCMORIntegration:
                 with resources.path(cmor_tables, cmor_table_file) as table_path:
                     try:
                         cmoriser = ACCESS_ESM_CMORiser(
-                            input_paths=input_files,
+                            input_paths=input_files,  # None = use bundled resource file
                             compound_name=compound_name,
                             experiment_id=experiment_id,
                             source_id=source_id,
@@ -226,7 +237,9 @@ class TestFullCMORIntegration:
                         ), f"No output files found for {cmor_name} in {output_dir}"
 
                         # Validate output with the configured backend
-                        if table_name != "Omon":
+                        # Skip compliance validation for Omon and Ofx (ocean fixed fields
+                        # use non-standard grid structures not validated by PrePARE/WCRP)
+                        if table_name not in ("Omon", "Ofx"):
                             self._validate_output_compliance(
                                 output_files[0],
                                 cmor_name,


### PR DESCRIPTION
## Summary

Adds integration test coverage for CMIP6 `Ofx` (Ocean Fixed) variables.

## Changes

### `src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json`
- Added `"ressource_file": "ocean-2d-ht.nc"` to the `deptho` entry. It uses `ht` as its model variable (same source as `hfgeou`), so the bundled resource file can be reused without needing external ocean data.

### `tests/conftest.py`
- Added `"Ofx": "ocean"` to the `table_to_component` map so `load_filtered_variables` resolves Ofx variables to the ocean component.
- Updated the `"Ofx"` entry in `test_data_compatible_vars` to list the four resource-backed variables: `areacello`, `sftof`, `hfgeou`, `deptho`.

### `tests/integration/test_full_cmorisation.py`
- Added `("Ofx", "ACCESS-ESM1.6", "CMIP6_Ofx.json")` to the `CMOR_TABLES` parametrize list.
- Added an `Ofx` branch in `_get_input_files_for_compound` that returns `None`, signalling the CMORiser to auto-load its bundled resource file.
- Updated the file-existence skip guard to treat `None` (resource-backed) as valid input.
- Extended compliance validation exclusion from `"Omon"` to `("Omon", "Ofx")`.

## Test result

```
SUBPASSED(variable='areacello')
SUBPASSED(variable='deptho')
SUBPASSED(variable='hfgeou')
SUBPASSED(variable='sftof')
1 passed, 4 subtests passed
```
