### PR TITLE
refactor: unify resource loading via load_ressource_data

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -330,6 +330,14 @@ class CMORiser:
                     )
 
         else:
+            # If no input files were provided, initialise an empty Dataset.
+            # This supports self-contained formula calculations (e.g. using
+            # load_ressource_data nested expressions) that do not need an
+            # external primary dataset.
+            if not self.input_paths:
+                self.ds = xr.Dataset()
+                return
+
             # Original file-based loading logic
             def _preprocess(ds):
                 ds = ds[list(required_vars & set(ds.data_vars))]

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -175,14 +175,23 @@ class ACCESS_ESM_CMORiser:
         # Check if this is an internal calculation that doesn't need input data
         is_internal_calc = False
         ressource_file = None
+        model_vars = None
         if cmor_name in self.variable_mapping:
             calc = self.variable_mapping[cmor_name].get("calculation", {})
             is_internal_calc = calc.get("type") == "internal"
             ressource_file = self.variable_mapping[cmor_name].get("ressource_file")
+            model_vars = self.variable_mapping[cmor_name].get("model_variables")
+
+        # A self-contained calculation needs no primary input files: either it
+        # is an "internal" type, or model_variables is an empty list (all data
+        # is loaded inside the formula via load_ressource_data nested calls).
+        is_self_contained = is_internal_calc or (
+            isinstance(model_vars, list) and len(model_vars) == 0
+        )
 
         if input_paths is None and input_data is None:
-            if is_internal_calc:
-                print(f"✓ No input data required for internal calculation: {cmor_name}")
+            if is_self_contained:
+                pass  # no input data needed
             elif ressource_file is not None:
                 resource_path = get_bundled_resource_path(ressource_file)
                 resolved_path = self._resource_stack.enter_context(

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -2884,14 +2884,15 @@
             },
             "units": "kg m-2",
             "positive": null,
-            "model_variables": [
-                "mrsofc"
-            ],
+            "model_variables": [],
             "calculation": {
-                "type": "direct",
-                "formula": "mrsofc"
+                "type": "formula",
+                "operation": "load_ressource_data",
+                "args": [
+                    {"literal": "fx.mrsofc_ACCESS-ESM.nc"},
+                    {"literal": "mrsofc"}
+                ]
             },
-            "ressource_file": "fx.mrsofc_ACCESS-ESM.nc",
             "CF standard Name": "soil_moisture_content_at_field_capacity"
         },
         "mrsol": {
@@ -4071,14 +4072,15 @@
             },
             "units": "m2",
             "positive": null,
-            "model_variables": [
-                "areacello"
-            ],
+            "model_variables": [],
             "calculation": {
-                "type": "direct",
-                "formula": "areacello"
+                "type": "formula",
+                "operation": "load_ressource_data",
+                "args": [
+                    {"literal": "fx.areacello_ACCESS-ESM.nc"},
+                    {"literal": "areacello"}
+                ]
             },
-            "ressource_file": "fx.areacello_ACCESS-ESM.nc",
             "CF standard Name": "cell_area"
         },
         "agessc": {
@@ -4168,21 +4170,21 @@
             },
             "units": "m",
             "positive": null,
-            "model_variables": [
-                "ht"
-            ],
+            "model_variables": [],
             "calculation": {
                 "type": "formula",
                 "operation": "drop_time_axis",
                 "args": [
-                    "ht"
+                    {
+                        "operation": "load_ressource_data",
+                        "args": [
+                            {"literal": "ocean-2d-ht.nc"},
+                            {"literal": "ht"}
+                        ]
+                    }
                 ]
             },
