### PR TITLE
optimise error message

### DIFF
--- a/src/access_moppy/atmosphere.py
+++ b/src/access_moppy/atmosphere.py
@@ -26,7 +26,8 @@ class Atmosphere_CMORiser(CMORiser):
             if bnds_var not in self.ds.data_vars and bnds_var not in self.ds.coords:
                 if coord_name not in self.ds.coords:
                     raise ValueError(
-                        f"Cannot calculate {bnds_var}: coordinate '{coord_name}' not found in dataset"
+                        f"Cannot calculate bounds '{bnds_var}': coordinate '{coord_name}' not found. "
+                        f"Available coordinates: {sorted(self.ds.coords)}"
                     )
 
                 # Warn user that bounds are missing and will be calculated automatically
@@ -240,7 +241,10 @@ class Atmosphere_CMORiser(CMORiser):
             self.ds = self.ds.rename({required_vars[0]: self.cmor_name})
             self.ds = custom_functions[func_name](self.ds, **calc.get("kwargs", {}))
         else:
-            raise ValueError(f"Unsupported calculation type: {calc['type']}")
+            raise ValueError(
+                f"Unsupported calculation type '{calc['type']}' for '{self.cmor_name}'. "
+                f"Supported: 'direct', 'formula', 'dataset_function', 'internal'."
+            )
 
         # Rename axes and bounds variables
         rename_map = {

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -600,8 +600,9 @@ class CMORiser:
         declared = self.mapping.get(cmor_name, {}).get("units")
         if declared and expected and declared != expected:
             raise ValueError(
-                f"Mapping units mismatch for {cmor_name}: "
-                f"mapping declares '{declared}' but CMIP expects '{expected}'"
+                f"Mapping units mismatch for '{cmor_name}': "
+                f"mapping declares '{declared}' but CMIP expects '{expected}'. "
+                f"Update the 'units' field in the variable mapping file."
             )
 
     def _check_calendar(self, var: str):
@@ -624,7 +625,10 @@ class CMORiser:
                 start=units.split("since")[1].strip(), periods=3, calendar=calendar
             )
         except Exception as e:
-            raise ValueError(f"Failed calendar check for {var}: {e}")
+            raise ValueError(
+                f"Failed calendar check for '{var}' "
+                f"(calendar='{calendar}', units='{units}'): {e}"
+            )
         if calendar in ("noleap", "365_day"):
             for d in dates:
                 if d.month == 2 and d.day == 29:
@@ -644,9 +648,17 @@ class CMORiser:
             too_small = (arr < vmin).any().item()
             too_large = (arr > vmax).any().item()
         if too_small:
-            raise ValueError(f"Values of '{var}' below valid_min: {vmin}")
+            actual_min = arr.min().values
+            raise ValueError(
+                f"Variable '{var}' has values below valid_min={vmin}. "
+                f"Actual minimum found: {actual_min}"
+            )
         if too_large:
-            raise ValueError(f"Values of '{var}' above valid_max: {vmax}")
+            actual_max = arr.max().values
+            raise ValueError(
+                f"Variable '{var}' has values above valid_max={vmax}. "
+                f"Actual maximum found: {actual_max}"
+            )
 
     def drop_intermediates(self):
         if self.mapping[self.cmor_name].get("model_variables"):

--- a/src/access_moppy/derivations/calc_seaice.py
+++ b/src/access_moppy/derivations/calc_seaice.py
@@ -109,8 +109,10 @@ def calc_hemi_seaice(invar, tarea, hemi, extent=False):
     elif hemi == "south":
         var = var.where(lat < 0.0)
     else:
-        logging.error(f"invalid hemisphere: {hemi}")
-        raise ValueError(f"invalid hemisphere: {hemi}")
+        logging.error("Invalid hemisphere '%s'. Supported: 'north', 'south'.", hemi)
+        raise ValueError(
+            f"Invalid hemisphere '{hemi}'. Supported values: 'north' or 'south'."
+        )
 
     # sum over latitude and longitude (skip time dimension)
     # This implements CMIP7 cell_methods: "area: sum time: mean"

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -368,6 +368,34 @@ class ACCESS_ESM_CMORiser:
                 variable_mapping=self.variable_mapping,
                 drs_root=drs_root if drs_root else None,
             )
+        else:
+            _atmos_tables = (
+                "Amon",
+                "Lmon",
+                "LImon",
+                "Emon",
+                "AERmon",
+                "AERday",
+                "day",
+                "CFmon",
+                "CFday",
+                "3hr",
+                "6hrPlev",
+                "E1hr",
+                "Eday",
+                "fx",
+                "Efx",
+                "atmos",
+            )
+            _ocean_tables = ("Oyr", "Oday", "Omon", "Ofx")
+            _seaice_tables = ("SImon", "SIday")
+            raise ValueError(
+                f"Unsupported CMIP table '{table}' in compound_name '{compound_name}'. "
+                f"Supported tables — "
+                f"atmosphere: {_atmos_tables}, "
+                f"ocean: {_ocean_tables}, "
+                f"sea-ice: {_seaice_tables}."
+            )
 
     def __getitem__(self, key):
         return self.cmoriser.ds[key]

--- a/src/access_moppy/ocean.py
+++ b/src/access_moppy/ocean.py
@@ -113,6 +113,11 @@ class Ocean_CMORiser(CMORiser):
         ##self.calculate_missing_bounds_variables(required_bounds)
 
         # Handle the calculation type
+        if calc["type"] in ("direct", "dataset_function") and not required_vars:
+            raise ValueError(
+                f"Calculation type '{calc['type']}' for '{self.cmor_name}' requires at least "
+                f"one model_variable, but 'model_variables' is empty in the mapping."
+            )
         if calc["type"] == "direct":
             # If the calculation is direct, just rename the variable
             self.ds[self.cmor_name] = self.ds[required_vars[0]]
@@ -307,7 +312,12 @@ class Ocean_CMORiser_OM2(Ocean_CMORiser):
             if coords.issubset(present_coords):
                 return type_, None
 
-        raise ValueError("Could not infer grid type from dataset coordinates.")
+        expected = {t: sorted(c) for t, c in grid_types.items()}
+        raise ValueError(
+            f"Could not infer grid type from dataset coordinates (MOM5/OM2). "
+            f"Expected one of {expected}. "
+            f"Found coordinates: {sorted(present_coords)}"
+        )
 
     def _get_dim_rename(self):
         """Get the dimension renaming mapping for the grid type."""
@@ -322,7 +332,10 @@ class Ocean_CMORiser_OM2(Ocean_CMORiser):
                 "st_ocean": "lev",  # depth level
             }
         else:
-            raise ValueError(f"Unsupported source_id: {self.vocab.source_id}")
+            raise ValueError(
+                f"Unsupported source_id '{self.vocab.source_id}' for Ocean_CMORiser_OM2. "
+                f"Supported: {supported_sources}"
+            )
 
 
 class Ocean_CMORiser_OM3(Ocean_CMORiser):
@@ -374,7 +387,12 @@ class Ocean_CMORiser_OM3(Ocean_CMORiser):
             if coords.issubset(present_coords):
                 return type_, symmetric
 
-        raise ValueError("Could not infer grid type from dataset coordinates.")
+        expected = {t: sorted(c) for t, c in grid_types.items()}
+        raise ValueError(
+            f"Could not infer grid type from dataset coordinates (MOM6/OM3). "
+            f"Expected one of {expected}. "
+            f"Found coordinates: {sorted(present_coords)}"
+        )
 
     def _get_dim_rename(self):
         """Get the dimension renaming mapping for the grid type."""
@@ -387,4 +405,7 @@ class Ocean_CMORiser_OM3(Ocean_CMORiser):
                 "zl": "lev",  # depth level
             }
         else:
-            raise ValueError(f"Unsupported source_id: {self.vocab.source_id}")
+            raise ValueError(
+                f"Unsupported source_id '{self.vocab.source_id}' for Ocean_CMORiser_OM3. "
+                f"source_id must contain 'ACCESS-OM3' or 'ACCESS-CM'."
+            )

