### PR TITLE
merge ilamb-tree-generator to Moppy

### DIFF
--- a/docs/source/CMORise_ILAMB_workflow.md
+++ b/docs/source/CMORise_ILAMB_workflow.md
@@ -351,45 +351,92 @@ output_folder/
 
 ## Preparing ILAMB-Ready Files
 
-ILAMB does **not** use CMIP6 DRS directory trees. It expects each variable to
-be a single file named `<variable>.nc` inside a flat directory, which is then
-set as `ILAMB_ROOT`.
+ILAMB requires a specific directory layout called **ILAMB-ROOT**:
 
-Run the following command after all batch jobs complete. Set `OUTPUT_FOLDER`
-to your actual output path, then copy-paste the block as-is:
-
-```bash
-OUTPUT_FOLDER="/scratch/tm70/$USER/ilamb_cmorised/historical-02"
-
-mkdir -p "${OUTPUT_FOLDER}/ILAMB_format"
-for f in "${OUTPUT_FOLDER}"/*.nc; do
-    fname="${f##*/}"
-    var="${fname%%_*}"
-    ln -sf "../${fname}" "${OUTPUT_FOLDER}/ILAMB_format/${var}.nc" && echo "  ${var}.nc"
-done
 ```
+ILAMB_ROOT/
+├── DATA/          → observational reference datasets
+└── MODELS/
+    └── <model_name>/
+        ├── tas.nc → <CMORised file>
+        ├── pr.nc  → <CMORised file>
+        └── ...
+```
+
+Use `create_ilamb_data_tree` to build this layout in one call after all batch
+jobs complete:
+
+```python
+from access_moppy.utilities import create_ilamb_data_tree
+
+create_ilamb_data_tree(
+    output_dir="/scratch/tm70/$USER/ilamb_cmorised/historical-02",
+    ilamb_root="/scratch/tm70/$USER/ilamb_root",
+    model_name="ACCESS-ESM1-6",
+)
+```
+
+This call:
+
+1. Creates `ILAMB_ROOT/DATA` as a symlink to the NCI observational dataset
+   replica at `/g/data/ct11/access-nri/replicas/ILAMB` (default).
+2. Creates `ILAMB_ROOT/MODELS/ACCESS-ESM1-6/` and populates it with
+   `<variable>.nc` symlinks pointing at the CMORised files in `output_dir`.
 
 The resulting layout:
 
 ```