-            "CF standard Name": "sea_floor_depth_below_geoid",
-            "ressource_file": "ocean-2d-ht.nc",
-            "model_variable_units": {
-                "ht": "m"
-            }
+            "CF standard Name": "sea_floor_depth_below_geoid"
         },
         "evs": {
             "dimensions": {
@@ -4334,21 +4336,21 @@
             },
             "units": "W m-2",
             "positive": "up",
-            "model_variables": [
-                "ht"
-            ],
+            "model_variables": [],
             "calculation": {
                 "type": "formula",
                 "operation": "calc_hfgeou",
                 "args": [
-                    "ht"
+                    {
+                        "operation": "load_ressource_data",
+                        "args": [
+                            {"literal": "ocean-2d-ht.nc"},
+                            {"literal": "ht"}
+                        ]
+                    }
                 ]
             },
-            "ressource_file": "ocean-2d-ht.nc",
-            "CF standard Name": "upward_geothermal_heat_flux_at_sea_floor",
-            "model_variable_units": {
-                "ht": "m"
-            }
+            "CF standard Name": "upward_geothermal_heat_flux_at_sea_floor"
         },
         "hfibthermds2d": {
             "dimensions": {
@@ -5110,18 +5112,21 @@
             },
             "units": "%",
             "positive": null,
-            "model_variables": [
-                "land_ocean_mask"
-            ],
+            "model_variables": [],
             "calculation": {
                 "type": "formula",
                 "operation": "multiply",
                 "args": [
-                    "land_ocean_mask",
+                    {
+                        "operation": "load_ressource_data",
+                        "args": [
+                            {"literal": "land_ocean_mask_ACCESS-ESM.nc"},
+                            {"literal": "land_ocean_mask"}
+                        ]
+                    },
                     100
                 ]
             },
-            "ressource_file": "land_ocean_mask_ACCESS-ESM.nc",
             "CF standard Name": "sea_area_fraction"
         },
         "tauuo": {

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1767,6 +1767,59 @@ class TestPreprocessAuxTimeCoords:
         assert "cSoil" in base_cmoriser.ds.data_vars
 
 
+class TestLoadDatasetEmptyInputPaths:
+    """Tests for the early-return branch in load_dataset when input_paths is [].
+
+    Self-contained calculations (e.g. mrsofc with model_variables: []) set
+    input_paths to an empty list.  load_dataset must initialise self.ds to an
+    empty xr.Dataset and return immediately, without touching the filesystem.
+    """
+
+    @pytest.fixture
+    def mock_vocab(self):
+        vocab = Mock()
+        vocab.__class__.__name__ = "CMIP6Vocabulary"
+        return vocab
+
+    @pytest.fixture
+    def mock_mapping(self):
+        return {
+            "CF standard Name": "soil_moisture_content_at_field_capacity",
+            "units": "kg m-2",
+            "dimensions": {"lat": "lat", "lon": "lon"},
+            "positive": None,
+        }
+
+    @pytest.fixture
+    def empty_path_cmoriser(self, mock_vocab, mock_mapping, tmp_path):
+        return CMORiser(
+            input_paths=[],
+            output_path=str(tmp_path),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="fx.mrsofc",
+            enable_chunking=False,
+        )
+
+    @pytest.mark.unit
+    def test_load_dataset_returns_empty_dataset_when_no_input_paths(
+        self, empty_path_cmoriser
+    ):
+        """load_dataset must set self.ds to an empty Dataset for self-contained calcs."""
+        empty_path_cmoriser.load_dataset(required_vars=set())
+        assert isinstance(empty_path_cmoriser.ds, xr.Dataset)
+        assert len(empty_path_cmoriser.ds.data_vars) == 0
+
+    @pytest.mark.unit
+    def test_load_dataset_does_not_touch_filesystem_when_no_input_paths(
+        self, empty_path_cmoriser
+    ):
+        """load_dataset must not attempt to open any file when input_paths is empty."""
+        with patch("access_moppy.base.xr.open_mfdataset") as mock_open:
+            empty_path_cmoriser.load_dataset(required_vars=set())
+        mock_open.assert_not_called()
+
+
 class TestLoadDatasetFxFile:
     """Tests for the time-independent (fx) file loading branch of load_dataset.
 

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -430,6 +430,42 @@ class TestACCESSESMCMORiser:
                 )
 
     @pytest.mark.unit
+    def test_empty_model_variables_allows_no_input_data(self, valid_config, temp_dir):
+        """When model_variables is [] no input_data is required; input_paths stays empty."""
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.CMIP6Vocabulary") as mock_vocab,
+            patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
+        ):
+            mock_load.return_value = {
+                "mrsofc": {
+                    "model_variables": [],
+                    "calculation": {
+                        "type": "formula",
+                        "operation": "load_ressource_data",
+                        "args": [
+                            {"literal": "fx.mrsofc_ACCESS-ESM.nc"},
+                            {"literal": "mrsofc"},
+                        ],
+                    },
+                    "units": "kg m-2",
+                }
+            }
+            mock_vocab.return_value = MagicMock()
+            mock_instance = MagicMock()
+            mock_instance.ds = xr.Dataset()
+            mock_atmos.return_value = mock_instance
+
+            cmoriser = ACCESS_ESM_CMORiser(
+                compound_name="Lmon.mrsofc",
+                output_path=temp_dir,
+                **valid_config,
+            )
+
+            # No input paths — the calculation is self-contained
+            assert cmoriser.input_paths == []
+
+    @pytest.mark.unit
     def test_xarray_input_dataarray_converts_to_dataset_and_disables_validation(
         self, valid_config, temp_dir
     ):

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -414,22 +414,6 @@ class TestACCESSESMCMORiser:
             mock_as_file.assert_called_once_with(mock_resource)
 
     @pytest.mark.unit
-    def test_ressource_file_missing_and_no_input_raises(self, valid_config, temp_dir):
-        """When no input_data is supplied and the mapping has no ressource_file,
-        a ValueError is raised."""
-        with patch("access_moppy.driver.load_model_mappings") as mock_load:
-            mock_load.return_value = {"tas": {"units": "K"}}
-
-            with pytest.raises(
-                ValueError, match="Must specify either 'input_data' or 'input_paths'"
-            ):
-                ACCESS_ESM_CMORiser(
-                    compound_name="Amon.tas",
-                    output_path=temp_dir,
-                    **valid_config,
-                )
-
-    @pytest.mark.unit
     def test_empty_model_variables_allows_no_input_data(self, valid_config, temp_dir):
         """When model_variables is [] no input_data is required; input_paths stays empty."""
         with (


### PR DESCRIPTION
## Summary

Follows on from #357. Eliminates the dual convention for loading bundled resource files by consolidating everything under the `load_ressource_data` nested-expression pattern.

### Problem

After #357 there were two different ways to declare "I need data from the resources folder" in a mapping:

1. **`ressource_file` side-channel key** (old) — driver.py detects it, overrides `input_data`, and loads the whole file as the primary dataset.
2. **`load_ressource_data` nested expression** (new, from #357) — declared inline in the `calculation.args`, evaluated lazily at derivation time.

Having both caused duplicated implementation logic and ambiguity for future contributors.

### Changes

#### `mappings/ACCESS-ESM1.6_mappings.json`

Five entries converted from `ressource_file` + `model_variables:[var]` to `model_variables:[]` + `load_ressource_data` nested expression:

| Variable | Resource file | Before | After |
|---|---|---|---|
| `mrsofc` | `fx.mrsofc_ACCESS-ESM.nc` | `direct` + `ressource_file` | top-level `load_ressource_data` |
| `areacello` | `fx.areacello_ACCESS-ESM.nc` | `direct` + `ressource_file` | top-level `load_ressource_data` |
| `deptho` | `ocean-2d-ht.nc` | `drop_time_axis(ht)` + `ressource_file` | `drop_time_axis(load_ressource_data(...))` |
| `hfgeou` | `ocean-2d-ht.nc` | `calc_hfgeou(ht)` + `ressource_file` | `calc_hfgeou(load_ressource_data(...))` |
| `sftof` | `land_ocean_mask_ACCESS-ESM.nc` | `multiply(land_ocean_mask, 100)` + `ressource_file` | `multiply(load_ressource_data(...), 100)` |

> `zfull` is intentionally left with `ressource_file` because its `dataset_function` calculation operates on the full loaded dataset and cannot use a nested expression.

#### `base.py`

`load_dataset()` now returns early with an empty `xr.Dataset()` when `input_paths` is `[]`, so self-contained formula calculations don't attempt to open files.

#### `driver.py`

The "no input needed" check is extended to cover `model_variables: []` (in addition to the existing `"type": "internal"` case). The `ressource_file` fallback path is retained for `zfull`.

#### `tests/unit/test_driver.py`

Added `test_empty_model_variables_allows_no_input_data` to cover the new path.