--- a/src/access_moppy/ocean_supergrid.py
+++ b/src/access_moppy/ocean_supergrid.py
@@ -30,7 +30,8 @@ class Supergrid:
 
         if nominal_resolution not in supergrid_filenames:
             raise ValueError(
-                f"Unknown or unsupported nominal resolution: {nominal_resolution}"
+                f"Unknown nominal resolution '{nominal_resolution}'. "
+                f"Supported: {sorted(supergrid_filenames.keys())}"
             )
 
         supergrid_filename = supergrid_filenames[nominal_resolution]
@@ -271,7 +272,8 @@ class Supergrid:
                         y_bounds = self.qcell_corners_y[1:, 1:, :]
                     case _:
                         raise ValueError(
-                            f"grid_type={grid_type} is not a supported grid_type for arakawa={arakawa}"
+                            f"grid_type='{grid_type}' is not supported for arakawa='{arakawa}' (B-grid). "
+                            f"Supported grid types: ['T', 'U', 'V', 'C']"
                         )
             case "C":
                 i_start = 0 if symmetric else 1
@@ -298,10 +300,13 @@ class Supergrid:
                         y_bounds = self.qcell_corners_y[i_start:, i_start:, :]
                     case _:
                         raise ValueError(
-                            f"grid_type={grid_type} is not a supported grid_type for arakawa={arakawa}"
+                            f"grid_type='{grid_type}' is not supported for arakawa='{arakawa}' (C-grid). "
+                            f"Supported grid types: ['T', 'U', 'V', 'C']"
                         )
             case _:
-                raise ValueError(f"arakawa={arakawa} is not supported")
+                raise ValueError(
+                    f"arakawa='{arakawa}' is not supported. Expected 'B' or 'C'."
+                )
 
         lat = xr.DataArray(y_centers, dims=("j", "i"), name="latitude")
         lon = xr.DataArray(x_centers, dims=("j", "i"), name="longitude")

--- a/src/access_moppy/sea_ice.py
+++ b/src/access_moppy/sea_ice.py
@@ -79,9 +79,15 @@ class SeaIce_CMORiser(Ocean_CMORiser):
                     elif "VLON" in coord_attr and "VLAT" in coord_attr:
                         return "V", None
 
+        coord_attrs_found = {
+            v: self.ds[v].attrs.get("coordinates", "<missing>")
+            for v in self.ds.data_vars
+        }
         raise ValueError(
-            "Could not infer grid type from coordinate attributes or dataset coordinates. "
-            "Expected coordinate attributes like 'ULON ULAT', 'TLON TLAT', or 'VLON VLAT'"
+            f"Could not infer grid type from coordinate attributes. "
+            f"Expected a 'coordinates' attribute containing 'ULON ULAT' (U-grid), "
+            f"'TLON TLAT' (T-grid), or 'VLON VLAT' (V-grid) on at least one data variable. "
+            f"Found data_vars with their 'coordinates' attrs: {coord_attrs_found}"
         )
 
     def _get_dim_rename(self):
@@ -96,7 +102,8 @@ class SeaIce_CMORiser(Ocean_CMORiser):
             }
         else:
             raise ValueError(
-                f"Unsupported source_id for sea-ice: {self.vocab.source_id}"
+                f"Unsupported source_id '{self.vocab.source_id}' for SeaIce_CMORiser. "
+                f"source_id must start with 'ACCESS-'."
             )
 
     def select_and_process_variables(self):
@@ -148,11 +155,24 @@ class SeaIce_CMORiser(Ocean_CMORiser):
         self.sort_time_dimension()
 
         # Handle the calculation type
+        if calc["type"] in ("direct", "dataset_function") and not required_vars:
+            raise ValueError(
+                f"Calculation type '{calc['type']}' for '{self.cmor_name}' requires at least "
+                f"one model_variable, but 'model_variables' is empty in the mapping."
+            )
         if calc["type"] == "direct":
             # If the calculation is direct, just rename the variable
             self.ds[self.cmor_name] = self.ds[required_vars[0]]
         elif calc["type"] == "formula":
             # If the calculation is a formula, evaluate it
+            missing_model_vars = [v for v in required_vars if v not in self.ds]
+            if missing_model_vars:
+                raise KeyError(
+                    f"Required model variable(s) {missing_model_vars} not found in input "
+                    f"files for '{self.cmor_name}'. "
+                    f"Available data variables: {sorted(self.ds.data_vars)}. "
+                    f"Check 'model_variables' in the mapping."
+                )
             context = {var: self.ds[var] for var in required_vars}
             context.update(custom_functions)
             self.ds[self.cmor_name] = evaluate_expression(calc, context)
@@ -161,6 +181,7 @@ class SeaIce_CMORiser(Ocean_CMORiser):
             func_name = calc["function"]
             self.ds = self.ds.rename({required_vars[0]: self.cmor_name})
             self.ds = custom_functions[func_name](self.ds, **calc.get("kwargs", {}))