-output_folder/
-├── pr_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
-├── tas_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
-├── gpp_Lmon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
-├── ...
-├── cmor_tasks.db
-└── ILAMB_format/
-    ├── pr.nc     -> ../pr_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
-    ├── tas.nc    -> ../tas_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
-    ├── gpp.nc    -> ../gpp_Lmon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
-    └── ...
+/scratch/tm70/$USER/ilamb_root/
+├── DATA  →  /g/data/ct11/access-nri/replicas/ILAMB
+└── MODELS/
+    └── ACCESS-ESM1-6/
+        ├── pr.nc   →  /scratch/tm70/$USER/ilamb_cmorised/historical-02/pr_Amon_…nc
+        ├── tas.nc  →  /scratch/tm70/$USER/ilamb_cmorised/historical-02/tas_Amon_…nc
+        ├── gpp.nc  →  /scratch/tm70/$USER/ilamb_cmorised/historical-02/gpp_Lmon_…nc
+        └── ...
 ```
 
-Point ILAMB at the `ILAMB_format` subdirectory in `ilamb-setup.txt`:
+### Optional: custom observational source
 
+To point `DATA` at a different observational archive, pass `obs_source`:
+
+```python
+create_ilamb_data_tree(
+    output_dir="/scratch/tm70/$USER/ilamb_cmorised/historical-02",
+    ilamb_root="/scratch/tm70/$USER/ilamb_root",
+    model_name="ACCESS-ESM1-6",
+    obs_source="/path/to/custom/obs",
+)
 ```
-ACCESS-ESM1_6_historical_Moppy_cmorised, /scratch/tm70/$USER/ilamb_variables/batch-processing2/ilamb_format, CMIP6
+
+### Optional: step-by-step control
+
+To create the `DATA` link and model symlinks independently:
+
+```python
+from access_moppy.utilities import (
+    create_ilamb_observational_symlinks,
+    create_ilamb_model_symlinks,
+)
+
+# Step 1 – observational data
+create_ilamb_observational_symlinks(
+    ilamb_root="/scratch/tm70/$USER/ilamb_root",
+)
+
+# Step 2 – model output
+create_ilamb_model_symlinks(
+    output_dir="/scratch/tm70/$USER/ilamb_cmorised/historical-02",
+    ilamb_dir="/scratch/tm70/$USER/ilamb_root/MODELS/ACCESS-ESM1-6",
+)
 ```
+
+Set `ILAMB_ROOT` to the root directory when running ILAMB:
+
+```bash
+export ILAMB_ROOT=/scratch/tm70/$USER/ilamb_root
+```
+
 ---
 
 After set-up, run ilamb with following command.

--- a/docs/source/CMORise_ILAMB_workflow.md
+++ b/docs/source/CMORise_ILAMB_workflow.md
@@ -36,9 +36,11 @@ used to standardise variable names, units, and metadata — not for data submiss
 
 | Requirement | Details |
 |-------------|---------|
-| NCI project access | `p73`, `tm70`|
+| NCI project access | `p73`, `xp65`|
 | Software | `conda/analysis3-26.04` via `xp65` modules |
 | Scheduler | PBS Pro (Gadi) |
+
+> **Note:** `tm70` appears in the example paths throughout this guide (e.g. `/scratch/tm70/$USER/…`) but is **not** a required prerequisite. Substitute your own project code where appropriate.
 
 ---
 

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -2983,7 +2983,7 @@ def generate_both_cmip_mappings(
     return forward_mapping, reverse_mapping
 
 
-def create_ilamb_symlinks(
+def create_ilamb_model_symlinks(
     output_dir: Union[str, Path],
     ilamb_dir: Union[str, Path],
     drs_format: str = "auto",
@@ -3024,10 +3024,10 @@ def create_ilamb_symlinks(
 
     Examples:
         >>> # Flat DRS output
-        >>> links = create_ilamb_symlinks("/path/to/flat_output", "/path/to/ilamb_input")
+        >>> links = create_ilamb_model_symlinks("/path/to/flat_output", "/path/to/ilamb_input")
 
         >>> # CMIP6 DRS output
-        >>> links = create_ilamb_symlinks(
+        >>> links = create_ilamb_model_symlinks(
         ...     "/path/to/drs_root",
         ...     "/path/to/ilamb_input",
         ...     drs_format="cmip6",
@@ -3100,6 +3100,143 @@ def create_ilamb_symlinks(
         created[variable_id] = link_path
 
     return created
+
+
+def create_ilamb_observational_symlinks(
+    ilamb_root: Union[str, Path],
+    obs_source: Union[str, Path] = "/g/data/ct11/access-nri/replicas/ILAMB",
+    overwrite: bool = False,
+) -> Path:
+    """
+    Create the ``DATA`` symlink inside an ILAMB-ROOT directory.
+
+    ILAMB expects observational datasets to be located under
+    ``<ILAMB_ROOT>/DATA``.  This function creates that directory entry as a
+    symbolic link pointing to *obs_source*.
+
+    Args:
+        ilamb_root: Root of the ILAMB tree (created if absent).
+        obs_source: Path to the observational data directory.  Defaults to
+            ``/g/data/ct11/access-nri/replicas/ILAMB``.
+        overwrite: Replace an existing ``DATA`` symlink when ``True``.
+            Default ``False``.
+
+    Returns:
+        The :class:`~pathlib.Path` of the ``DATA`` entry inside *ilamb_root*.
+
+    Raises:
+        FileNotFoundError: If *obs_source* does not exist.
+        FileExistsError: If ``DATA`` already exists and *overwrite* is
+            ``False``.
+
+    Examples:
+        >>> create_ilamb_observational_symlinks("/path/to/ilamb_root")
+
+        >>> create_ilamb_observational_symlinks(
+        ...     "/path/to/ilamb_root",
+        ...     obs_source="/custom/obs/path",
+        ...     overwrite=True,
+        ... )
+    """
+    ilamb_root = Path(ilamb_root).resolve()
+    obs_source = Path(obs_source).resolve()
+
+    if not obs_source.exists():
+        raise FileNotFoundError(
+            f"Observational data source does not exist: {obs_source}"
+        )
+
+    ilamb_root.mkdir(parents=True, exist_ok=True)
+
+    data_link = ilamb_root / "DATA"
+
+    if data_link.exists() or data_link.is_symlink():
+        if overwrite:
+            if data_link.is_symlink() or data_link.is_file():
+                data_link.unlink()
+            else:
+                import shutil
+
+                shutil.rmtree(data_link)
+        else:
+            raise FileExistsError(
+                f"DATA already exists at {data_link}. Use overwrite=True to replace it."
+            )
+
+    data_link.symlink_to(obs_source, target_is_directory=True)
+    return data_link
+
+
+def create_ilamb_data_tree(
+    output_dir: Union[str, Path],
+    ilamb_root: Union[str, Path],
+    model_name: str,
+    obs_source: Union[str, Path] = "/g/data/ct11/access-nri/replicas/ILAMB",
+    drs_format: str = "auto",
+    overwrite: bool = False,
+) -> Dict[str, Path]:
+    """
+    Build a complete ILAMB-ROOT directory tree for a single model.
+
+    Creates the standard two-level structure expected by ILAMB:
+
+    .. code-block:: text
+
+        <ilamb_root>/
+            DATA  ->  <obs_source>
+            MODELS/
+                <model_name>/
+                    <variable_id>.nc  ->  <original file>
+
+    Calls :func:`create_ilamb_observational_symlinks` to set up ``DATA`` and
+    :func:`create_ilamb_model_symlinks` to populate ``MODELS/<model_name>``.
+
+    Args:
+        output_dir: Root directory of MOPPY output to scan for model files.
+        ilamb_root: Root of the ILAMB tree (created if absent).
+        model_name: Name used for the model sub-directory under
+            ``<ilamb_root>/MODELS/``.
+        obs_source: Path to observational data; forwarded to
+            :func:`create_ilamb_observational_symlinks`.
+        drs_format: ``'flat'``, ``'cmip6'``, or ``'auto'`` (default);
+            forwarded to :func:`create_ilamb_model_symlinks`.
+        overwrite: Replace existing symlinks when ``True``; applies to both
+            the ``DATA`` link and the per-variable model links.
+
+    Returns:
+        Mapping of *variable_id* to the :class:`~pathlib.Path` of each
+        model symlink created (same as the return value of
+        :func:`create_ilamb_model_symlinks`).
+
+    Raises:
+        FileNotFoundError: If *output_dir* or *obs_source* does not exist.
+        FileExistsError: If the ``DATA`` symlink already exists and
+            *overwrite* is ``False``.
+        ValueError: If *drs_format* is not recognised, or if multiple source
+            files are found for the same variable.
+
+    Examples:
+        >>> create_ilamb_data_tree(
+        ...     output_dir="/path/to/moppy_output",
+        ...     ilamb_root="/path/to/ilamb_root",
+        ...     model_name="ACCESS-ESM1-6",
+        ... )
+    """
+    ilamb_root = Path(ilamb_root).resolve()
+    model_dir = ilamb_root / "MODELS" / model_name
+
+    create_ilamb_observational_symlinks(
+        ilamb_root=ilamb_root,
+        obs_source=obs_source,
+        overwrite=overwrite,
+    )
+
+    return create_ilamb_model_symlinks(
+        output_dir=output_dir,
+        ilamb_dir=model_dir,
+        drs_format=drs_format,
+        overwrite=overwrite,
+    )
 
 
 def check_for_updates() -> None:

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -18,7 +18,9 @@ from access_moppy.utilities import (
     _infer_frequency,
     _model_mapping_file_exists,
     calculate_time_bounds,
-    create_ilamb_symlinks,
+    create_ilamb_data_tree,
+    create_ilamb_model_symlinks,
+    create_ilamb_observational_symlinks,
     detect_time_frequency_lazy,
     get_requested_variables_from_data_request,
 )
@@ -614,14 +616,14 @@ def _make_cmip6(root, *variable_ids):
 
 
 class TestCreateIlambSymlinksFlat:
-    """Tests for create_ilamb_symlinks with flat DRS output."""
+    """Tests for create_ilamb_model_symlinks with flat DRS output."""
 
     def test_creates_symlinks_for_all_variables(self, tmp_path):
         output_dir = tmp_path / "output"
         output_dir.mkdir()
         _make_flat(output_dir, "tas", "pr")
 
-        created = create_ilamb_symlinks(
+        created = create_ilamb_model_symlinks(
             output_dir, tmp_path / "ilamb", drs_format="flat"
         )
 
@@ -634,7 +636,7 @@ class TestCreateIlambSymlinksFlat:
         output_dir.mkdir()
         src_map = _make_flat(output_dir, "tas")
 
-        created = create_ilamb_symlinks(
+        created = create_ilamb_model_symlinks(
             output_dir, tmp_path / "ilamb", drs_format="flat"
         )
 
@@ -646,7 +648,7 @@ class TestCreateIlambSymlinksFlat:
         _make_flat(output_dir, "tas")
         ilamb_dir = tmp_path / "nested" / "ilamb"
 
-        create_ilamb_symlinks(output_dir, ilamb_dir, drs_format="flat")
+        create_ilamb_model_symlinks(output_dir, ilamb_dir, drs_format="flat")
 
         assert ilamb_dir.is_dir()
 
@@ -656,7 +658,7 @@ class TestCreateIlambSymlinksFlat:
         _make_flat(output_dir, "tos")
         ilamb_dir = tmp_path / "ilamb"
 
-        created = create_ilamb_symlinks(output_dir, ilamb_dir, drs_format="flat")
+        created = create_ilamb_model_symlinks(output_dir, ilamb_dir, drs_format="flat")
 
         assert created["tos"] == ilamb_dir / "tos.nc"
 
@@ -665,7 +667,7 @@ class TestCreateIlambSymlinksFlat:
         output_dir.mkdir()
         (output_dir / "areacella_fx_ACCESS-ESM1-5_historical_r1i1p1f1_gn.nc").touch()
 
-        created = create_ilamb_symlinks(
+        created = create_ilamb_model_symlinks(
             output_dir, tmp_path / "ilamb", drs_format="flat"
         )
 
@@ -673,14 +675,14 @@ class TestCreateIlambSymlinksFlat:
 
 
 class TestCreateIlambSymlinksCmip6:
-    """Tests for create_ilamb_symlinks with CMIP6 DRS output."""
+    """Tests for create_ilamb_model_symlinks with CMIP6 DRS output."""
 
     def test_creates_symlinks_from_hierarchy(self, tmp_path):
         output_dir = tmp_path / "drs_root"
         _make_cmip6(output_dir, "tas", "pr")
         ilamb_dir = tmp_path / "ilamb"
 
-        created = create_ilamb_symlinks(output_dir, ilamb_dir, drs_format="cmip6")
+        created = create_ilamb_model_symlinks(output_dir, ilamb_dir, drs_format="cmip6")
 
         assert set(created.keys()) == {"tas", "pr"}
         assert (ilamb_dir / "tas.nc").is_symlink()
@@ -691,7 +693,7 @@ class TestCreateIlambSymlinksCmip6:
         src_map = _make_cmip6(output_dir, "tas")
         ilamb_dir = tmp_path / "ilamb"
 
-        created = create_ilamb_symlinks(output_dir, ilamb_dir, drs_format="cmip6")
+        created = create_ilamb_model_symlinks(output_dir, ilamb_dir, drs_format="cmip6")
 
         assert created["tas"].resolve() == src_map["tas"].resolve()
 
@@ -701,8 +703,8 @@ class TestCreateIlambSymlinksCmip6:
         _make_cmip6(output_dir, "tas")
         ilamb_dir = output_dir / "ilamb"  # deliberately nested inside output_dir
 
-        create_ilamb_symlinks(output_dir, ilamb_dir, drs_format="cmip6")
-        created2 = create_ilamb_symlinks(
+        create_ilamb_model_symlinks(output_dir, ilamb_dir, drs_format="cmip6")
+        created2 = create_ilamb_model_symlinks(
             output_dir, ilamb_dir, drs_format="cmip6", overwrite=True
         )
 
@@ -717,7 +719,7 @@ class TestCreateIlambSymlinksAutoDetect:
         output_dir.mkdir()
         _make_flat(output_dir, "tas")
 
-        created = create_ilamb_symlinks(output_dir, tmp_path / "ilamb")
+        created = create_ilamb_model_symlinks(output_dir, tmp_path / "ilamb")
 
         assert "tas" in created
 
@@ -725,7 +727,7 @@ class TestCreateIlambSymlinksAutoDetect:
         output_dir = tmp_path / "drs_root"
         _make_cmip6(output_dir, "tas")
 
-        created = create_ilamb_symlinks(output_dir, tmp_path / "ilamb")
+        created = create_ilamb_model_symlinks(output_dir, tmp_path / "ilamb")
 
         assert "tas" in created
 
@@ -735,24 +737,26 @@ class TestCreateIlambSymlinksAutoDetect:
         output_dir.mkdir()
         _make_flat(output_dir, "pr")
 
-        created = create_ilamb_symlinks(output_dir, tmp_path / "ilamb")
+        created = create_ilamb_model_symlinks(output_dir, tmp_path / "ilamb")
 
         assert "pr" in created
 
 
 class TestCreateIlambSymlinksErrors:
-    """Tests for error handling in create_ilamb_symlinks."""
+    """Tests for error handling in create_ilamb_model_symlinks."""
 
     def test_missing_output_dir_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError, match="does not exist"):
-            create_ilamb_symlinks(tmp_path / "nonexistent", tmp_path / "ilamb")
+            create_ilamb_model_symlinks(tmp_path / "nonexistent", tmp_path / "ilamb")
 
     def test_invalid_drs_format_raises(self, tmp_path):
         output_dir = tmp_path / "output"
         output_dir.mkdir()
 
         with pytest.raises(ValueError, match="Invalid drs_format"):
-            create_ilamb_symlinks(output_dir, tmp_path / "ilamb", drs_format="drs7")
+            create_ilamb_model_symlinks(
+                output_dir, tmp_path / "ilamb", drs_format="drs7"
+            )
 
     def test_multiple_files_same_variable_raises(self, tmp_path):
         output_dir = tmp_path / "output"
@@ -761,7 +765,9 @@ class TestCreateIlambSymlinksErrors:
         _make_flat(output_dir, "tas", time_range="190101-200012")
 
         with pytest.raises(ValueError, match="Multiple source files"):
-            create_ilamb_symlinks(output_dir, tmp_path / "ilamb", drs_format="flat")
+            create_ilamb_model_symlinks(
+                output_dir, tmp_path / "ilamb", drs_format="flat"
+            )
 
     def test_error_message_lists_conflicting_files(self, tmp_path):
         output_dir = tmp_path / "output"
@@ -770,14 +776,16 @@ class TestCreateIlambSymlinksErrors:
         _make_flat(output_dir, "pr", time_range="190101-200012")
 
         with pytest.raises(ValueError, match="pr"):
-            create_ilamb_symlinks(output_dir, tmp_path / "ilamb", drs_format="flat")
+            create_ilamb_model_symlinks(
+                output_dir, tmp_path / "ilamb", drs_format="flat"
+            )
 
     def test_empty_directory_warns_and_returns_empty(self, tmp_path):
         output_dir = tmp_path / "output"
         output_dir.mkdir()
 
         with pytest.warns(UserWarning, match="No .nc files"):
-            result = create_ilamb_symlinks(
+            result = create_ilamb_model_symlinks(
                 output_dir, tmp_path / "ilamb", drs_format="flat"
             )
 
@@ -806,7 +814,7 @@ class TestCreateIlambSymlinksOverwrite:
         )
 
         with pytest.warns(UserWarning, match="already exists"):
-            created = create_ilamb_symlinks(
+            created = create_ilamb_model_symlinks(
                 output_dir, ilamb_dir, drs_format="flat", overwrite=False
             )
 
@@ -818,11 +826,175 @@ class TestCreateIlambSymlinksOverwrite:
             tmp_path
         )
 
-        created = create_ilamb_symlinks(
+        created = create_ilamb_model_symlinks(
             output_dir, ilamb_dir, drs_format="flat", overwrite=True
         )
 
         assert "tas" in created
+
+
+class TestCreateIlambObservationalSymlinks:
+    """Tests for create_ilamb_observational_symlinks."""
+
+    def test_creates_data_symlink(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        ilamb_root = tmp_path / "ilamb_root"
+
+        create_ilamb_observational_symlinks(ilamb_root, obs_source=obs_source)
+
+        assert (ilamb_root / "DATA").is_symlink()
+
+    def test_symlink_points_to_obs_source(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        ilamb_root = tmp_path / "ilamb_root"
+
+        create_ilamb_observational_symlinks(ilamb_root, obs_source=obs_source)
+
+        assert (ilamb_root / "DATA").resolve() == obs_source.resolve()
+
+    def test_returns_data_link_path(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        ilamb_root = tmp_path / "ilamb_root"
+
+        result = create_ilamb_observational_symlinks(ilamb_root, obs_source=obs_source)
+
+        assert result == ilamb_root / "DATA"
+
+    def test_ilamb_root_created_if_absent(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        ilamb_root = tmp_path / "nested" / "ilamb_root"
+
+        create_ilamb_observational_symlinks(ilamb_root, obs_source=obs_source)
+
+        assert ilamb_root.is_dir()
+
+    def test_missing_obs_source_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            create_ilamb_observational_symlinks(
+                tmp_path / "ilamb_root", obs_source=tmp_path / "nonexistent"
+            )
+
+    def test_existing_data_raises_by_default(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        ilamb_root = tmp_path / "ilamb_root"
+        create_ilamb_observational_symlinks(ilamb_root, obs_source=obs_source)
+
+        with pytest.raises(FileExistsError, match="DATA already exists"):
+            create_ilamb_observational_symlinks(ilamb_root, obs_source=obs_source)
+
+    def test_overwrite_replaces_existing_symlink(self, tmp_path):
+        old_obs = tmp_path / "old_obs"
+        old_obs.mkdir()
+        new_obs = tmp_path / "new_obs"
+        new_obs.mkdir()
+        ilamb_root = tmp_path / "ilamb_root"
+        create_ilamb_observational_symlinks(ilamb_root, obs_source=old_obs)
+
+        create_ilamb_observational_symlinks(
+            ilamb_root, obs_source=new_obs, overwrite=True
+        )
+
+        assert (ilamb_root / "DATA").resolve() == new_obs.resolve()
+
+
+class TestCreateIlambDataTree:
+    """Tests for create_ilamb_data_tree."""
+
+    def test_creates_data_symlink(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        _make_flat(output_dir, "tas")
+
+        create_ilamb_data_tree(
+            output_dir, tmp_path / "ilamb_root", "MyModel", obs_source=obs_source
+        )
+
+        assert (tmp_path / "ilamb_root" / "DATA").is_symlink()
+        assert (tmp_path / "ilamb_root" / "DATA").resolve() == obs_source.resolve()
+
+    def test_creates_model_symlinks_under_model_name(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        _make_flat(output_dir, "tas", "pr")
+
+        create_ilamb_data_tree(
+            output_dir, tmp_path / "ilamb_root", "ACCESS-ESM1-6", obs_source=obs_source
+        )
+
+        model_dir = tmp_path / "ilamb_root" / "MODELS" / "ACCESS-ESM1-6"
+        assert (model_dir / "tas.nc").is_symlink()
+        assert (model_dir / "pr.nc").is_symlink()
+
+    def test_returns_variable_symlink_dict(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        _make_flat(output_dir, "tas")
+
+        result = create_ilamb_data_tree(
+            output_dir, tmp_path / "ilamb_root", "MyModel", obs_source=obs_source
+        )
+
+        assert "tas" in result
+        assert (
+            result["tas"] == tmp_path / "ilamb_root" / "MODELS" / "MyModel" / "tas.nc"
+        )
+
+    def test_forwards_drs_format(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        output_dir = tmp_path / "drs_root"
+        _make_cmip6(output_dir, "tas")
+
+        result = create_ilamb_data_tree(
+            output_dir,
+            tmp_path / "ilamb_root",
+            "MyModel",
+            obs_source=obs_source,
+            drs_format="cmip6",
+        )
+
+        assert "tas" in result
+
+    def test_overwrite_forwarded_to_both(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        _make_flat(output_dir, "tas")
+        ilamb_root = tmp_path / "ilamb_root"
+
+        create_ilamb_data_tree(output_dir, ilamb_root, "MyModel", obs_source=obs_source)
+        # Second call with overwrite=True should not raise
+        create_ilamb_data_tree(
+            output_dir, ilamb_root, "MyModel", obs_source=obs_source, overwrite=True
+        )
+
+        assert (ilamb_root / "DATA").resolve() == obs_source.resolve()
+        assert (ilamb_root / "MODELS" / "MyModel" / "tas.nc").is_symlink()
+
+    def test_missing_obs_source_raises(self, tmp_path):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        _make_flat(output_dir, "tas")
+
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            create_ilamb_data_tree(
+                output_dir,
+                tmp_path / "ilamb_root",
+                "MyModel",
+                obs_source=tmp_path / "nonexistent",
+            )
 
 
 class TestModelMappingFileExists:

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -901,6 +901,24 @@ class TestCreateIlambObservationalSymlinks:
 
         assert (ilamb_root / "DATA").resolve() == new_obs.resolve()
 
+    def test_overwrite_replaces_real_directory(self, tmp_path):
+        obs_source = tmp_path / "obs"
+        obs_source.mkdir()
+        new_obs = tmp_path / "new_obs"
+        new_obs.mkdir()
+        ilamb_root = tmp_path / "ilamb_root"
+        ilamb_root.mkdir()
+        # Create DATA as a real directory (not a symlink)
+        real_data_dir = ilamb_root / "DATA"
+        real_data_dir.mkdir()
+
+        create_ilamb_observational_symlinks(
+            ilamb_root, obs_source=new_obs, overwrite=True
+        )
+
+        assert (ilamb_root / "DATA").is_symlink()
+        assert (ilamb_root / "DATA").resolve() == new_obs.resolve()
+
 
 class TestCreateIlambDataTree:
     """Tests for create_ilamb_data_tree."""


### PR DESCRIPTION
## Summary

This PR extends the ILAMB utility functions in `utilities.py` to support building
a complete ILAMB-ROOT directory tree, and updates the workflow documentation accordingly.

---

## Changes

### `src/access_moppy/utilities.py`

- **Renamed** `create_ilamb_symlinks` → `create_ilamb_model_symlinks` for clarity
- **Added** `create_ilamb_observational_symlinks`: creates `ILAMB_ROOT/DATA` as a
  symlink pointing to an observational dataset directory (default:
  `/g/data/ct11/access-nri/replicas/ILAMB`)
- **Added** `create_ilamb_data_tree`: convenience wrapper that calls both
  `create_ilamb_observational_symlinks` and `create_ilamb_model_symlinks` to build
  the full ILAMB-ROOT layout in one call:

```
ILAMB_ROOT/
├── DATA  →  <obs_source>
└── MODELS/
    └── <model_name>/
        ├── tas.nc  →  <CMORised file>
        ├── pr.nc   →  <CMORised file>
        └── ...
