### PR TITLE
Fix/sqlite delete journal mode lustre

### DIFF
--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -11,13 +11,18 @@ class TaskTracker:
             db_path = Path.home() / ".moppy" / "db" / "cmor_tasks.db"
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path, timeout=30)
         self._init_db()
 
     def _init_db(self):
-        # Enable WAL mode for better concurrent access
-        self.conn.execute("PRAGMA journal_mode=WAL")
-        self.conn.execute("PRAGMA synchronous=NORMAL")
+        # DELETE journal mode uses fcntl() file locks instead of mmap'd .db-shm,
+        # which is required for correctness on Lustre (Gadi /scratch, /g/data).
+        # WAL mode's .db-shm relies on cross-process shared memory that Lustre
+        # does not guarantee across compute nodes, causing SIGBUS and corruption.
+        self.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")  # flush any existing WAL before switching
+        self.conn.execute("PRAGMA journal_mode=DELETE")
+        self.conn.execute("PRAGMA synchronous=FULL")  # FULL required on network filesystems
+        self.conn.execute("PRAGMA busy_timeout=30000")  # wait up to 30s on lock contention
         with self.conn:
             self.conn.execute(
                 """

--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -105,6 +105,9 @@ class TaskTracker:
     def is_done(self, variable: str, experiment_id: str) -> bool:
         return self.get_status(variable, experiment_id) == "completed"
 
+    def _db_execute(self, query, params=()):
+        return self.conn.execute(query, params)
+
     def _execute_with_retry(self, query, params=(), max_retries=5):
         # Retries on two transient Lustre errors:
         # - "database is locked": another process holds the write lock
@@ -114,7 +117,7 @@ class TaskTracker:
         for attempt in range(max_retries):
             try:
                 with self.conn:
-                    return self.conn.execute(query, params)
+                    return self._db_execute(query, params)
             except sqlite3.OperationalError as e:
                 if (
                     any(msg in str(e) for msg in _TRANSIENT)

--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -21,7 +21,7 @@ class TaskTracker:
         # does not guarantee across compute nodes, causing SIGBUS and corruption.
         self.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")  # flush any existing WAL before switching
         self.conn.execute("PRAGMA journal_mode=DELETE")
-        self.conn.execute("PRAGMA synchronous=FULL")  # FULL required on network filesystems
+        self.conn.execute("PRAGMA synchronous=NORMAL")  # NORMAL avoids fsync() on database file; safe on Lustre
         self.conn.execute("PRAGMA busy_timeout=30000")  # wait up to 30s on lock contention
         with self.conn:
             self.conn.execute(

--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -15,14 +15,23 @@ class TaskTracker:
         self._init_db()
 
     def _init_db(self):
-        # DELETE journal mode uses fcntl() file locks instead of mmap'd .db-shm,
-        # which is required for correctness on Lustre (Gadi /scratch, /g/data).
-        # WAL mode's .db-shm relies on cross-process shared memory that Lustre
-        # does not guarantee across compute nodes, causing SIGBUS and corruption.
-        self.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")  # flush any existing WAL before switching
+        # On Lustre (Gadi /scratch, /g/data), fsync() intermittently returns
+        # EIO under concurrent PBS job access (SQLITE_IOERR: disk I/O error).
+        # WAL mode also causes SIGBUS via its mmap'd .db-shm.
+        # Fix: DELETE journal mode (journal file survives crashes for recovery)
+        # + synchronous=OFF (no fsync() calls, eliminating the EIO source).
+        # pwrite() to the journal file goes through the OS page cache and does
+        # not trigger EIO; only fsync() does.
+        self.conn.execute(
+            "PRAGMA busy_timeout=30000"
+        )  # set first so subsequent PRAGMAs wait on contention
+        self.conn.execute(
+            "PRAGMA wal_checkpoint(TRUNCATE)"
+        )  # flush any pre-existing WAL before switching
         self.conn.execute("PRAGMA journal_mode=DELETE")
-        self.conn.execute("PRAGMA synchronous=NORMAL")  # NORMAL avoids fsync() on database file; safe on Lustre
-        self.conn.execute("PRAGMA busy_timeout=30000")  # wait up to 30s on lock contention
+        self.conn.execute(
+            "PRAGMA synchronous=OFF"
+        )  # no fsync(); journal file still written for crash recovery
         with self.conn:
             self.conn.execute(
                 """
@@ -42,83 +51,75 @@ class TaskTracker:
             )
 
     def add_task(self, variable: str, experiment_id: str):
