### PR TITLE
Support List Patterns in `cmor_python_script.j2`

### DIFF
--- a/src/access_moppy/templates/cmor_python_script.j2
+++ b/src/access_moppy/templates/cmor_python_script.j2
@@ -83,10 +83,12 @@ def main():
         if not pattern:
             raise ValueError(f'No pattern found for variable {variable}')
 
-        full_pattern = str(input_folder + pattern)
-        input_files = glob.glob(full_pattern)
+        patterns = pattern if isinstance(pattern, list) else [pattern]
+        input_files = []
+        for p in patterns:
+            input_files.extend(glob.glob(input_folder + p))
         if not input_files:
-            raise ValueError(f'No files found for pattern {full_pattern}')
+            raise ValueError(f'No files found for variable {variable} (patterns: {patterns})')
 
         print(f'Processing {variable} with {len(input_files)} files')
 


### PR DESCRIPTION
## Background

In the batch-processing workflow, each variable's input files are located using a glob
pattern defined in the YAML configuration file under `file_patterns`:

```yaml
file_patterns:
  tas: "atm/tas_*.nc"
```

Previously, the template only accepted a **single string** per variable. This became a
limitation when a variable's source files are spread across multiple naming conventions
or sub-directories that cannot be captured by a single glob expression.

## Problem

Some variables (e.g., ocean or land surface fields) may have input files that match
more than one distinct pattern. A single glob pattern cannot always cover all cases,
for example:

```yaml
# Cannot express both patterns at once with a single string
file_patterns:
  zostoga: "ocean/ocean-3d-*-1monthly-mean-ym_*.nc"        # only catches one naming convention
```

Forcing users to unify patterns into one expression (e.g., with brace expansion) is
fragile and not portable across all glob implementations.

## Change

**File:** `src/access_moppy/templates/cmor_python_script.j2`

The pattern lookup and file collection logic was updated to accept either a `str` or a
`list[str]` from the YAML config:

```python
# Before
full_pattern = str(input_folder + pattern)
input_files = glob.glob(full_pattern)

# After
patterns = pattern if isinstance(pattern, list) else [pattern]
input_files = []
for p in patterns:
    input_files.extend(glob.glob(input_folder + p))
```

The change is backward-compatible: existing configs that use a single string continue
to work unchanged.

## Usage

```yaml
file_patterns:
  # Single pattern — existing usage, unchanged
  tas: "atm/tas_*.nc"

  # List of patterns — new capability
  zostoga:
    - "ocean/ocean-3d-pot_temp-1monthly-mean-ym_1850_01.nc"
    - "ocean/ocean-3d-dzt-1monthly-mean-ym_1850_01.nc"
```

All matching files from every pattern in the list are merged into `input_files` before
being passed to `ACCESS_ESM_CMORiser`.

## Why This Approach

- **Minimal change:** only the pattern normalisation and glob loop were touched; no
  other logic was modified.
- **No new dependency:** `isinstance` check avoids introducing any extra library.
- **Fail-fast preserved:** if the combined file list is still empty, a `ValueError` is
  raised immediately with the full pattern list shown for easier debugging.