+
         else:
             raise ValueError(f"Unsupported calculation type: {calc['type']}")
 

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -1243,7 +1243,10 @@ def detect_time_frequency_lazy(
         ValueError: if time coordinate is missing or has insufficient data
     """
     if time_coord not in ds.coords:
-        raise ValueError(f"Time coordinate '{time_coord}' not found in dataset")
+        raise ValueError(
+            f"Time coordinate '{time_coord}' not found in dataset. "
+            f"Available coordinates: {sorted(ds.coords)}"
+        )
 
     time_var = ds[time_coord]
 
@@ -1866,7 +1869,10 @@ def resample_dataset_temporal(
         Resampled xarray Dataset
     """
     if time_coord not in ds.coords:
-        raise ValueError(f"Time coordinate '{time_coord}' not found in dataset")
+        raise ValueError(
+            f"Time coordinate '{time_coord}' not found in dataset for resampling. "
+            f"Available coordinates: {sorted(ds.coords)}"
+        )
 
     # Convert target frequency to resampling string
     freq_str = get_resampling_frequency_string(target_freq)
@@ -1962,7 +1968,10 @@ def resample_dataset_temporal(
         return ds_resampled
 
     except Exception as e:
-        raise RuntimeError(f"Failed to resample dataset: {e}")
+        raise RuntimeError(
+            f"Failed to resample variable '{variable_name}' to target_freq={target_freq} "
+            f"using method='{method}': {e}"
+        )
 
 
 def validate_and_resample_if_needed(
@@ -1988,7 +1997,10 @@ def validate_and_resample_if_needed(
     # Detect current frequency
     detected_freq = detect_time_frequency_lazy(ds, time_coord)
     if detected_freq is None:
-        raise ValueError("Could not detect temporal frequency from dataset")
+        raise ValueError(
+            f"Could not detect temporal frequency from dataset for '{compound_name}'. "
+            f"Check that the '{time_coord}' coordinate has valid units and sufficient time points."
+        )
 
     # Get target frequency
     target_freq = parse_cmip6_table_frequency(compound_name)
@@ -2000,7 +2012,10 @@ def validate_and_resample_if_needed(
     # Check compatibility first
     is_compatible, reason = is_frequency_compatible(detected_freq, target_freq)
     if not is_compatible:
-        raise IncompatibleFrequencyError(f"Cannot resample: {reason}")
+        raise IncompatibleFrequencyError(
+            f"Cannot resample '{compound_name}': {reason} "
+            f"(detected={detected_freq}, target={target_freq})"
+        )
 
     # Check if both frequencies are monthly (special case)
     monthly_min = 20 * 86400  # 20 days in seconds
@@ -2343,7 +2358,10 @@ def calculate_latitude_bounds(
         ValueError: If latitude coordinate is missing or has insufficient points
     """
     if lat_coord not in ds.coords:
-        raise ValueError(f"Latitude coordinate '{lat_coord}' not found in dataset")
+        raise ValueError(
+            f"Latitude coordinate '{lat_coord}' not found in dataset. "
+            f"Available coordinates: {sorted(ds.coords)}"
+        )
 
     lat_var = ds[lat_coord]
     lat_values = lat_var.values
@@ -2428,7 +2446,10 @@ def calculate_longitude_bounds(
                    or contains values outside expected ranges
     """
     if lon_coord not in ds.coords:
-        raise ValueError(f"Longitude coordinate '{lon_coord}' not found in dataset")
+        raise ValueError(
+            f"Longitude coordinate '{lon_coord}' not found in dataset. "
+            f"Available coordinates: {sorted(ds.coords)}"
+        )
 
     lon_var = ds[lon_coord]
     lon_values = lon_var.values

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -91,8 +91,10 @@ class CMIP6Vocabulary:
         try:
             return self.vocab["experiment_id"][self.experiment_id]
         except KeyError:
+            available = sorted(self.vocab.get("experiment_id", {}).keys())
             raise ValueError(
-                f"Experiment '{self.experiment_id}' not found in controlled vocabularies."
+                f"Experiment '{self.experiment_id}' not found in controlled vocabularies. "
+                f"Available experiments: {available}"
             )
 
     def _get_parent_metadata(self) -> Dict[str, Any]:
@@ -110,8 +112,10 @@ class CMIP6Vocabulary:
         try:
             return self.vocab["source_id"][self.source_id]
         except KeyError:
+            available = sorted(self.vocab.get("source_id", {}).keys())
             raise ValueError(
-                f"Source '{self.source_id}' not found in controlled vocabularies."
+                f"Source '{self.source_id}' not found in controlled vocabularies. "
+                f"Available source_ids: {available}"
             )
 
     def get_parent_experiment_attrs(self) -> Dict[str, Any]:
@@ -161,7 +165,10 @@ class CMIP6Vocabulary:
         entry = files(self.table_dir) / self._table_filename(self.table)
 
         if not entry.exists():
-            raise FileNotFoundError(f"Table file not found: {entry}")
+            raise FileNotFoundError(
+                f"CMOR table file not found for table='{self.table}' "
+                f"(looked for '{self._table_filename(self.table)}' in '{self.table_dir}')"
+            )
 
         with as_file(entry) as path:
             with open(path, "r", encoding="utf-8") as f:

--- a/tests/unit/test_atmosphere.py
+++ b/tests/unit/test_atmosphere.py
@@ -648,6 +648,22 @@ class TestCalculateMissingBoundsVariables:
             cmoriser.calculate_missing_bounds_variables(bnds_required)
 
     @pytest.mark.unit
+    def test_missing_coord_error_lists_available_coordinates(self, tmp_path):
+        """Missing-coordinate error must list the coordinates actually present."""
+        ds = _make_monthly_ds()
+        ds = ds.drop_vars("lat")
+
+        cmoriser = _bare_cmoriser(ds, tmp_path)
+        bnds_required = {"lat_bnds": {"out_name": "lat", "must_have_bounds": "yes"}}
+
+        with pytest.raises(ValueError, match="Available coordinates") as exc_info:
+            cmoriser.calculate_missing_bounds_variables(bnds_required)
+
+        msg = str(exc_info.value)
+        assert "time" in msg
+        assert "lon" in msg
+
+    @pytest.mark.unit
     def test_multiple_bounds_all_calculated(self, tmp_path):
         """
         When bnds_required contains multiple entries (time, lat, lon),
@@ -1789,3 +1805,47 @@ class TestMissingModelVarValidation:
             cmoriser.select_and_process_variables()
 
         assert "zg" in cmoriser.ds
+
+
+class TestUnsupportedCalcType:
+    """Tests for the else branch when calc['type'] is unknown."""
+
+    @pytest.mark.unit
+    def test_unsupported_calc_type_lists_supported(self, tmp_path):
+        """ValueError must include cmor_name and the list of supported calc types."""
+        ds = xr.Dataset(
+            {
+                "fld_s16i201": (
+                    ["time", "lat", "lon"],
+                    np.ones((3, 5, 8), dtype="f4"),
+                    {"units": "m"},
+                )
+            },
+            coords={
+                "time": np.arange(3, dtype=float),
+                "lat": np.linspace(-90, 90, 5),
+                "lon": np.linspace(0, 360, 8, endpoint=False),
+            },
+        )
+        cmoriser = _make_cmoriser(ds, "zg", tmp_path=tmp_path)
+        cmoriser.mapping = {
+            "zg": {
+                "model_variables": ["fld_s16i201"],
+                "calculation": {"type": "bogus_type"},
+            }
+        }
+        cmoriser.cmor_name = "zg"
+
+        with patch.object(cmoriser, "load_dataset"):
+            cmoriser.ds = ds.copy()
+            with pytest.raises(
+                ValueError, match="Unsupported calculation type 'bogus_type'"
+            ) as exc_info:
+                cmoriser.select_and_process_variables()
+
+        msg = str(exc_info.value)
+        assert "'zg'" in msg
+        assert "direct" in msg
+        assert "formula" in msg
+        assert "dataset_function" in msg
+        assert "internal" in msg

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -2226,7 +2226,7 @@ class TestCheckUnits:
     def test_raises_on_mismatch(self):
         """ValueError raised when declared units differ from expected."""
         obj = self._make_cmoriser({"tas": {"units": "degC"}})
-        with pytest.raises(ValueError, match="Mapping units mismatch for tas"):
+        with pytest.raises(ValueError, match="Mapping units mismatch for"):
             CMORiser._check_units(obj, "tas", "K")
 
     @pytest.mark.unit

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -2254,3 +2254,85 @@ class TestCheckUnits:
         with pytest.raises(ValueError, match="kg m-2 s-1") as exc_info:
             CMORiser._check_units(obj, "pr", "mm d-1")
         assert "mm d-1" in str(exc_info.value)
+
+    @pytest.mark.unit
+    def test_error_message_contains_fix_hint(self):
+        """Error message must include a hint to update the mapping file."""
+        obj = self._make_cmoriser({"tas": {"units": "degC"}})
+        with pytest.raises(ValueError, match="variable mapping file") as exc_info:
+            CMORiser._check_units(obj, "tas", "K")
+        assert "Update the 'units' field" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _check_calendar
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCalendar:
+    """Tests for CMORiser._check_calendar."""
+
+    def _make_cmoriser(self, ds):
+        obj = MagicMock(spec=CMORiser)
+        obj.ds = ds
+        return obj
+
+    @pytest.mark.unit
+    def test_calendar_check_failure_includes_calendar_and_units(self):
+        """Failed parsing must surface the calendar and units in the message."""
+        time = xr.DataArray(
+            [0, 1, 2],
+            dims="time",
+            attrs={"calendar": "noleap", "units": "garbage units string"},
+        )
+        ds = xr.Dataset(coords={"time": time})
+        obj = self._make_cmoriser(ds)
+
+        with pytest.raises(ValueError, match="Failed calendar check") as exc_info:
+            CMORiser._check_calendar(obj, "time")
+
+        msg = str(exc_info.value)
+        assert "noleap" in msg
+        assert "garbage units string" in msg
+
+
+# ---------------------------------------------------------------------------
+# _check_range
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRange:
+    """Tests for CMORiser._check_range."""
+
+    def _make_cmoriser(self, ds):
+        obj = MagicMock(spec=CMORiser)
+        obj.ds = ds
+        return obj
+
+    @pytest.mark.unit
+    def test_below_min_error_includes_actual_minimum(self):
+        """Error for too-small values must include the actual minimum found."""
+        arr = xr.DataArray(np.array([1.0, -5.0, 0.0]), dims="x")
+        ds = xr.Dataset({"tas": arr})
+        obj = self._make_cmoriser(ds)
+
+        with pytest.raises(ValueError, match="below valid_min") as exc_info:
+            CMORiser._check_range(obj, "tas", vmin=0.0, vmax=10.0)
+
+        msg = str(exc_info.value)
+        assert "Actual minimum found" in msg
+        assert "-5" in msg
+
+    @pytest.mark.unit
+    def test_above_max_error_includes_actual_maximum(self):
+        """Error for too-large values must include the actual maximum found."""
+        arr = xr.DataArray(np.array([1.0, 9.0, 0.0]), dims="x")
+        ds = xr.Dataset({"tas": arr})
+        obj = self._make_cmoriser(ds)
+
+        with pytest.raises(ValueError, match="above valid_max") as exc_info:
+            CMORiser._check_range(obj, "tas", vmin=-1.0, vmax=5.0)
+
+        msg = str(exc_info.value)
+        assert "Actual maximum found" in msg
+        assert "9" in msg

--- a/tests/unit/test_derivations_calc_seaice.py
+++ b/tests/unit/test_derivations_calc_seaice.py
@@ -139,7 +139,7 @@ class TestCalcHemiSeaice:
     @pytest.mark.unit
     def test_invalid_hemisphere_raises(self):
         aice, areacello = _make_hemi_grid()
-        with pytest.raises(ValueError, match="invalid hemisphere"):
+        with pytest.raises(ValueError, match="[Ii]nvalid hemisphere"):
             calc_hemi_seaice(aice, areacello, "east")
 
     @pytest.mark.unit

--- a/tests/unit/test_derivations_calc_seaice.py
+++ b/tests/unit/test_derivations_calc_seaice.py
@@ -143,6 +143,16 @@ class TestCalcHemiSeaice:
             calc_hemi_seaice(aice, areacello, "east")
 
     @pytest.mark.unit
+    def test_invalid_hemisphere_error_lists_supported(self):
+        """Error message must list the supported hemisphere values."""
+        aice, areacello = _make_hemi_grid()
+        with pytest.raises(ValueError, match="'east'") as exc_info:
+            calc_hemi_seaice(aice, areacello, "east")
+        msg = str(exc_info.value)
+        assert "'north'" in msg
+        assert "'south'" in msg
+
+    @pytest.mark.unit
     def test_raises_when_no_lat_coord(self):
         """Raises ValueError when no latitude coordinate can be found."""
         da = xr.DataArray(np.ones((2, 4, 4)), dims=["time", "x", "y"])

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -562,6 +562,49 @@ class TestACCESSESMCMORiser:
             mock_om2.assert_called_once()
 
     @pytest.mark.unit
+    def test_unsupported_table_raises_value_error_with_supported_list(
+        self, valid_config, temp_dir
+    ):
+        """Unknown CMIP table raises ValueError listing atmosphere/ocean/sea-ice tables."""
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.CMIP6Vocabulary"),
+        ):
+            mock_load.return_value = {"foo": {"units": "1"}}
+
+            with pytest.raises(ValueError, match="Unsupported CMIP table 'XXXmon'"):
+                ACCESS_ESM_CMORiser(
+                    input_paths=["test.nc"],
+                    compound_name="XXXmon.foo",
+                    output_path=temp_dir,
+                    **valid_config,
+                )
+
+    @pytest.mark.unit
+    def test_unsupported_table_error_lists_known_tables(self, valid_config, temp_dir):
+        """The ValueError message for an unknown table must mention known table groups."""
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.CMIP6Vocabulary"),
+        ):
+            mock_load.return_value = {"foo": {"units": "1"}}
+
+            with pytest.raises(ValueError, match="atmosphere:") as exc_info:
+                ACCESS_ESM_CMORiser(
+                    input_paths=["test.nc"],
+                    compound_name="XXXmon.foo",
+                    output_path=temp_dir,
+                    **valid_config,
+                )
+
+            msg = str(exc_info.value)
+            assert "ocean:" in msg
+            assert "sea-ice:" in msg
+            assert "Amon" in msg
+            assert "Omon" in msg
+            assert "SImon" in msg
+
+    @pytest.mark.unit
     def test_sea_ice_table_selects_seaice_cmoriser(self, valid_config, temp_dir):
         with (
             patch("access_moppy.driver.load_model_mappings") as mock_load,

--- a/tests/unit/test_ocean.py
+++ b/tests/unit/test_ocean.py
@@ -135,6 +135,58 @@ class TestCMIP6OceanCMORiserOM2:
             assert cmoriser.arakawa == "B"
 
     @pytest.mark.unit
+    def test_infer_grid_type_unknown_coords_raises_with_context(
+        self, mock_vocab, mock_mapping, temp_dir
+    ):
+        """infer_grid_type raises ValueError with expected/found coord sets when no match."""
+        ds = xr.Dataset(coords={"unknown_x": ("unknown_x", np.arange(5))})
+
+        with patch("access_moppy.ocean.Supergrid"):
+            cmoriser = Ocean_CMORiser_OM2(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="Omon.tos",
+                vocab=mock_vocab,
+                variable_mapping=mock_mapping,
+            )
+            cmoriser.ds = ds
+
+            with pytest.raises(ValueError, match="MOM5/OM2") as exc_info:
+                cmoriser.infer_grid_type()
+
+            msg = str(exc_info.value)
+            assert "xt_ocean" in msg
+            assert "Found coordinates" in msg
+
+    @pytest.mark.unit
+    def test_select_and_process_empty_required_vars_direct_raises(
+        self, mock_vocab, temp_dir
+    ):
+        """direct calc type with empty model_variables raises ValueError."""
+        mapping = {
+            "tos": {
+                "model_variables": [],
+                "calculation": {"type": "direct"},
+            }
+        }
+
+        with patch("access_moppy.ocean.Supergrid"):
+            cmoriser = Ocean_CMORiser_OM2(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="Omon.tos",
+                vocab=mock_vocab,
+                variable_mapping=mapping,
+            )
+
+        with patch.object(cmoriser, "load_dataset", return_value=None):
+            cmoriser.ds = xr.Dataset()
+            with pytest.raises(
+                ValueError, match="requires at least one model_variable"
+            ):
+                cmoriser.select_and_process_variables()
+
+    @pytest.mark.unit
     def test_time_bnds_dimensions_in_used_coords(
         self, mock_vocab, mock_mapping, mock_om2_dataset, temp_dir
     ):
@@ -326,6 +378,58 @@ class TestCMIP6OceanCMORiserOM3:
             )
 
             assert cmoriser.arakawa == "C"
+
+    @pytest.mark.unit
+    def test_infer_grid_type_unknown_coords_raises_with_context(
+        self, mock_vocab, mock_mapping, temp_dir
+    ):
+        """infer_grid_type raises ValueError with expected/found coord sets when no match."""
+        ds = xr.Dataset(coords={"unknown_x": ("unknown_x", np.arange(5))})
+
+        with patch("access_moppy.ocean.Supergrid"):
+            cmoriser = Ocean_CMORiser_OM3(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="Omon.tos",
+                vocab=mock_vocab,
+                variable_mapping=mock_mapping,
+            )
+            cmoriser.ds = ds
+
+            with pytest.raises(ValueError, match="MOM6/OM3") as exc_info:
+                cmoriser.infer_grid_type()
+
+            msg = str(exc_info.value)
+            assert "xh" in msg
+            assert "Found coordinates" in msg
+
+    @pytest.mark.unit
+    def test_select_and_process_empty_required_vars_direct_raises(
+        self, mock_vocab, temp_dir
+    ):
+        """direct calc type with empty model_variables raises ValueError."""
+        mapping = {
+            "tos": {
+                "model_variables": [],
+                "calculation": {"type": "direct"},
+            }
+        }
+
+        with patch("access_moppy.ocean.Supergrid"):
+            cmoriser = Ocean_CMORiser_OM3(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="Omon.tos",
+                vocab=mock_vocab,
+                variable_mapping=mapping,
+            )
+
+        with patch.object(cmoriser, "load_dataset", return_value=None):
+            cmoriser.ds = xr.Dataset()
+            with pytest.raises(
+                ValueError, match="requires at least one model_variable"
+            ):
+                cmoriser.select_and_process_variables()
 
 
 class TestOceanDerivations:

--- a/tests/unit/test_ocean.py
+++ b/tests/unit/test_ocean.py
@@ -187,6 +187,33 @@ class TestCMIP6OceanCMORiserOM2:
                 cmoriser.select_and_process_variables()
 
     @pytest.mark.unit
+    def test_om2_get_dim_rename_unsupported_source_id_lists_supported(
+        self, mock_mapping, temp_dir
+    ):
+        """OM2 _get_dim_rename raises ValueError listing supported source_ids."""
+        vocab = Mock()
+        vocab.source_id = "UNKNOWN-MODEL"
+        vocab._get_nominal_resolution = Mock(return_value="1deg")
+
+        with patch("access_moppy.ocean.Supergrid"):
+            cmoriser = Ocean_CMORiser_OM2(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="Omon.tos",
+                vocab=vocab,
+                variable_mapping=mock_mapping,
+            )
+
+            with pytest.raises(
+                ValueError, match="Unsupported source_id 'UNKNOWN-MODEL'"
+            ) as exc_info:
+                cmoriser._get_dim_rename()
+
+            msg = str(exc_info.value)
+            assert "Ocean_CMORiser_OM2" in msg
+            assert "ACCESS-OM2" in msg
+
+    @pytest.mark.unit
     def test_time_bnds_dimensions_in_used_coords(
         self, mock_vocab, mock_mapping, mock_om2_dataset, temp_dir
     ):
@@ -430,6 +457,34 @@ class TestCMIP6OceanCMORiserOM3:
                 ValueError, match="requires at least one model_variable"
             ):
                 cmoriser.select_and_process_variables()
+
+    @pytest.mark.unit
+    def test_om3_get_dim_rename_unsupported_source_id_mentions_required(
+        self, mock_mapping, temp_dir
+    ):
+        """OM3 _get_dim_rename raises ValueError naming the required source_id prefix."""
+        vocab = Mock()
+        vocab.source_id = "OTHER-MODEL"
+        vocab._get_nominal_resolution = Mock(return_value="1deg")
+
+        with patch("access_moppy.ocean.Supergrid"):
+            cmoriser = Ocean_CMORiser_OM3(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="Omon.tos",
+                vocab=vocab,
+                variable_mapping=mock_mapping,
+            )
+
+            with pytest.raises(
+                ValueError, match="Unsupported source_id 'OTHER-MODEL'"
+            ) as exc_info:
+                cmoriser._get_dim_rename()
+
+            msg = str(exc_info.value)
+            assert "Ocean_CMORiser_OM3" in msg
+            assert "ACCESS-OM3" in msg
+            assert "ACCESS-CM" in msg
 
 
 class TestOceanDerivations:

--- a/tests/unit/test_sea_ice.py
+++ b/tests/unit/test_sea_ice.py
@@ -73,3 +73,64 @@ class TestSeaIceCMORiser:
                 cmoriser.select_and_process_variables()
 
                 assert cmoriser.ds[cmoriser.cmor_name].dims == ("time", "j", "i")
+
+    @pytest.mark.unit
+    def test_select_and_process_missing_model_var_in_formula_raises_key_error(
+        self, mock_vocab, temp_dir
+    ):
+        """Formula calc with a missing model variable raises KeyError with context."""
+        import pandas as pd
+
+        mapping = {
+            "siconc": {
+                "model_variables": ["missing_var"],
+                "calculation": {"type": "formula", "operation": "missing_var * 0.01"},
+            }
+        }
+        time = pd.date_range("2000-01-01", periods=2, freq="ME")
+        ds = xr.Dataset(
+            {"other_var": (["time"], [1.0, 2.0])},
+            coords={"time": time},
+        )
+
+        with patch("access_moppy.sea_ice.Supergrid"):
+            with patch("access_moppy.ocean.CMORiser.load_dataset", return_value=None):
+                cmoriser = SeaIce_CMORiser(
+                    input_paths=["test.nc"],
+                    output_path=str(temp_dir),
+                    compound_name="SImon.siconc",
+                    vocab=mock_vocab,
+                    variable_mapping=mapping,
+                )
+                cmoriser.ds = ds
+
+                with pytest.raises(KeyError, match="missing_var"):
+                    cmoriser.select_and_process_variables()
+
+    @pytest.mark.unit
+    def test_select_and_process_empty_required_vars_direct_raises(
+        self, mock_vocab, temp_dir
+    ):
+        """direct calc type with empty model_variables raises ValueError."""
+        mapping = {
+            "siconc": {
+                "model_variables": [],
+                "calculation": {"type": "direct"},
+            }
+        }
+
+        with patch("access_moppy.sea_ice.Supergrid"):
+            with patch("access_moppy.ocean.CMORiser.load_dataset", return_value=None):
+                cmoriser = SeaIce_CMORiser(
+                    input_paths=["test.nc"],
+                    output_path=str(temp_dir),
+                    compound_name="SImon.siconc",
+                    vocab=mock_vocab,
+                    variable_mapping=mapping,
+                )
+                cmoriser.ds = xr.Dataset()
+
+                with pytest.raises(
+                    ValueError, match="requires at least one model_variable"
+                ):
+                    cmoriser.select_and_process_variables()

--- a/tests/unit/test_sea_ice.py
+++ b/tests/unit/test_sea_ice.py
@@ -134,3 +134,67 @@ class TestSeaIceCMORiser:
                     ValueError, match="requires at least one model_variable"
                 ):
                     cmoriser.select_and_process_variables()
+
+    @pytest.mark.unit
+    def test_infer_grid_type_lists_data_var_coord_attrs(
+        self, mock_vocab, mock_mapping, temp_dir
+    ):
+        """infer_grid_type error must list each data_var with its 'coordinates' attr."""
+        ds = xr.Dataset(
+            data_vars={
+                "ice_conc": (
+                    ["nj", "ni"],
+                    np.zeros((2, 2)),
+                    {"coordinates": "XLON XLAT"},
+                ),
+                "ice_thick": (["nj", "ni"], np.zeros((2, 2))),
+            }
+        )
+
+        with patch("access_moppy.sea_ice.Supergrid"):
+            cmoriser = SeaIce_CMORiser(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="SImon.siconc",
+                vocab=mock_vocab,
+                variable_mapping=mock_mapping,
+            )
+            cmoriser.ds = ds
+
+            with pytest.raises(
+                ValueError, match="Could not infer grid type"
+            ) as exc_info:
+                cmoriser.infer_grid_type()
+
+            msg = str(exc_info.value)
+            assert "ice_conc" in msg
+            assert "XLON XLAT" in msg
+            assert "ice_thick" in msg
+            assert "<missing>" in msg
+
+    @pytest.mark.unit
+    def test_get_dim_rename_unsupported_source_id_mentions_access_prefix(
+        self, mock_mapping, temp_dir
+    ):
+        """_get_dim_rename raises ValueError naming the required ACCESS- prefix."""
+        vocab = Mock()
+        vocab.source_id = "OTHER-MODEL"
+        vocab._get_nominal_resolution = Mock(return_value="1deg")
+
+        with patch("access_moppy.sea_ice.Supergrid"):
+            cmoriser = SeaIce_CMORiser(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="SImon.siconc",
+                vocab=vocab,
+                variable_mapping=mock_mapping,
+            )
+
+            with pytest.raises(
+                ValueError, match="Unsupported source_id 'OTHER-MODEL'"
+            ) as exc_info:
+                cmoriser._get_dim_rename()
+
+            msg = str(exc_info.value)
+            assert "SeaIce_CMORiser" in msg
+            assert "ACCESS-" in msg

--- a/tests/unit/test_supergrid.py
+++ b/tests/unit/test_supergrid.py
@@ -197,6 +197,15 @@ class TestSupergrid:
             supergrid_instance.extract_grid(grid_type="T", arakawa="A")
 
     @pytest.mark.unit
+    def test_extract_grid_unsupported_arakawa_message_lists_expected(
+        self, supergrid_instance
+    ):
+        """Arakawa error message must state the expected values 'B' or 'C'."""
+        with pytest.raises(ValueError, match="Expected 'B' or 'C'") as exc_info:
+            supergrid_instance.extract_grid(grid_type="T", arakawa="A")
+        assert "'A'" in str(exc_info.value)
+
+    @pytest.mark.unit
     @pytest.mark.parametrize("arakawa,symmetric", [("B", None), ("C", True)])
     def test_extract_grid_unsupported_grid_type(
         self, supergrid_instance, arakawa, symmetric
@@ -206,6 +215,33 @@ class TestSupergrid:
             supergrid_instance.extract_grid(
                 grid_type="X", arakawa=arakawa, symmetric=symmetric
             )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("arakawa,symmetric", [("B", None), ("C", True)])
+    def test_extract_grid_unsupported_grid_type_lists_supported(
+        self, supergrid_instance, arakawa, symmetric
+    ):
+        """grid_type error message must list the supported grid types."""
+        with pytest.raises(
+            ValueError, match=r"Supported grid types: \['T', 'U', 'V', 'C'\]"
+        ) as exc_info:
+            supergrid_instance.extract_grid(
+                grid_type="X", arakawa=arakawa, symmetric=symmetric
+            )
+        assert "'X'" in str(exc_info.value)
+
+    @pytest.mark.unit
+    def test_get_supergrid_path_invalid_resolution_lists_supported(self):
+        """get_supergrid_path error message must list the supported resolutions."""
+        with patch.object(Supergrid, "load_supergrid"):
+            sg = Supergrid.__new__(Supergrid)
+            sg.nominal_resolution = "50 km"
+            with pytest.raises(ValueError, match="Supported:") as exc_info:
+                sg.get_supergrid_path("50 km")
+        msg = str(exc_info.value)
+        assert "100 km" in msg
+        assert "25 km" in msg
+        assert "10 km" in msg
 
     # ==================== extract_grid Output Validation ====================
 

--- a/tests/unit/test_supergrid.py
+++ b/tests/unit/test_supergrid.py
@@ -80,7 +80,7 @@ class TestSupergrid:
     @pytest.mark.parametrize(
         "resolution,error_match",
         [
-            ("50 km", "Unknown or unsupported nominal resolution"),
+            ("50 km", "Unknown nominal resolution"),
             (None, "nominal_resolution must be provided"),
         ],
     )
@@ -202,7 +202,7 @@ class TestSupergrid:
         self, supergrid_instance, arakawa, symmetric
     ):
         """Test that unsupported grid type raises error."""
-        with pytest.raises(ValueError, match="is not a supported grid_type"):
+        with pytest.raises(ValueError, match="is not supported for arakawa"):
             supergrid_instance.extract_grid(
                 grid_type="X", arakawa=arakawa, symmetric=symmetric
             )

--- a/tests/unit/test_temporal_resampling.py
+++ b/tests/unit/test_temporal_resampling.py
@@ -387,5 +387,51 @@ class TestErrorHandling:
         assert "tas" in ds_result.data_vars
 
 
+class TestErrorMessageContext:
+    """Tests that error messages include the new diagnostic context fields."""
+
+    def test_resample_missing_time_coord_lists_available_coords(self):
+        """resample_dataset_temporal: missing time error lists available coords."""
+        ds = xr.Dataset({"tas": (["x"], [1, 2, 3])}, coords={"x": [1, 2, 3]})
+        target_freq = pd.Timedelta(days=1)
+
+        with pytest.raises(ValueError, match="Available coordinates") as exc_info:
+            resample_dataset_temporal(ds, target_freq, "tas")
+        assert "'x'" in str(exc_info.value)
+
+    def test_validate_incompatible_includes_detected_and_target(self):
+        """Incompatible-frequency error must include detected= and target= values."""
+        # Monthly dataset; ask for daily (upsampling — not allowed)
+        time = pd.date_range("2020-01-01", periods=12, freq="MS")
+        ds = xr.Dataset(
+            {
+                "tas": (
+                    ["time"],
+                    np.random.normal(290, 5, 12),
+                    {"units": "K"},
+                ),
+                "time_bnds": (
+                    ["time", "bnds"],
+                    np.zeros((12, 2)),
+                ),
+            },
+            coords={
+                "time": (
+                    "time",
+                    time,
+                    {"units": "days since 1850-01-01", "calendar": "standard"},
+                )
+            },
+        )
+
+        with pytest.raises(IncompatibleFrequencyError) as exc_info:
+            validate_and_resample_if_needed(ds, "day.tas", "tas")
+
+        msg = str(exc_info.value)
+        assert "Cannot resample 'day.tas'" in msg
+        assert "detected=" in msg
+        assert "target=" in msg
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -17,6 +17,8 @@ from access_moppy.utilities import (
     _detect_frequency_from_bounds,
     _infer_frequency,
     _model_mapping_file_exists,
+    calculate_latitude_bounds,
+    calculate_longitude_bounds,
     calculate_time_bounds,
     create_ilamb_data_tree,
     create_ilamb_model_symlinks,
@@ -310,6 +312,37 @@ class TestInferFrequency:
 
         freq = _infer_frequency(time_values)
         assert freq is None
+
+
+class TestDetectTimeFrequencyLazyErrors:
+    """Tests that detect_time_frequency_lazy includes available coords in errors."""
+
+    def test_missing_time_coord_lists_available_coords(self):
+        """Missing time coord error must list the coords actually present."""
+        ds = xr.Dataset(coords={"foo": [1, 2, 3], "bar": [4, 5, 6]})
+        with pytest.raises(ValueError, match="Available coordinates") as exc_info:
+            detect_time_frequency_lazy(ds)
+        msg = str(exc_info.value)
+        assert "foo" in msg
+        assert "bar" in msg
+
+
+class TestLatLonBoundsErrors:
+    """Tests that calculate_latitude_bounds / calculate_longitude_bounds include available coords."""
+
+    def test_calculate_latitude_bounds_lists_available_coords(self):
+        """Missing latitude coord error must list available coords."""
+        ds = xr.Dataset(coords={"foo": [1, 2, 3]})
+        with pytest.raises(ValueError, match="Available coordinates") as exc_info:
+            calculate_latitude_bounds(ds)
+        assert "foo" in str(exc_info.value)
+
+    def test_calculate_longitude_bounds_lists_available_coords(self):
+        """Missing longitude coord error must list available coords."""
+        ds = xr.Dataset(coords={"foo": [1, 2, 3]})
+        with pytest.raises(ValueError, match="Available coordinates") as exc_info:
+            calculate_longitude_bounds(ds)
+        assert "foo" in str(exc_info.value)
 
 
 class TestCalculateTimeBoundsEdgeCases:

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -810,3 +810,83 @@ def test_get_nominal_resolution_multiple_realms_target_missing_key(
         },
     )
     assert vocab._get_nominal_resolution(target_realm="atmos") is None
+
+
+# ---------------------------------------------------------------------------
+# Error message context: _get_experiment / _get_source / _load_table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_experiment_error_lists_available(mock_vocab_data, mock_table_data):
+    """Unknown experiment_id error must list available experiments from the CV."""
+    with (
+        patch.object(
+            CMIP6Vocabulary, "_load_controlled_vocab", return_value=mock_vocab_data
+        ),
+        patch.object(CMIP6Vocabulary, "_load_table", return_value=mock_table_data),
+        pytest.raises(
+            ValueError, match="Experiment 'unknownExp' not found"
+        ) as exc_info,
+    ):
+        CMIP6Vocabulary(
+            compound_name="Amon.tas",
+            experiment_id="unknownExp",
+            source_id="ACCESS-ESM1.6",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+        )
+    msg = str(exc_info.value)
+    assert "Available experiments" in msg
+    assert "piControl" in msg
+
+
+@pytest.mark.unit
+def test_get_source_error_lists_available(mock_vocab_data, mock_table_data):
+    """Unknown source_id error must list available source_ids from the CV."""
+    with (
+        patch.object(
+            CMIP6Vocabulary, "_load_controlled_vocab", return_value=mock_vocab_data
+        ),
+        patch.object(CMIP6Vocabulary, "_load_table", return_value=mock_table_data),
+        pytest.raises(ValueError, match="Source 'UNKNOWN-MODEL' not found") as exc_info,
+    ):
+        CMIP6Vocabulary(
+            compound_name="Amon.tas",
+            experiment_id="piControl",
+            source_id="UNKNOWN-MODEL",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+        )
+    msg = str(exc_info.value)
+    assert "Available source_ids" in msg
+    assert "ACCESS-ESM1.6" in msg
+
+
+@pytest.mark.unit
+def test_load_table_error_includes_filename_and_directory(
+    mock_vocab_data, mock_table_data
+):
+    """Missing table file raises FileNotFoundError with the searched filename and table name."""
+    # Build a vocab where loading succeeds, then call _load_table for a non-existent table
+    with (
+        patch.object(
+            CMIP6Vocabulary, "_load_controlled_vocab", return_value=mock_vocab_data
+        ),
+        patch.object(CMIP6Vocabulary, "_load_table", return_value=mock_table_data),
+    ):
+        vocab = CMIP6Vocabulary(
+            compound_name="Amon.tas",
+            experiment_id="piControl",
+            source_id="ACCESS-ESM1.6",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+        )
+
+    # Force a load failure for a non-existent table
+    vocab.table = "NonexistentTable12345"
+    with pytest.raises(FileNotFoundError, match="NonexistentTable12345") as exc_info:
+        vocab._load_table()
+    msg = str(exc_info.value)
+    assert "looked for" in msg
+    assert str(vocab.table_dir) in msg


### PR DESCRIPTION
# Improve error messages in `Ocean_CMORiser`, `SeaIce_CMORiser`, and `Atmosphere_CMORiser`

## Summary

Several error messages across `ocean.py`, `sea_ice.py`, and `atmosphere.py` are either missing
context, inconsistent across sibling classes, or silent where they should raise. This issue
documents each case with the exact current message and the proposed replacement.

Extended scope covers `base.py`, `driver.py`, `ocean_supergrid.py`,
`vocabulary_processors.py`, `utilities.py`, and `derivations/calc_seaice.py`.

---

## Part 1 — Enhanced existing error messages

### 1.1 `src/access_moppy/base.py`

#### `_check_units()`

**Current:**
```python
raise ValueError(f"Mapping units mismatch for {self.cmor_name} ...")
```

**Proposed:** add fix hint
```python
raise ValueError(
    f"Mapping units mismatch for {self.cmor_name} ... "
    f"Update the 'units' field in the variable mapping file."
)
```

#### `_check_calendar()`

**Current:** no `calendar` / `units` context in the message.

**Proposed:** include `calendar` and `units` values so the reader does not have to open the file.

#### `_check_range()`

**Current:** no actual min/max values.

**Proposed:** include the actual minimum and maximum found in the data so out-of-range values can be located immediately.

---

### 1.2 `src/access_moppy/ocean.py`

#### Issue 1 — `custom_functions` lookup: missing CMOR variable name and available function list

**Files affected:**
- `src/access_moppy/ocean.py` line 72–74
- `src/access_moppy/sea_ice.py` line 121–123
- `src/access_moppy/atmosphere.py` line 127–129

**Current (all three files):**
```python
raise ValueError(
    f"Internal calculation function '{func_name}' not found in custom_functions"
)
```

**Problem:** The message does not say which CMOR variable triggered the failure or what
functions are actually registered, so the user must guess where to look in the mapping files.

**Proposed:**
```python
raise ValueError(
    f"Internal calculation function '{func_name}' not found in custom_functions "
    f"(processing CMOR variable '{self.cmor_name}'). "
    f"Available functions: {sorted(custom_functions.keys())}"
)
```

---

#### Issue 2 — Internal function output check: missing list of variables actually generated

**Files affected:**
- `src/access_moppy/ocean.py` line 84–87
- `src/access_moppy/sea_ice.py` line 133–136
- `src/access_moppy/atmosphere.py` line 140–142

**Current (all three files):**
```python
raise ValueError(
    f"Internal calculation function '{func_name}' did not generate variable '{self.cmor_name}'"
)
```

**Problem:** The user knows what was expected but not what the function actually produced,
making it hard to diagnose a naming mismatch in the function implementation.

**Proposed:**
```python
raise ValueError(
    f"Internal calculation function '{func_name}' did not generate the expected "
    f"variable '{self.cmor_name}'. "
    f"Variables present in the returned dataset: {sorted(self.ds.data_vars)}"
)
```

---

#### Issue 3 — Unsupported calculation type: inconsistency between `ocean.py`/`sea_ice.py` and `atmosphere.py`

**Files affected (weak version):**
- `src/access_moppy/ocean.py` line 139
- `src/access_moppy/sea_ice.py` line 186

**Files unaffected (already correct):**
- `src/access_moppy/atmosphere.py` lines 244–247 ✓

**Current in `ocean.py` and `sea_ice.py`:**
```python
raise ValueError(f"Unsupported calculation type: {calc['type']}")
```

**Current in `atmosphere.py` (reference — already correct):**
```python
raise ValueError(
    f"Unsupported calculation type '{calc['type']}' for '{self.cmor_name}'. "
    f"Supported: 'direct', 'formula', 'dataset_function', 'internal'."
)
```

**Proposed (apply to `ocean.py` line 139 and `sea_ice.py` line 186):**
```python
raise ValueError(
    f"Unsupported calculation type '{calc['type']}' for '{self.cmor_name}'. "
    f"Supported: 'direct', 'formula', 'dataset_function', 'internal'."
)
```

---

#### `Ocean_CMORiser_OM2.infer_grid_type()`

**Proposed:** list all expected coordinate sets and the coordinates actually found; label as `(MOM5/OM2)`.

#### `Ocean_CMORiser_OM2._get_dim_rename()`

**Proposed:** list all supported `source_id` values in the error message.

#### `Ocean_CMORiser_OM3.infer_grid_type()`

**Proposed:** same pattern as OM2; label as `(MOM6/OM3)`.

#### `Ocean_CMORiser_OM3._get_dim_rename()`

**Proposed:** state that `source_id` must contain `'ACCESS-OM3'` or `'ACCESS-CM'`.

---

### 1.3 `src/access_moppy/sea_ice.py`

#### `infer_grid_type()`

**Proposed:** list each data variable together with its `coordinates` attribute value so the user can see exactly why inference failed.

#### `_get_dim_rename()`

**Proposed:** state that `source_id` must start with `'ACCESS-'`.

---

### 1.4 `src/access_moppy/ocean_supergrid.py`

#### `get_supergrid_path()`

**Proposed:** list all supported resolutions: `"100 km"`, `"25 km"`, `"10 km"`.

#### `extract_grid()` — unsupported `grid_type`

**Proposed:** list supported grid types: `['T', 'U', 'V', 'C']`.

#### `extract_grid()` — unsupported `arakawa`

**Proposed:** state that only `'B'` or `'C'` are accepted.

---

### 1.5 `src/access_moppy/atmosphere.py`

#### `calculate_missing_bounds_variables()`

**Proposed:** list the coordinate names currently present in the dataset.

#### `select_and_process_variables()` — else branch

**Proposed:** list all supported calculation types (`'direct'`, `'formula'`, `'dataset_function'`, `'internal'`).

---

### 1.6 `src/access_moppy/vocabulary_processors.py`

#### `_get_experiment()`

**Proposed:** list all available `experiment_id` values from the controlled vocabulary.

#### `_get_source()`

**Proposed:** list all available `source_id` values from the controlled vocabulary.

#### `_load_table()`

**Proposed:** include the filename being searched and the directory path in the error message.

---

### 1.7 `src/access_moppy/utilities.py`

#### `detect_time_frequency_lazy()`

**Proposed:** list the coordinates actually present in the dataset.

#### `resample_dataset_temporal()`

**Proposed:** add variable name, resampling method, and target frequency to the `except` branch message.

#### `validate_and_resample_if_needed()`

**Proposed:** include `compound_name`, `detected_freq`, and `target_freq` in the error context.

---

### 1.8 `src/access_moppy/derivations/calc_seaice.py`

#### `calc_hemi_seaice()`

**Proposed:** state explicitly that the only valid values are `'north'` and `'south'`.

---

## Part 2 — Logic gap fixes (new validation added)

### Fix 1 — `src/access_moppy/driver.py`: unknown CMIP table name falls through silently

**Problem:** When the table name extracted from `compound_name` does not match any known
atmosphere, ocean, or sea-ice table, the code fails silently with no actionable message.

**Fix:** add an `else` branch that raises `ValueError` and lists all three groups of
supported table names:

```python
else:
    _atmos_tables = (
        "Amon", "Lmon", "LImon", "Emon", "AERmon", "AERday",
        "day", "CFmon", "CFday", "3hr", "6hrPlev", "E1hr", "Eday",
        "fx", "Efx", "atmos",
    )
    _ocean_tables = ("Oyr", "Oday", "Omon", "Ofx")
    _seaice_tables = ("SImon", "SIday")
    raise ValueError(
        f"Unsupported CMIP table '{table}' in compound_name '{compound_name}'. "
        f"Supported tables — "
        f"atmosphere: {_atmos_tables}, "
        f"ocean: {_ocean_tables}, "
        f"sea-ice: {_seaice_tables}."
    )
```

---

### Fix 3 — `src/access_moppy/sea_ice.py`: missing model-variable check in `formula` branch

**Problem:** `select_and_process_variables()` constructs the formula context directly
without checking whether all `model_variables` are present in the dataset, producing a
cryptic `KeyError` at evaluation time.

**Fix:** validate before constructing the context:

```python
elif calc["type"] == "formula":
    missing_model_vars = [v for v in required_vars if v not in self.ds]
    if missing_model_vars:
        raise KeyError(
            f"Required model variable(s) {missing_model_vars} not found in input "
            f"files for '{self.cmor_name}'. "
            f"Available data variables: {sorted(self.ds.data_vars)}. "
            f"Check 'model_variables' in the mapping."
        )
    context = {var: self.ds[var] for var in required_vars}
```

---

### Fix 4 — `ocean.py` & `sea_ice.py`: empty `model_variables` for `direct`/`dataset_function`

**Problem:** When `model_variables` is an empty list and `calc type` is `direct` or
`dataset_function`, subsequent code fails with an index error or `KeyError` that gives no
indication of the root cause.

**Fix:** add a pre-flight check (applies to both `Ocean_CMORiser` and `SeaIce_CMORiser`):

```python
if calc["type"] in ("direct", "dataset_function") and not required_vars:
    raise ValueError(
        f"Calculation type '{calc['type']}' for '{self.cmor_name}' requires at least "
        f"one model_variable, but 'model_variables' is empty in the mapping."
    )
```

---

#### Issue 4 — `ocean.py` silently drops missing formula variables; siblings raise explicitly

**File affected:** `src/access_moppy/ocean.py` lines 129–132

**Current in `ocean.py`:**
```python
elif calc["type"] == "formula":
    # Variables listed in model_variables that are absent from the
    # loaded dataset (e.g. optional frazil fields) are silently
    # omitted from the context; individual derivation functions
    # handle the None case via {"optional": ...} expressions.
    context = {var: self.ds[var] for var in required_vars if var in self.ds}
```

**Current in `sea_ice.py` lines 168–175 (reference — already correct):**
```python
elif calc["type"] == "formula":
    missing_model_vars = [v for v in required_vars if v not in self.ds]
    if missing_model_vars:
        raise KeyError(
            f"Required model variable(s) {missing_model_vars} not found in input "
            f"files for '{self.cmor_name}'. "
            f"Available data variables: {sorted(self.ds.data_vars)}. "
            f"Check 'model_variables' in the mapping."
        )
    context = {var: self.ds[var] for var in required_vars}
```

**Problem:** In `ocean.py`, a misspelled or missing model variable in the mapping is
silently excluded from the formula context. The formula then fails with a cryptic
`KeyError` or produces a wrong result with no diagnostic message. The comment mentions
"optional frazil fields" as justification, but this opt-out applies to all ocean
formula variables indiscriminately.

**Proposed:** until the mapping schema supports an explicit `"optional": true` field,
emit a `UserWarning` for each silently skipped variable:

```python
elif calc["type"] == "formula":
    missing_model_vars = [v for v in required_vars if v not in self.ds]
    for v in missing_model_vars:
        import warnings
        warnings.warn(
            f"Optional model variable '{v}' not found in input files for "
            f"'{self.cmor_name}' — excluded from formula context. "
            f"If this variable is required, check 'model_variables' in the mapping.",
            UserWarning,
            stacklevel=2,
        )
    context = {var: self.ds[var] for var in required_vars if var in self.ds}
```

---

## Part 3 — Test updates

### 3.1 Existing tests updated (match strings)

| File | Old match | New match |
|---|---|---|
| `tests/unit/test_derivations_calc_seaice.py` line 142 | `"invalid hemisphere"` | `"[Ii]nvalid hemisphere"` |
| `tests/unit/test_supergrid.py` line 83 | `"Unknown or unsupported nominal resolution"` | `"Unknown nominal resolution"` |
| `tests/unit/test_supergrid.py` line 205 | `"is not a supported grid_type"` | `"is not supported for arakawa"` |
| `tests/unit/test_base.py` line 2229 | `"Mapping units mismatch for tas"` | `"Mapping units mismatch for"` |

---

### 3.2 New tests added

#### `tests/unit/test_driver.py` — Fix 1 (2 tests)

| Test name | What it verifies |
|---|---|
| `test_unsupported_table_raises_value_error_with_supported_list` | Unknown table name triggers `ValueError`; message contains the table name |
| `test_unsupported_table_error_lists_known_tables` | Error message contains representative table names from all three groups |

#### `tests/unit/test_ocean.py` — enhanced errors + Fix 4 (4 tests)

| Test name | Class | What it verifies |
|---|---|---|
| `test_infer_grid_type_unknown_coords_raises_with_context` | `TestCMIP6OceanCMORiserOM2` | Coordinate mismatch raises `ValueError` with `MOM5/OM2` context |
| `test_select_and_process_empty_required_vars_direct_raises` | `TestCMIP6OceanCMORiserOM2` | Empty `model_variables` + `direct` type raises `ValueError` |
| `test_infer_grid_type_unknown_coords_raises_with_context` | `TestCMIP6OceanCMORiserOM3` | Coordinate mismatch raises `ValueError` with `MOM6/OM3` context |
| `test_select_and_process_empty_required_vars_direct_raises` | `TestCMIP6OceanCMORiserOM3` | Empty `model_variables` + `direct` type raises `ValueError` |

#### `tests/unit/test_sea_ice.py` — Fix 3 + Fix 4 (2 tests)

| Test name | What it verifies |
|---|---|
| `test_select_and_process_missing_model_var_in_formula_raises_key_error` | Missing formula variable raises `KeyError` containing the variable name |
| `test_select_and_process_empty_required_vars_direct_raises` | Empty `model_variables` + `direct` type raises `ValueError` |

---

## Part 4 — Intentionally not modified

| Location | Reason |
|---|---|
| `ocean_supergrid.py` `RuntimeError` (download failure) | Explicitly excluded by user |
| `atmosphere.py` internal calculation function errors | Explicitly excluded by user |
| `utilities.py` `"Could not detect frequency..."` error | Explicitly excluded by user |
| All files under `esmval/` | Explicitly excluded by user |

---

## Part 5 — Outstanding items (not yet implemented)

| ID | Location | Description |
|---|---|---|
| Fix 2 | `driver.py` | `SeaIce_CMORiser` is passed a `VariableMapping` object instead of `.to_dict()`, inconsistent with other CMORisers |
| Fix 5 | `ocean.py` `update_attributes()` | After an `internal` calc path, `self.grid_type` is `None`; `extract_grid()` is called without a guard |
| Fix 6 | `base.py` `write()` / `run()` | `self.ds is None` has no protection before these methods proceed |
| Fix 7 | `atmosphere.py` | `self.vocab.axes[dim]` raises a bare `KeyError` when `dim` is absent |

---

## Summary Table

| # | File | Location | Type | Status |
|---|---|---|---|---|
| 1 | `ocean.py`, `sea_ice.py`, `atmosphere.py` | `custom_functions` lookup | Missing CMOR name + function list in `ValueError` | Proposed |
| 2 | `ocean.py`, `sea_ice.py`, `atmosphere.py` | Internal function output check | Missing generated-vars list in `ValueError` | Proposed |
| 3 | `ocean.py`, `sea_ice.py` | Unsupported calc type | Inconsistent with `atmosphere.py` | Proposed |
| 4 | `ocean.py` | `formula` branch | Silent variable skip; no warning | Proposed |
| 5 | `base.py` | `_check_units/calendar/range` | Missing context fields | Proposed |
| 6 | `ocean.py` | `infer_grid_type` / `_get_dim_rename` | OM2 + OM3 context improvements | Proposed |
| 7 | `sea_ice.py` | `infer_grid_type` / `_get_dim_rename` | Coordinate attr dump + source_id hint | Proposed |
| 8 | `ocean_supergrid.py` | `get_supergrid_path` / `extract_grid` | Supported values listed | Proposed |
| 9 | `atmosphere.py` | `calculate_missing_bounds_variables` + else | Available coords + supported types | Proposed |
| 10 | `vocabulary_processors.py` | `_get_experiment/source/_load_table` | CV values + file path in message | Proposed |
| 11 | `utilities.py` | `detect_time_frequency_lazy` / `resample` / `validate` | Freq + variable context | Proposed |
| 12 | `calc_seaice.py` | `calc_hemi_seaice` | Hemisphere valid values | Proposed |
| Fix 1 | `driver.py` | Unknown CMIP table name | Silent failure → `ValueError` with table lists | Proposed |
| Fix 3 | `sea_ice.py` | `formula` missing-variable check | Silent `KeyError` → explicit `KeyError` | Proposed |
| Fix 4 | `ocean.py`, `sea_ice.py` | Empty `model_variables` pre-flight | Silent index error → `ValueError` | Proposed |