-        with self.conn:
-            self.conn.execute(
-                """
-                INSERT OR IGNORE INTO cmor_tasks (variable, experiment_id)
-                VALUES (?, ?)
-                """,
-                (variable, experiment_id),
-            )
+        self._execute_with_retry(
+            """
+            INSERT OR IGNORE INTO cmor_tasks (variable, experiment_id)
+            VALUES (?, ?)
+            """,
+            (variable, experiment_id),
+        )
 
     def mark_running(self, variable: str, experiment_id: str):
-        with self.conn:
-            self.conn.execute(
-                """
-                UPDATE cmor_tasks
-                SET status='running', start_time=datetime('now')
-                WHERE variable=? AND experiment_id=?
-                """,
-                (variable, experiment_id),
-            )
+        self._execute_with_retry(
+            """
+            UPDATE cmor_tasks
+            SET status='running', start_time=datetime('now')
+            WHERE variable=? AND experiment_id=?
+            """,
+            (variable, experiment_id),
+        )
 
     def mark_completed(self, variable: str, experiment_id: str):
-        with self.conn:
-            self.conn.execute(
-                """
-                UPDATE cmor_tasks
-                SET status='completed', end_time=datetime('now'), error_message=NULL
-                WHERE variable=? AND experiment_id=?
-                """,
-                (variable, experiment_id),
-            )
+        self._execute_with_retry(
+            """
+            UPDATE cmor_tasks
+            SET status='completed', end_time=datetime('now'), error_message=NULL
+            WHERE variable=? AND experiment_id=?
+            """,
+            (variable, experiment_id),
+        )
 
     def mark_done(self, variable: str, experiment_id: str):
         """Alias for mark_completed for backward compatibility."""
         self.mark_completed(variable, experiment_id)
 
     def mark_failed(self, variable: str, experiment_id: str, error_message: str):
-        with self.conn:
-            self.conn.execute(
-                """
-                UPDATE cmor_tasks
-                SET status='failed', end_time=datetime('now'), error_message=?
-                WHERE variable=? AND experiment_id=?
-                """,
-                (error_message, variable, experiment_id),
-            )
+        self._execute_with_retry(
+            """
+            UPDATE cmor_tasks
+            SET status='failed', end_time=datetime('now'), error_message=?
+            WHERE variable=? AND experiment_id=?
+            """,
+            (error_message, variable, experiment_id),
+        )
 
     def get_status(self, variable: str, experiment_id: str) -> Optional[str]:
         """Get the status of a task."""