```

Example usage:

```python
from access_moppy.utilities import create_ilamb_data_tree

create_ilamb_data_tree(
    output_dir="/scratch/tm70/$USER/ilamb_cmorised/historical-02",
    ilamb_root="/scratch/tm70/$USER/ilamb_root",
    model_name="ACCESS-ESM1-6",
)
```

---

### `tests/unit/test_utilities.py`

- Updated all references from `create_ilamb_symlinks` to `create_ilamb_model_symlinks`
- **Added** `TestCreateIlambObservationalSymlinks` (7 tests):
  - Symlink creation and target resolution
  - Auto-creation of `ilamb_root` if absent
  - `FileNotFoundError` when `obs_source` does not exist
  - `FileExistsError` when `DATA` already exists and `overwrite=False`
  - Replacement of existing symlink when `overwrite=True`
- **Added** `TestCreateIlambDataTree` (6 tests):
  - `DATA` and model variable symlink creation
  - Return value matches `create_ilamb_model_symlinks` output
  - `drs_format` forwarded correctly
  - `overwrite` applied to both `DATA` and model symlinks
  - `FileNotFoundError` when `obs_source` does not exist

---

### `docs/source/CMORise_ILAMB_workflow.md`

Replaced the bash-script-based **Preparing ILAMB-Ready Files** section with the
Python API workflow using `create_ilamb_data_tree`. The updated section covers:

- The expected ILAMB-ROOT directory structure
- One-call usage via `create_ilamb_data_tree`
- Optional custom `obs_source`
- Step-by-step usage of `create_ilamb_observational_symlinks` and
  `create_ilamb_model_symlinks` independently

---