### PR TITLE
Further optimization based on the database

### DIFF
--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -22,33 +22,47 @@ class TaskTracker:
         # + synchronous=OFF (no fsync() calls, eliminating the EIO source).
         # pwrite() to the journal file goes through the OS page cache and does
         # not trigger EIO; only fsync() does.
-        self.conn.execute(
-            "PRAGMA busy_timeout=30000"
-        )  # set first so subsequent PRAGMAs wait on contention
-        self.conn.execute(
-            "PRAGMA wal_checkpoint(TRUNCATE)"
-        )  # flush any pre-existing WAL before switching
-        self.conn.execute("PRAGMA journal_mode=DELETE")
-        self.conn.execute(
-            "PRAGMA synchronous=OFF"
-        )  # no fsync(); journal file still written for crash recovery
-        with self.conn:
-            self.conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS cmor_tasks (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    variable TEXT NOT NULL,
-                    experiment_id TEXT NOT NULL,
-                    status TEXT CHECK(status IN ('pending', 'running', 'completed', 'failed')) NOT NULL DEFAULT 'pending',
-                    start_time TEXT,
-                    end_time TEXT,
-                    error_message TEXT
-                )
-                """
-            )
-            self.conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_var_exp ON cmor_tasks(variable, experiment_id)"
-            )
+        #
+        # The whole sequence is retried because PRAGMA wal_checkpoint and
+        # journal_mode involve file I/O and can transiently fail with EIO on
+        # Lustre. All operations are idempotent (IF NOT EXISTS), so retrying
+        # from the top is safe.
+        _TRANSIENT = ("database is locked", "disk I/O error")
+        for attempt in range(5):
+            try:
+                self.conn.execute(
+                    "PRAGMA busy_timeout=30000"
+                )  # set first so subsequent PRAGMAs wait on contention
+                self.conn.execute(
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
+                )  # flush any pre-existing WAL before switching
+                self.conn.execute("PRAGMA journal_mode=DELETE")
+                self.conn.execute(
+                    "PRAGMA synchronous=OFF"
+                )  # no fsync(); journal file still written for crash recovery
+                with self.conn:
+                    self.conn.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS cmor_tasks (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            variable TEXT NOT NULL,
+                            experiment_id TEXT NOT NULL,
+                            status TEXT CHECK(status IN ('pending', 'running', 'completed', 'failed')) NOT NULL DEFAULT 'pending',
+                            start_time TEXT,
+                            end_time TEXT,
+                            error_message TEXT
+                        )
+                        """
+                    )
+                    self.conn.execute(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS idx_var_exp ON cmor_tasks(variable, experiment_id)"
+                    )
+                return
+            except sqlite3.OperationalError as e:
+                if any(msg in str(e) for msg in _TRANSIENT) and attempt < 4:
+                    time.sleep((2**attempt) + random.uniform(0, 1))
+                else:
+                    raise
 
     def add_task(self, variable: str, experiment_id: str):
         self._execute_with_retry(

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -152,6 +152,67 @@ class TestTaskTracker:
         assert call_count == 2  # wal_checkpoint retried once
 
     @pytest.mark.unit
+    def test_init_db_no_retry_on_non_transient_error(self, temp_dir):
+        """Non-transient errors in _init_db are raised immediately without retry."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+
+        real_conn = tracker.conn
+        call_count = 0
+
+        class BadConn:
+            def execute(self, query, params=()):
+                nonlocal call_count
+                if "wal_checkpoint" in query:
+                    call_count += 1
+                    raise sqlite3.OperationalError("no such table: nonexistent")
+                return real_conn.execute(query, params)
+
+            def __enter__(self):
+                return real_conn.__enter__()
+
+            def __exit__(self, *args):
+                return real_conn.__exit__(*args)
+
+        tracker.conn = BadConn()
+
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            tracker._init_db()
+
+        assert call_count == 1  # raised immediately, no retry
+
+    @pytest.mark.unit
+    def test_init_db_raises_after_max_retries(self, temp_dir):
+        """Transient EIO in _init_db raises after all 5 attempts are exhausted."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+
+        real_conn = tracker.conn
+        call_count = 0
+
+        class AlwaysBadConn:
+            def execute(self, query, params=()):
+                nonlocal call_count
+                if "wal_checkpoint" in query:
+                    call_count += 1
+                    raise sqlite3.OperationalError("disk I/O error")
+                return real_conn.execute(query, params)
+
+            def __enter__(self):
+                return real_conn.__enter__()
+
+            def __exit__(self, *args):
+                return real_conn.__exit__(*args)
+
+        tracker.conn = AlwaysBadConn()
+
+        with patch("time.sleep"):
+            with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+                tracker._init_db()
+
+        assert call_count == 5  # tried 5 times then gave up
+
+    @pytest.mark.unit
     def test_retry_on_database_locked(self, temp_dir):
         """Transient 'database is locked' errors are retried with backoff."""
         db_path = temp_dir / "test_tracker.db"

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -121,6 +121,37 @@ class TestTaskTracker:
         assert row[0] == "delete"
 
     @pytest.mark.unit
+    def test_init_db_retries_on_eio(self, temp_dir):
+        """_init_db retries when PRAGMA wal_checkpoint hits EIO on Lustre."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+
+        real_conn = tracker.conn
+        call_count = 0
+
+        class FlakyConn:
+            def execute(self, query, params=()):
+                nonlocal call_count
+                if "wal_checkpoint" in query:
+                    call_count += 1
+                    if call_count == 1:
+                        raise sqlite3.OperationalError("disk I/O error")
+                return real_conn.execute(query, params)
+
+            def __enter__(self):
+                return real_conn.__enter__()
+
+            def __exit__(self, *args):
+                return real_conn.__exit__(*args)
+
+        tracker.conn = FlakyConn()
+
+        with patch("time.sleep"):
+            tracker._init_db()  # should succeed despite first EIO on wal_checkpoint
+
+        assert call_count == 2  # wal_checkpoint retried once
+
+    @pytest.mark.unit
     def test_retry_on_database_locked(self, temp_dir):
         """Transient 'database is locked' errors are retried with backoff."""
         db_path = temp_dir / "test_tracker.db"


### PR DESCRIPTION
# Fix: Add retry loop to `_init_db()` for Lustre EIO resilience

## Background

`TaskTracker.__init__()` calls `_init_db()` which executes several SQLite
`PRAGMA` statements and `CREATE TABLE / INDEX` directly via `self.conn.execute()`,
bypassing the existing `_execute_with_retry()` protection entirely.

Two of these statements involve real file I/O on the Lustre filesystem:

- `PRAGMA wal_checkpoint(TRUNCATE)` — flushes WAL pages to the main DB file
- `PRAGMA journal_mode=DELETE` — creates/unlinks the journal file

On Gadi (`/scratch`, `/g/data`), the Lustre MDS intermittently returns `EIO`
under high-concurrency PBS job access. Without a retry, the first EIO during
`_init_db()` propagates immediately as an unhandled `sqlite3.OperationalError`,
causing the entire job to fail before any CMORisation work begins.

## Change

Wrap the entire `_init_db()` body in a retry loop using the same transient-error
set as `_execute_with_retry()`:

```python
_TRANSIENT = ("database is locked", "disk I/O error")
for attempt in range(5):
    try:
        self.conn.execute("PRAGMA busy_timeout=30000")
        self.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
        self.conn.execute("PRAGMA journal_mode=DELETE")
        self.conn.execute("PRAGMA synchronous=OFF")
        with self.conn:
            self.conn.execute("CREATE TABLE IF NOT EXISTS cmor_tasks (...)")
            self.conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS ...")
        return
    except sqlite3.OperationalError as e:
        if any(msg in str(e) for msg in _TRANSIENT) and attempt < 4:
            time.sleep((2**attempt) + random.uniform(0, 1))
        else:
            raise
```

Retrying from the top is safe because all operations are idempotent
(`IF NOT EXISTS`), and `busy_timeout=30000` is re-applied on each attempt so
subsequent PRAGMAs still benefit from lock-wait semantics.

## Tests

- `test_init_db_retries_on_eio`: injects a `disk I/O error` on the first
  `wal_checkpoint` call via a `FlakyConn` wrapper (required because
  `sqlite3.Connection.execute` is a read-only C-extension attribute in
  Python 3.12 and cannot be patched on instances directly). Asserts that
  `_init_db()` succeeds and `wal_checkpoint` was called exactly twice.