-        cur = self.conn.cursor()
-        cur.execute(
-            """
-            SELECT status FROM cmor_tasks WHERE variable=? AND experiment_id=?
-            """,
+        cur = self._execute_with_retry(
+            "SELECT status FROM cmor_tasks WHERE variable=? AND experiment_id=?",
             (variable, experiment_id),
         )
         row = cur.fetchone()
         return row[0] if row is not None else None
 
     def is_done(self, variable: str, experiment_id: str) -> bool:
-        cur = self.conn.cursor()
-        cur.execute(
-            """
-            SELECT status FROM cmor_tasks WHERE variable=? AND experiment_id=?
-            """,
-            (variable, experiment_id),
-        )
-        row = cur.fetchone()
-        return row is not None and row[0] == "completed"
+        return self.get_status(variable, experiment_id) == "completed"
 
     def _execute_with_retry(self, query, params=(), max_retries=5):
+        # Retries on two transient Lustre errors:
+        # - "database is locked": another process holds the write lock
+        # - "disk I/O error": Lustre metadata server EIO under high concurrency
+        #   (open/unlink of the journal file can transiently fail; retrying succeeds)
+        _TRANSIENT = ("database is locked", "disk I/O error")
         for attempt in range(max_retries):
             try:
                 with self.conn:
                     return self.conn.execute(query, params)
             except sqlite3.OperationalError as e:
-                if "database is locked" in str(e) and attempt < max_retries - 1:
-                    # Exponential backoff with jitter
+                if (
+                    any(msg in str(e) for msg in _TRANSIENT)
+                    and attempt < max_retries - 1
+                ):
                     delay = (2**attempt) + random.uniform(0, 1)
                     time.sleep(delay)
                     continue

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -93,3 +93,26 @@ class TestTaskTracker:
         # Task completed
         tracker.mark_completed("Amon.tas", "historical")
         assert tracker.is_done("Amon.tas", "historical")
+
+    @pytest.mark.unit
+    def test_delete_journal_mode_no_shm_file(self, temp_dir):
+        """Verify DELETE journal mode is active: no .db-shm file must be created.
+
+        WAL mode creates .db-shm via mmap(), which is unsafe on Lustre (Gadi).
+        DELETE mode uses fcntl() locks only and must not produce .db-shm.
+        """
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.conn.close()
+
+        assert not (temp_dir / "test_tracker.db-shm").exists()
+        assert not (temp_dir / "test_tracker.db-wal").exists()
+
+    @pytest.mark.unit
+    def test_journal_mode_is_delete(self, temp_dir):
+        """Verify SQLite reports DELETE journal mode, not WAL."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+        row = tracker.conn.execute("PRAGMA journal_mode").fetchone()
+        assert row[0] == "delete"

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -1,4 +1,5 @@
 import sqlite3
+from unittest.mock import patch
 
 import pytest
 
@@ -118,3 +119,70 @@ class TestTaskTracker:
         tracker = TaskTracker(db_path)
         row = tracker.conn.execute("PRAGMA journal_mode").fetchone()
         assert row[0] == "delete"
+
+    @pytest.mark.unit
+    def test_retry_on_database_locked(self, temp_dir):
+        """Transient 'database is locked' errors are retried with backoff."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+
+        locked_error = sqlite3.OperationalError("database is locked")
+        call_count = 0
+        original = tracker._db_execute
+
+        def flaky(query, params=()):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise locked_error
+            return original(query, params)
+
+        with patch.object(tracker, "_db_execute", side_effect=flaky):
+            with patch("time.sleep"):
+                tracker._execute_with_retry("SELECT 1", ())
+
+        assert call_count == 3  # failed twice, succeeded on third attempt
+
+    @pytest.mark.unit
+    def test_retry_on_disk_io_error(self, temp_dir):
+        """Transient 'disk I/O error' (Lustre EIO) errors are retried."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+
+        io_error = sqlite3.OperationalError("disk I/O error")
+        call_count = 0
+        original = tracker._db_execute
+
+        def flaky(query, params=()):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise io_error
+            return original(query, params)
+
+        with patch.object(tracker, "_db_execute", side_effect=flaky):
+            with patch("time.sleep"):
+                tracker._execute_with_retry("SELECT 1", ())
+
+        assert call_count == 2  # failed once, succeeded on retry
+
+    @pytest.mark.unit
+    def test_no_retry_on_other_operational_error(self, temp_dir):
+        """Non-transient OperationalError (e.g. syntax error) is not retried."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+
+        call_count = 0
+
+        def bad(query, params=()):
+            nonlocal call_count
+            call_count += 1
+            raise sqlite3.OperationalError("no such table: nonexistent")
+
+        with patch.object(tracker, "_db_execute", side_effect=bad):
+            with pytest.raises(sqlite3.OperationalError, match="no such table"):
+                tracker._execute_with_retry("SELECT 1", ())
+
+        assert call_count == 1  # raised immediately, no retry

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -95,11 +95,13 @@ class TestTaskTracker:
         assert tracker.is_done("Amon.tas", "historical")
 
     @pytest.mark.unit
-    def test_delete_journal_mode_no_shm_file(self, temp_dir):
-        """Verify DELETE journal mode is active: no .db-shm file must be created.
+    def test_no_shm_or_wal_files_on_disk(self, temp_dir):
+        """Verify no WAL-mode files (.db-shm, .db-wal) are created.
 
-        WAL mode creates .db-shm via mmap(), which is unsafe on Lustre (Gadi).
-        DELETE mode uses fcntl() locks only and must not produce .db-shm.
+        WAL mode creates .db-shm via mmap(), which causes SIGBUS on Lustre
+        (Gadi) because cross-node mmap coherency is not guaranteed.
+        DELETE+synchronous=OFF uses a journal file for crash recovery but
+        no shared-memory structures.
         """
         db_path = temp_dir / "test_tracker.db"
         tracker = TaskTracker(db_path)
@@ -111,7 +113,7 @@ class TestTaskTracker:
 
     @pytest.mark.unit
     def test_journal_mode_is_delete(self, temp_dir):
-        """Verify SQLite reports DELETE journal mode, not WAL."""
+        """Verify DELETE journal mode: crash-safe journal file, no fsync()."""
         db_path = temp_dir / "test_tracker.db"
         tracker = TaskTracker(db_path)
         row = tracker.conn.execute("PRAGMA journal_mode").fetchone()


### PR DESCRIPTION
Solve #274 

# Fix: SQLite Concurrent Write Crashes on Lustre (Gadi)

## Problem

Batch CMORisation on Gadi failed with two classes of SQLite errors when multiple PBS jobs
accessed the shared tracking database concurrently.

**1. SIGBUS (Bus error, signal 7) in `walIndexReadHdr()`**
```
[gadi-cpu-clx-1361:2245122] Caught signal 7 (Bus error: nonexistent physical address)
2 walIndexReadHdr()  sqlite3.c:0
3 walTryBeginRead()  sqlite3.c:0
4 sqlite3PagerSharedLock()  sqlite3.c:0
```

WAL mode creates a `.db-shm` file accessed via `mmap()` to share the WAL index across
processes. On Lustre (`/scratch`, `/g/data`), `mmap()` cache coherency is not guaranteed
across compute nodes, causing the mapped memory to reference a nonexistent physical address.

**2. `disk I/O error` (SQLITE_IOERR)**

```
Error processing Amon.tas: disk I/O error
```

With 71 PBS jobs starting simultaneously, Lustre's Metadata Server (MDS) intermittently
returns `EIO` under high concurrent load. `fsync()` calls on journal files as well as
direct `read()`/`write()` syscalls to the database file can fail transiently.

## Changes

### `src/access_moppy/tracking.py`

**SQLite configuration (`_init_db`)**

| Setting | Before | After | Reason |
|---|---|---|---|
| `journal_mode` | `WAL` | `DELETE` | Eliminates `.db-shm` mmap — safe on Lustre |
| `synchronous` | `NORMAL` | `OFF` | No `fsync()` calls; removes the primary EIO source |
| `busy_timeout` | not set | `30000` ms (moved first) | Covers lock contention for all subsequent PRAGMAs |
| `connect timeout` | not set | `30` s | Python-level connection timeout |
| `wal_checkpoint(TRUNCATE)` | not set | before mode switch | Flushes any pre-existing WAL when migrating old databases |

`DELETE + synchronous=OFF` rationale: DELETE mode writes a rollback journal via the OS
page cache (no `fsync()`), which survives process crashes for automatic recovery.
`synchronous=OFF` eliminates all `fsync()` calls. `pwrite()` to the journal goes through
the kernel page cache and does not trigger EIO; only `fsync()` does.

**Retry logic (`_execute_with_retry`)**

Extended the retry condition from `"database is locked"` only to also cover
`"disk I/O error"`. Lustre MDS EIO errors are transient; exponential backoff retries
(1 s, 2 s, 4 s, 8 s, 16 s) succeed once the metadata server recovers.

**All read and write methods now route through `_execute_with_retry`**

Previously, `get_status()` and `is_done()` called `cursor.execute()` directly with no
retry protection. These are the first DB calls made by each PBS job at startup — the
highest-risk window for concurrent EIO failures. Routing them through `_execute_with_retry`
closes this gap. `is_done()` is simplified to delegate to `get_status()`, removing
duplicate query logic.

### `tests/unit/test_tracking.py`

- Added `test_no_shm_or_wal_files_on_disk`: asserts that no `.db-shm` or `.db-wal` files
  are created after writes (WAL mode absent).
- Added `test_journal_mode_is_delete`: asserts `PRAGMA journal_mode` returns `delete`.

## Test Results

Five rounds of 71 concurrent PBS jobs on Gadi:

| Run | Configuration | `disk I/O error` | SIGBUS risk |
|---|---|---|---|
| test_1 | WAL + NORMAL (original) | 6 / 71 | present |
| test_2 | DELETE + NORMAL | 8 / 71 | eliminated |
| test_3 | DELETE + OFF | 3 / 71 | eliminated |
| test_4 | DELETE + OFF + write retry (reads unprotected) | 2 / 71 | eliminated |
| **test_5** | **DELETE + OFF + full retry (all reads and writes)** | **0 / 71** | **eliminated** |

## Trade-offs

- **`synchronous=OFF`**: the OS page cache is not forced to disk after each commit. If a
  PBS job is killed mid-write (e.g. walltime exceeded during the <10 ms write window),
  the tracking database may be inconsistent. The tracking DB is non-critical status
  metadata; it can be deleted and repopulated without affecting CMORised output files.
- **DELETE vs WAL read concurrency**: DELETE mode requires readers to wait for exclusive
  write locks, unlike WAL's concurrent-reader model. In MOPPy's workload each job writes
  twice in under 10 ms across hours of processing, so this has no measurable impact on
  throughput.
