### PR TITLE
add CLI dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ dynamic = ["version"]
 dashboard = [
   "streamlit>=1.35.0"
 ]
+# pip install access_moppy[tui]
+# Terminal dashboard alternative for environments without browser access
+# (e.g. plain SSH into Gadi login nodes).
+tui = [
+  "rich>=13"
+]
 # pip install access_moppy[atmos-tools]
 # Required for the moppy-calc-ab-coeffts utility that reads UM vertlevs
 # Fortran namelist files to compute correct hybrid-height b coefficients.
@@ -75,6 +81,7 @@ docs = [
 [project.scripts]
 moppy-cmorise = "access_moppy.batch_cmoriser:main"
 moppy-dashboard = "access_moppy.dashboard.cmor_dashboard:main"
+moppy-tui = "access_moppy.dashboard.cli_dashboard:main"
 moppy-example-config = "access_moppy.examples.show_config:main"
 moppy-calc-ab-coeffts = "access_moppy.legacy_utilities.calc_hybrid_height_coeffs:main"
 moppy-esmval-prepare = "access_moppy.esmval.cli_commands:main_prepare"

--- a/src/access_moppy/dashboard/cli_dashboard.py
+++ b/src/access_moppy/dashboard/cli_dashboard.py
@@ -210,9 +210,7 @@ def clamp_offset(offset: int, page_size: int, n_visible: int) -> int:
     return max(0, min(offset, max_offset))
 
 
-def apply_key(
-    key: str, offset: int, page_size: int, n_visible: int
-) -> int:
+def apply_key(key: str, offset: int, page_size: int, n_visible: int) -> int:
     """Pure key→offset mapping. Unit-tested without termios."""
     max_offset = max(0, n_visible - page_size)
     if key in ("j", "\x1b[B"):
@@ -266,9 +264,7 @@ def render(
         (snap.refreshed_at.strftime("%Y-%m-%d %H:%M:%S"), "magenta"),
     )
 
-    bar = ProgressBar(
-        total=max(snap.total, 1), completed=snap.completed, width=40
-    )
+    bar = ProgressBar(total=max(snap.total, 1), completed=snap.completed, width=40)
     pct = f"{snap.progress_fraction * 100:5.1f}%"
     eta_text = _format_duration(snap.eta_seconds)
     progress_line = Text.assemble(
@@ -282,9 +278,7 @@ def render(
     for status in STATUS_ORDER:
         n = snap.summary.get(status, 0)
         summary_text.append(f"{status} ", style=STATUS_STYLE.get(status, ""))
-        summary_text.append(
-            f"{n}   ", style=f"bold {STATUS_STYLE.get(status, '')}"
-        )
+        summary_text.append(f"{n}   ", style=f"bold {STATUS_STYLE.get(status, '')}")
 
     n_visible = len(snap.tasks)
     offset = clamp_offset(offset, page_size, n_visible)
@@ -316,8 +310,7 @@ def render(
         title = f"Tasks {first}-{last} of {n_visible}"
     else:
         title = (
-            f"Tasks {first}-{last} of {n_visible} filtered "
-            f"(DB total {snap.total})"
+            f"Tasks {first}-{last} of {n_visible} filtered " f"(DB total {snap.total})"
         )
 
     panels = [
@@ -332,9 +325,7 @@ def render(
     ]
 
     if snap.failures:
-        fail_table = Table(
-            expand=True, header_style="bold red", show_lines=False
-        )
+        fail_table = Table(expand=True, header_style="bold red", show_lines=False)
         fail_table.add_column("Variable")
         fail_table.add_column("Experiment")
         fail_table.add_column("Error", overflow="fold")
@@ -347,20 +338,30 @@ def render(
                 f["experiment_id"] or "",
                 err,
             )
-        panels.append(
-            Panel(fail_table, border_style="red", title="Recent failures")
-        )
+        panels.append(Panel(fail_table, border_style="red", title="Recent failures"))
 
     if show_footer:
         hint = Text.assemble(
-            ("  j/", "dim"), ("↓", "bold"), (" down  ", "dim"),
-            ("k/", "dim"), ("↑", "bold"), (" up  ", "dim"),
-            ("n/", "dim"), ("Space", "bold"), (" pgDn  ", "dim"),
-            ("p/", "dim"), ("b", "bold"), (" pgUp  ", "dim"),
-            ("g", "bold"), (" top  ", "dim"),
-            ("G", "bold"), (" bottom  ", "dim"),
-            ("r", "bold"), (" refresh  ", "dim"),
-            ("q", "bold"), (" quit", "dim"),
+            ("  j/", "dim"),
+            ("↓", "bold"),
+            (" down  ", "dim"),
+            ("k/", "dim"),
+            ("↑", "bold"),
+            (" up  ", "dim"),
+            ("n/", "dim"),
+            ("Space", "bold"),
+            (" pgDn  ", "dim"),
+            ("p/", "dim"),
+            ("b", "bold"),
+            (" pgUp  ", "dim"),
+            ("g", "bold"),
+            (" top  ", "dim"),
+            ("G", "bold"),
+            (" bottom  ", "dim"),
+            ("r", "bold"),
+            (" refresh  ", "dim"),
+            ("q", "bold"),
+            (" quit", "dim"),
         )
         panels.append(Panel(hint, border_style="dim"))
 
@@ -495,9 +496,7 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit a machine-readable JSON snapshot and exit.",
     )
-    parser.add_argument(
-        "--no-color", action="store_true", help="Disable ANSI colors."
-    )
+    parser.add_argument("--no-color", action="store_true", help="Disable ANSI colors.")
     return parser
 
 
@@ -508,8 +507,7 @@ def _parse_statuses(value: Optional[str]) -> Optional[list[str]]:
     invalid = [s for s in parsed if s not in STATUS_STYLE]
     if invalid:
         raise SystemExit(
-            f"Invalid status value(s): {invalid}. "
-            f"Allowed: {sorted(STATUS_STYLE)}."
+            f"Invalid status value(s): {invalid}. " f"Allowed: {sorted(STATUS_STYLE)}."
         )
     return parsed
 
@@ -538,7 +536,9 @@ def _run_live(args, db_path, statuses) -> int:
     with _cbreak_mode() as interactive:
         try:
             with Live(
-                render(snap, offset=offset, page_size=page_size, show_footer=interactive),
+                render(
+                    snap, offset=offset, page_size=page_size, show_footer=interactive
+                ),
                 console=console,
                 refresh_per_second=10,
                 screen=False,
@@ -610,9 +610,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.once:
         console = Console(no_color=args.no_color)
         snap = take_snapshot()
-        offset = clamp_offset(
-            (args.page - 1) * page_size, page_size, len(snap.tasks)
-        )
+        offset = clamp_offset((args.page - 1) * page_size, page_size, len(snap.tasks))
         console.print(
             render(snap, offset=offset, page_size=page_size, show_footer=False)
         )

--- a/src/access_moppy/dashboard/cli_dashboard.py
+++ b/src/access_moppy/dashboard/cli_dashboard.py
@@ -1,0 +1,625 @@
+"""Terminal dashboard for the CMORisation tracker.
+
+A `rich`-based alternative to the Streamlit dashboard. Reads the same
+`cmor_tasks` SQLite database, so it can run side-by-side with the web UI.
+
+Live mode supports interactive paging:
+
+    j / ↓     scroll down one row
+    k / ↑     scroll up one row
+    n / Space page down
+    p / b     page up
+    g         jump to top
+    G         jump to bottom
+    r         force DB re-read
+    q / Ctrl-C / Ctrl-D    quit
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import select
+import sqlite3
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+STATUS_ORDER = ("running", "pending", "failed", "completed")
+STATUS_STYLE = {
+    "running": "cyan",
+    "pending": "dim",
+    "failed": "red",
+    "completed": "green",
+}
+
+# Hard cap on rows pulled from the DB into a Snapshot. Larger than any
+# realistic batch size, so pagination operates fully in-memory.
+DEFAULT_LOAD_LIMIT = 10_000
+
+
+def resolve_db_path(cli_value: Optional[str]) -> Path:
+    if cli_value:
+        return Path(cli_value).expanduser()
+    env_value = os.environ.get("CMOR_TRACKER_DB")
+    if env_value:
+        return Path(env_value).expanduser()
+    return Path.home() / ".moppy" / "db" / "cmor_tasks.db"
+
+
+@dataclass
+class Snapshot:
+    db_path: Path
+    refreshed_at: datetime
+    summary: dict[str, int] = field(default_factory=dict)
+    tasks: list[dict] = field(default_factory=list)
+    failures: list[dict] = field(default_factory=list)
+    total: int = 0
+    completed: int = 0
+    avg_completed_seconds: Optional[float] = None
+    error: Optional[str] = None
+
+    @property
+    def progress_fraction(self) -> float:
+        return self.completed / self.total if self.total else 0.0
+
+    @property
+    def eta_seconds(self) -> Optional[float]:
+        if self.avg_completed_seconds is None:
+            return None
+        remaining = self.total - self.completed
+        if remaining <= 0:
+            return 0.0
+        return self.avg_completed_seconds * remaining
+
+
+def _open_readonly(db_path: Path) -> sqlite3.Connection:
+    uri = f"file:{db_path}?mode=ro"
+    return sqlite3.connect(uri, uri=True, timeout=5)
+
+
+def load_snapshot(
+    db_path: Path,
+    statuses: Optional[list[str]] = None,
+    experiment: Optional[str] = None,
+    max_rows: int = DEFAULT_LOAD_LIMIT,
+    max_failures: int = 10,
+) -> Snapshot:
+    snap = Snapshot(db_path=db_path, refreshed_at=datetime.now())
+
+    if not db_path.exists():
+        snap.error = f"Database not found: {db_path}"
+        return snap
+
+    try:
+        conn = _open_readonly(db_path)
+    except sqlite3.OperationalError as exc:
+        snap.error = f"Cannot open database (read-only): {exc}"
+        return snap
+
+    try:
+        conn.row_factory = sqlite3.Row
+        try:
+            summary_rows = conn.execute(
+                "SELECT status, COUNT(*) AS n FROM cmor_tasks GROUP BY status"
+            ).fetchall()
+        except sqlite3.OperationalError as exc:
+            snap.error = f"Table 'cmor_tasks' not ready yet: {exc}"
+            return snap
+
+        snap.summary = {row["status"]: row["n"] for row in summary_rows}
+        snap.total = sum(snap.summary.values())
+        snap.completed = snap.summary.get("completed", 0)
+
+        avg_row = conn.execute(
+            """
+            SELECT AVG((julianday(end_time) - julianday(start_time)) * 86400.0) AS avg_s
+            FROM cmor_tasks
+            WHERE status = 'completed'
+              AND start_time IS NOT NULL
+              AND end_time IS NOT NULL
+            """
+        ).fetchone()
+        if avg_row and avg_row["avg_s"] is not None:
+            snap.avg_completed_seconds = float(avg_row["avg_s"])
+
+        clauses, params = [], []
+        if statuses:
+            placeholders = ",".join("?" for _ in statuses)
+            clauses.append(f"status IN ({placeholders})")
+            params.extend(statuses)
+        if experiment:
+            clauses.append("experiment_id = ?")
+            params.append(experiment)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = conn.execute(
+            f"""
+            SELECT variable, experiment_id, status, start_time, end_time
+            FROM cmor_tasks
+            {where}
+            ORDER BY
+                CASE status
+                    WHEN 'running'   THEN 0
+                    WHEN 'pending'   THEN 1
+                    WHEN 'failed'    THEN 2
+                    ELSE 3
+                END,
+                start_time IS NULL,
+                start_time DESC,
+                variable ASC
+            LIMIT ?
+            """,
+            (*params, max_rows),
+        ).fetchall()
+        snap.tasks = [dict(r) for r in rows]
+
+        fail_rows = conn.execute(
+            """
+            SELECT variable, experiment_id, error_message, end_time
+            FROM cmor_tasks
+            WHERE status = 'failed'
+            ORDER BY end_time DESC
+            LIMIT ?
+            """,
+            (max_failures,),
+        ).fetchall()
+        snap.failures = [dict(r) for r in fail_rows]
+    finally:
+        conn.close()
+    return snap
+
+
+def _format_duration(seconds: Optional[float]) -> str:
+    if seconds is None or seconds < 0:
+        return "—"
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def _row_duration(row: dict) -> Optional[float]:
+    start = row.get("start_time")
+    end = row.get("end_time")
+    if not start:
+        return None
+    try:
+        start_dt = datetime.fromisoformat(start)
+    except ValueError:
+        return None
+    if end:
+        try:
+            end_dt = datetime.fromisoformat(end)
+        except ValueError:
+            return None
+    else:
+        end_dt = datetime.now()
+    return (end_dt - start_dt).total_seconds()
+
+
+def clamp_offset(offset: int, page_size: int, n_visible: int) -> int:
+    """Snap an offset into the valid range after DB changes or paging."""
+    if n_visible <= 0 or page_size <= 0:
+        return 0
+    max_offset = max(0, n_visible - page_size)
+    return max(0, min(offset, max_offset))
+
+
+def apply_key(
+    key: str, offset: int, page_size: int, n_visible: int
+) -> int:
+    """Pure key→offset mapping. Unit-tested without termios."""
+    max_offset = max(0, n_visible - page_size)
+    if key in ("j", "\x1b[B"):
+        return min(offset + 1, max_offset)
+    if key in ("k", "\x1b[A"):
+        return max(0, offset - 1)
+    if key in ("n", " ", "\x1b[6~"):
+        return min(offset + page_size, max_offset)
+    if key in ("p", "b", "\x1b[5~"):
+        return max(0, offset - page_size)
+    if key == "g":
+        return 0
+    if key == "G":
+        return max_offset
+    return offset
+
+
+def is_quit_key(key: str) -> bool:
+    return key in ("q", "Q", "\x03", "\x04")
+
+
+def render(
+    snap: Snapshot,
+    offset: int = 0,
+    page_size: int = 20,
+    show_footer: bool = False,
+):
+    """Build the rich renderable for a snapshot.
+
+    `offset` and `page_size` slice `snap.tasks` for paging.
+    `show_footer` adds the keyboard-hint line (only useful in live mode).
+    """
+    from rich.console import Group
+    from rich.panel import Panel
+    from rich.progress_bar import ProgressBar
+    from rich.table import Table
+    from rich.text import Text
+
+    if snap.error:
+        return Panel(
+            Text(snap.error, style="red"),
+            title="ACCESS-MOPPy CMORisation Monitor",
+            border_style="red",
+        )
+
+    header = Text.assemble(
+        ("DB: ", "bold"),
+        (str(snap.db_path), "magenta"),
+        "    ",
+        ("refreshed: ", "bold"),
+        (snap.refreshed_at.strftime("%Y-%m-%d %H:%M:%S"), "magenta"),
+    )
+
+    bar = ProgressBar(
+        total=max(snap.total, 1), completed=snap.completed, width=40
+    )
+    pct = f"{snap.progress_fraction * 100:5.1f}%"
+    eta_text = _format_duration(snap.eta_seconds)
+    progress_line = Text.assemble(
+        (f"  {pct}", "bold"),
+        (f"   completed {snap.completed} / {snap.total}", ""),
+        (f"   ETA {eta_text}", "dim"),
+    )
+    progress_group = Group(bar, progress_line)
+
+    summary_text = Text("  ")
+    for status in STATUS_ORDER:
+        n = snap.summary.get(status, 0)
+        summary_text.append(f"{status} ", style=STATUS_STYLE.get(status, ""))
+        summary_text.append(
+            f"{n}   ", style=f"bold {STATUS_STYLE.get(status, '')}"
+        )
+
+    n_visible = len(snap.tasks)
+    offset = clamp_offset(offset, page_size, n_visible)
+    page = snap.tasks[offset : offset + page_size]
+    first = offset + 1 if n_visible else 0
+    last = offset + len(page)
+
+    task_table = Table(
+        expand=True, show_lines=False, header_style="bold", pad_edge=False
+    )
+    task_table.add_column("#", justify="right", style="dim", no_wrap=True)
+    task_table.add_column("Variable", overflow="fold")
+    task_table.add_column("Experiment", overflow="fold")
+    task_table.add_column("Status")
+    task_table.add_column("Started", overflow="fold")
+    task_table.add_column("Duration", justify="right")
+    for i, row in enumerate(page, start=offset + 1):
+        status = row["status"]
+        task_table.add_row(
+            str(i),
+            row["variable"] or "",
+            row["experiment_id"] or "",
+            Text(status, style=STATUS_STYLE.get(status, "")),
+            row.get("start_time") or "—",
+            _format_duration(_row_duration(row)),
+        )
+
+    if snap.total == n_visible:
+        title = f"Tasks {first}-{last} of {n_visible}"
+    else:
+        title = (
+            f"Tasks {first}-{last} of {n_visible} filtered "
+            f"(DB total {snap.total})"
+        )
+
+    panels = [
+        Panel(
+            header,
+            border_style="blue",
+            title="ACCESS-MOPPy CMORisation Monitor",
+        ),
+        Panel(progress_group, border_style="blue", title="Progress"),
+        Panel(summary_text, border_style="blue", title="Summary"),
+        Panel(task_table, border_style="blue", title=title),
+    ]
+
+    if snap.failures:
+        fail_table = Table(
+            expand=True, header_style="bold red", show_lines=False
+        )
+        fail_table.add_column("Variable")
+        fail_table.add_column("Experiment")
+        fail_table.add_column("Error", overflow="fold")
+        for f in snap.failures:
+            err = (f.get("error_message") or "").strip().replace("\n", " ")
+            if len(err) > 160:
+                err = err[:157] + "..."
+            fail_table.add_row(
+                f["variable"] or "",
+                f["experiment_id"] or "",
+                err,
+            )
+        panels.append(
+            Panel(fail_table, border_style="red", title="Recent failures")
+        )
+
+    if show_footer:
+        hint = Text.assemble(
+            ("  j/", "dim"), ("↓", "bold"), (" down  ", "dim"),
+            ("k/", "dim"), ("↑", "bold"), (" up  ", "dim"),
+            ("n/", "dim"), ("Space", "bold"), (" pgDn  ", "dim"),
+            ("p/", "dim"), ("b", "bold"), (" pgUp  ", "dim"),
+            ("g", "bold"), (" top  ", "dim"),
+            ("G", "bold"), (" bottom  ", "dim"),
+            ("r", "bold"), (" refresh  ", "dim"),
+            ("q", "bold"), (" quit", "dim"),
+        )
+        panels.append(Panel(hint, border_style="dim"))
+
+    return Group(*panels)
+
+
+def snapshot_to_jsonable(snap: Snapshot) -> dict:
+    return {
+        "db_path": str(snap.db_path),
+        "refreshed_at": snap.refreshed_at.isoformat(timespec="seconds"),
+        "summary": snap.summary,
+        "total": snap.total,
+        "completed": snap.completed,
+        "progress_fraction": snap.progress_fraction,
+        "avg_completed_seconds": snap.avg_completed_seconds,
+        "eta_seconds": snap.eta_seconds,
+        "tasks": snap.tasks,
+        "failures": snap.failures,
+        "error": snap.error,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Keyboard handling (Live mode only)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _cbreak_mode():
+    """Put stdin in cbreak mode if it's a TTY. Yields whether it succeeded."""
+    if not sys.stdin.isatty():
+        yield False
+        return
+    try:
+        import termios
+        import tty
+    except ImportError:
+        yield False
+        return
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setcbreak(fd)
+        yield True
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+_KEY_BUFFER: list[str] = []
+
+
+def _read_key(timeout: float) -> Optional[str]:
+    """Non-blocking single-keystroke read. Returns a logical key string.
+
+    Uses ``os.read`` directly to bypass Python's TextIO buffering — without
+    this, terminal escape sequences like ``ESC [ A`` (arrow keys) arrive
+    as a single 3-byte burst from the kernel but Python's BufferedReader
+    pulls the trailing ``[A`` into its own buffer, where a subsequent
+    ``select(fd)`` cannot see them and they get dropped.
+    """
+    if _KEY_BUFFER:
+        return _KEY_BUFFER.pop(0)
+    fd = sys.stdin.fileno()
+    rlist, _, _ = select.select([fd], [], [], timeout)
+    if not rlist:
+        return None
+    try:
+        data = os.read(fd, 32)
+    except OSError:
+        return None
+    if not data:
+        return None
+    s = data.decode("utf-8", errors="replace")
+    if s.startswith("\x1b"):
+        return s
+    if len(s) > 1:
+        _KEY_BUFFER.extend(list(s[1:]))
+    return s[0]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="moppy-tui",
+        description="Terminal dashboard for ACCESS-MOPPy CMORisation tasks.",
+    )
+    parser.add_argument(
+        "--db",
+        help=(
+            "Path to cmor_tasks.db "
+            "(default: $CMOR_TRACKER_DB or ~/.moppy/db/cmor_tasks.db)."
+        ),
+    )
+    parser.add_argument(
+        "--refresh",
+        type=float,
+        default=5.0,
+        help="DB poll interval in seconds (default: 5.0). Ignored with --once/--json.",
+    )
+    parser.add_argument(
+        "--status",
+        help="Comma-separated statuses to include "
+        "(pending,running,completed,failed).",
+    )
+    parser.add_argument("--experiment", help="Filter by experiment_id.")
+    parser.add_argument(
+        "--max-rows",
+        "--page-size",
+        dest="page_size",
+        type=int,
+        default=20,
+        help="Page size: rows shown in the tasks table at a time (default: 20).",
+    )
+    parser.add_argument(
+        "--page",
+        type=int,
+        default=1,
+        help="1-based starting page (default 1). Only meaningful in --once/--json.",
+    )
+    parser.add_argument(
+        "--max-failures",
+        type=int,
+        default=10,
+        help="Rows shown in the failures panel.",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Render one snapshot and exit (useful for cron / logs).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON snapshot and exit.",
+    )
+    parser.add_argument(
+        "--no-color", action="store_true", help="Disable ANSI colors."
+    )
+    return parser
+
+
+def _parse_statuses(value: Optional[str]) -> Optional[list[str]]:
+    if not value:
+        return None
+    parsed = [s.strip() for s in value.split(",") if s.strip()]
+    invalid = [s for s in parsed if s not in STATUS_STYLE]
+    if invalid:
+        raise SystemExit(
+            f"Invalid status value(s): {invalid}. "
+            f"Allowed: {sorted(STATUS_STYLE)}."
+        )
+    return parsed
+
+
+def _run_live(args, db_path, statuses) -> int:
+    from rich.console import Console
+    from rich.live import Live
+
+    console = Console(no_color=args.no_color)
+    page_size = max(args.page_size, 1)
+
+    def take_snapshot() -> Snapshot:
+        return load_snapshot(
+            db_path,
+            statuses=statuses,
+            experiment=args.experiment,
+            max_rows=DEFAULT_LOAD_LIMIT,
+            max_failures=args.max_failures,
+        )
+
+    snap = take_snapshot()
+    offset = clamp_offset((args.page - 1) * page_size, page_size, len(snap.tasks))
+    last_db_refresh = time.monotonic()
+    dirty = True
+
+    with _cbreak_mode() as interactive:
+        try:
+            with Live(
+                render(snap, offset=offset, page_size=page_size, show_footer=interactive),
+                console=console,
+                refresh_per_second=10,
+                screen=False,
+            ) as live:
+                while True:
+                    now = time.monotonic()
+                    if now - last_db_refresh >= args.refresh:
+                        snap = take_snapshot()
+                        offset = clamp_offset(offset, page_size, len(snap.tasks))
+                        last_db_refresh = now
+                        dirty = True
+
+                    if interactive:
+                        key = _read_key(timeout=0.05)
+                        if key is not None:
+                            if is_quit_key(key):
+                                return 0
+                            if key == "r":
+                                snap = take_snapshot()
+                                last_db_refresh = now
+                                dirty = True
+                            else:
+                                new_offset = apply_key(
+                                    key, offset, page_size, len(snap.tasks)
+                                )
+                                if new_offset != offset:
+                                    offset = new_offset
+                                    dirty = True
+                    else:
+                        time.sleep(min(0.5, args.refresh))
+
+                    if dirty:
+                        live.update(
+                            render(
+                                snap,
+                                offset=offset,
+                                page_size=page_size,
+                                show_footer=interactive,
+                            )
+                        )
+                        dirty = False
+        except KeyboardInterrupt:
+            return 0
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    db_path = resolve_db_path(args.db)
+    statuses = _parse_statuses(args.status)
+    page_size = max(args.page_size, 1)
+
+    def take_snapshot() -> Snapshot:
+        return load_snapshot(
+            db_path,
+            statuses=statuses,
+            experiment=args.experiment,
+            max_rows=DEFAULT_LOAD_LIMIT,
+            max_failures=args.max_failures,
+        )
+
+    if args.json:
+        json.dump(snapshot_to_jsonable(take_snapshot()), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    from rich.console import Console
+
+    if args.once:
+        console = Console(no_color=args.no_color)
+        snap = take_snapshot()
+        offset = clamp_offset(
+            (args.page - 1) * page_size, page_size, len(snap.tasks)
+        )
+        console.print(
+            render(snap, offset=offset, page_size=page_size, show_footer=False)
+        )
+        return 0
+
+    return _run_live(args, db_path, statuses)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_cli_dashboard.py
+++ b/tests/unit/test_cli_dashboard.py
@@ -26,8 +26,10 @@ def _seed_db(db_path: Path) -> None:
         conn.execute(
             "UPDATE cmor_tasks SET status='completed', start_time=?, end_time=? "
             "WHERE variable='Amon.pr'",
-            (now.isoformat(timespec="seconds"),
-             (now + timedelta(seconds=600)).isoformat(timespec="seconds")),
+            (
+                now.isoformat(timespec="seconds"),
+                (now + timedelta(seconds=600)).isoformat(timespec="seconds"),
+            ),
         )
         conn.execute(
             "UPDATE cmor_tasks SET status='running', start_time=? "
@@ -63,7 +65,9 @@ class TestResolveDbPath:
     @pytest.mark.unit
     def test_cli_value_wins(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CMOR_TRACKER_DB", "/should/not/be/used.db")
-        assert cli_dashboard.resolve_db_path(str(tmp_path / "x.db")) == tmp_path / "x.db"
+        assert (
+            cli_dashboard.resolve_db_path(str(tmp_path / "x.db")) == tmp_path / "x.db"
+        )
 
     @pytest.mark.unit
     def test_env_used_when_no_cli(self, tmp_path, monkeypatch):
@@ -250,8 +254,14 @@ class TestMain:
     def test_once_mode_respects_page_arg(self, seeded_db, capsys):
         rc = cli_dashboard.main(
             [
-                "--once", "--db", str(seeded_db),
-                "--page-size", "2", "--page", "2", "--no-color",
+                "--once",
+                "--db",
+                str(seeded_db),
+                "--page-size",
+                "2",
+                "--page",
+                "2",
+                "--no-color",
             ]
         )
         assert rc == 0
@@ -261,6 +271,4 @@ class TestMain:
     @pytest.mark.unit
     def test_invalid_status_value_rejected(self, seeded_db):
         with pytest.raises(SystemExit):
-            cli_dashboard.main(
-                ["--once", "--db", str(seeded_db), "--status", "bogus"]
-            )
+            cli_dashboard.main(["--once", "--db", str(seeded_db), "--status", "bogus"])

--- a/tests/unit/test_cli_dashboard.py
+++ b/tests/unit/test_cli_dashboard.py
@@ -1,0 +1,266 @@
+"""Unit tests for the rich-based CLI dashboard."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from access_moppy.dashboard import cli_dashboard
+from access_moppy.tracking import TaskTracker
+
+
+def _seed_db(db_path: Path) -> None:
+    """Populate a tracker DB with a representative mix of statuses."""
+    tracker = TaskTracker(db_path)
+    for var in ("Amon.tas", "Amon.pr", "Omon.tos", "SImon.siconc", "Omon.thetao"):
+        tracker.add_task(var, "piControl")
+
+    now = datetime(2026, 5, 13, 12, 0, 0)
+    conn = sqlite3.connect(db_path)
+    with conn:
+        # completed with explicit start/end so avg duration is well-defined
+        conn.execute(
+            "UPDATE cmor_tasks SET status='completed', start_time=?, end_time=? "
+            "WHERE variable='Amon.pr'",
+            (now.isoformat(timespec="seconds"),
+             (now + timedelta(seconds=600)).isoformat(timespec="seconds")),
+        )
+        conn.execute(
+            "UPDATE cmor_tasks SET status='running', start_time=? "
+            "WHERE variable='Amon.tas'",
+            ((now + timedelta(minutes=10)).isoformat(timespec="seconds"),),
+        )
+        conn.execute(
+            "UPDATE cmor_tasks SET status='running', start_time=? "
+            "WHERE variable='Omon.tos'",
+            ((now + timedelta(minutes=11)).isoformat(timespec="seconds"),),
+        )
+        conn.execute(
+            "UPDATE cmor_tasks SET status='failed', start_time=?, end_time=?, "
+            "error_message=? WHERE variable='SImon.siconc'",
+            (
+                now.isoformat(timespec="seconds"),
+                (now + timedelta(seconds=120)).isoformat(timespec="seconds"),
+                "KeyError: 'aice_m' not found in input files",
+            ),
+        )
+        # Omon.thetao left as 'pending'
+    conn.close()
+
+
+@pytest.fixture()
+def seeded_db(tmp_path: Path) -> Path:
+    db = tmp_path / "cmor_tasks.db"
+    _seed_db(db)
+    return db
+
+
+class TestResolveDbPath:
+    @pytest.mark.unit
+    def test_cli_value_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CMOR_TRACKER_DB", "/should/not/be/used.db")
+        assert cli_dashboard.resolve_db_path(str(tmp_path / "x.db")) == tmp_path / "x.db"
+
+    @pytest.mark.unit
+    def test_env_used_when_no_cli(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CMOR_TRACKER_DB", str(tmp_path / "env.db"))
+        assert cli_dashboard.resolve_db_path(None) == tmp_path / "env.db"
+
+    @pytest.mark.unit
+    def test_default_home_fallback(self, monkeypatch):
+        monkeypatch.delenv("CMOR_TRACKER_DB", raising=False)
+        result = cli_dashboard.resolve_db_path(None)
+        assert result.name == "cmor_tasks.db"
+        assert result.parent.name == "db"
+
+
+class TestLoadSnapshot:
+    @pytest.mark.unit
+    def test_missing_db_returns_error_snapshot(self, tmp_path):
+        snap = cli_dashboard.load_snapshot(tmp_path / "does_not_exist.db")
+        assert snap.error is not None
+        assert "Database not found" in snap.error
+        assert snap.total == 0
+
+    @pytest.mark.unit
+    def test_summary_counts(self, seeded_db):
+        snap = cli_dashboard.load_snapshot(seeded_db)
+        assert snap.error is None
+        assert snap.total == 5
+        assert snap.summary == {
+            "pending": 1,
+            "running": 2,
+            "completed": 1,
+            "failed": 1,
+        }
+        assert snap.completed == 1
+
+    @pytest.mark.unit
+    def test_avg_completed_duration(self, seeded_db):
+        snap = cli_dashboard.load_snapshot(seeded_db)
+        # Only one completed task (600s).
+        assert snap.avg_completed_seconds is not None
+        assert abs(snap.avg_completed_seconds - 600.0) < 1.0
+
+    @pytest.mark.unit
+    def test_eta_uses_remaining_count(self, seeded_db):
+        snap = cli_dashboard.load_snapshot(seeded_db)
+        remaining = snap.total - snap.completed
+        expected = snap.avg_completed_seconds * remaining
+        assert abs(snap.eta_seconds - expected) < 1.0
+
+    @pytest.mark.unit
+    def test_status_filter(self, seeded_db):
+        snap = cli_dashboard.load_snapshot(seeded_db, statuses=["failed"])
+        assert len(snap.tasks) == 1
+        assert snap.tasks[0]["variable"] == "SImon.siconc"
+
+    @pytest.mark.unit
+    def test_experiment_filter_no_match(self, seeded_db):
+        snap = cli_dashboard.load_snapshot(seeded_db, experiment="historical")
+        assert snap.tasks == []
+
+    @pytest.mark.unit
+    def test_failures_panel_data(self, seeded_db):
+        snap = cli_dashboard.load_snapshot(seeded_db)
+        assert len(snap.failures) == 1
+        assert "aice_m" in snap.failures[0]["error_message"]
+
+
+class TestRender:
+    @pytest.mark.unit
+    def test_render_contains_key_strings(self, seeded_db):
+        from rich.console import Console
+
+        snap = cli_dashboard.load_snapshot(seeded_db)
+        console = Console(record=True, width=120, color_system=None)
+        console.print(cli_dashboard.render(snap, page_size=20))
+        out = console.export_text()
+
+        assert "CMORisation Monitor" in out
+        assert "Amon.tas" in out
+        assert "SImon.siconc" in out
+        assert "completed 1 / 5" in out
+        assert "Recent failures" in out
+        # New: title now uses range form
+        assert "Tasks 1-5 of 5" in out
+
+    @pytest.mark.unit
+    def test_render_handles_error_snapshot(self, tmp_path):
+        from rich.console import Console
+
+        snap = cli_dashboard.load_snapshot(tmp_path / "missing.db")
+        console = Console(record=True, width=120, color_system=None)
+        console.print(cli_dashboard.render(snap))
+        out = console.export_text()
+        assert "Database not found" in out
+
+    @pytest.mark.unit
+    def test_render_pagination_slices_rows(self, seeded_db):
+        from rich.console import Console
+
+        snap = cli_dashboard.load_snapshot(seeded_db)
+        console = Console(record=True, width=120, color_system=None)
+        console.print(cli_dashboard.render(snap, offset=2, page_size=2))
+        out = console.export_text()
+        # 5 tasks total; offset=2, page_size=2 → tasks 3-4
+        assert "Tasks 3-4 of 5" in out
+
+    @pytest.mark.unit
+    def test_render_filtered_title_shows_db_total(self, seeded_db):
+        from rich.console import Console
+
+        snap = cli_dashboard.load_snapshot(seeded_db, statuses=["failed"])
+        console = Console(record=True, width=120, color_system=None)
+        console.print(cli_dashboard.render(snap, page_size=20))
+        out = console.export_text()
+        # 1 visible after filter, 5 in DB
+        assert "filtered" in out
+        assert "DB total 5" in out
+
+
+class TestPagingHelpers:
+    @pytest.mark.unit
+    def test_clamp_offset_bounds(self):
+        assert cli_dashboard.clamp_offset(0, 20, 0) == 0
+        assert cli_dashboard.clamp_offset(50, 20, 100) == 50
+        assert cli_dashboard.clamp_offset(95, 20, 100) == 80
+        assert cli_dashboard.clamp_offset(-5, 20, 100) == 0
+
+    @pytest.mark.unit
+    def test_apply_key_scroll(self):
+        # j / arrow-down → +1
+        assert cli_dashboard.apply_key("j", 0, 20, 100) == 1
+        assert cli_dashboard.apply_key("\x1b[B", 5, 20, 100) == 6
+        # k / arrow-up → -1
+        assert cli_dashboard.apply_key("k", 5, 20, 100) == 4
+        assert cli_dashboard.apply_key("\x1b[A", 0, 20, 100) == 0
+
+    @pytest.mark.unit
+    def test_apply_key_page(self):
+        # n / Space / PgDn → +page_size, clamped
+        assert cli_dashboard.apply_key("n", 0, 20, 100) == 20
+        assert cli_dashboard.apply_key(" ", 70, 20, 100) == 80
+        assert cli_dashboard.apply_key("\x1b[6~", 70, 20, 100) == 80
+        # p / b / PgUp → -page_size
+        assert cli_dashboard.apply_key("p", 40, 20, 100) == 20
+        assert cli_dashboard.apply_key("\x1b[5~", 10, 20, 100) == 0
+
+    @pytest.mark.unit
+    def test_apply_key_jump(self):
+        assert cli_dashboard.apply_key("g", 50, 20, 100) == 0
+        assert cli_dashboard.apply_key("G", 0, 20, 100) == 80
+
+    @pytest.mark.unit
+    def test_apply_key_unknown_returns_offset(self):
+        assert cli_dashboard.apply_key("x", 5, 20, 100) == 5
+
+    @pytest.mark.unit
+    def test_is_quit_key(self):
+        for key in ("q", "Q", "\x03", "\x04"):
+            assert cli_dashboard.is_quit_key(key)
+        for key in ("j", "k", "n", "p"):
+            assert not cli_dashboard.is_quit_key(key)
+
+
+class TestMain:
+    @pytest.mark.unit
+    def test_json_mode_emits_valid_json(self, seeded_db, capsys, monkeypatch):
+        monkeypatch.setenv("CMOR_TRACKER_DB", str(seeded_db))
+        rc = cli_dashboard.main(["--json"])
+        captured = capsys.readouterr().out
+        payload = json.loads(captured)
+        assert rc == 0
+        assert payload["total"] == 5
+        assert payload["summary"]["running"] == 2
+        assert payload["failures"][0]["variable"] == "SImon.siconc"
+
+    @pytest.mark.unit
+    def test_once_mode_runs_and_returns_zero(self, seeded_db, capsys):
+        rc = cli_dashboard.main(["--once", "--db", str(seeded_db), "--no-color"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "completed 1 / 5" in out
+
+    @pytest.mark.unit
+    def test_once_mode_respects_page_arg(self, seeded_db, capsys):
+        rc = cli_dashboard.main(
+            [
+                "--once", "--db", str(seeded_db),
+                "--page-size", "2", "--page", "2", "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Tasks 3-4 of 5" in out
+
+    @pytest.mark.unit
+    def test_invalid_status_value_rejected(self, seeded_db):
+        with pytest.raises(SystemExit):
+            cli_dashboard.main(
+                ["--once", "--db", str(seeded_db), "--status", "bogus"]
+            )


### PR DESCRIPTION
# Add `moppy-tui`: terminal dashboard for CMORisation tasks

## Summary

Adds a `rich`-based terminal dashboard (`moppy-tui`) as a sibling to the existing Streamlit web dashboard. Both read the same `cmor_tasks.db`, so they coexist and stay in sync. The motivation is the friction of reaching the Streamlit UI from a laptop when batch jobs run on NCI Gadi (multiple login nodes, port collisions, login-node process reaper, no public ports) — a plain terminal works without any of that.

## What's in this PR

- **New module:** `src/access_moppy/dashboard/cli_dashboard.py` — `rich.Live`-driven TUI reading the same SQLite tracker DB as the Streamlit dashboard.
- **Entry point:** `moppy-tui = "access_moppy.dashboard.cli_dashboard:main"` in `pyproject.toml`.
- **Optional extra:** `tui = ["rich>=13"]` — keeps `rich` out of the default install footprint.
- **Tests:** `tests/unit/test_cli_dashboard.py` — 24 unit tests covering DB path resolution, snapshot loading, summary/ETA computation, status & experiment filters, the pure paging helpers (`clamp_offset`, `apply_key`, `is_quit_key`), and the three top-level modes (`--once`, `--json`, invalid-input handling).

## Features

### Three output modes

| Mode | Purpose |
|------|---------|
| Live (default) | Interactive auto-refreshing dashboard with keyboard pagination |
| `--once` | One snapshot to stdout — useful for cron, email, logs |
| `--json` | Machine-readable JSON — pipe into `jq` or scripts |

### Filters

- `--status pending,running,completed,failed` — subset by task status
- `--experiment EXP_ID` — subset by experiment
- `--max-failures N` — cap the failure panel

### Interactive paging (live mode)

| Key | Action |
|-----|--------|
| `j` / `↓` | Scroll down one row |
| `k` / `↑` | Scroll up one row |
| `n` / `Space` / `PgDn` | Next page |
| `p` / `b` / `PgUp` | Previous page |
| `g` / `G` | Jump to top / bottom |
| `r` | Force a DB re-read now |
| `q` / `Ctrl-C` / `Ctrl-D` | Quit |

Non-interactive paging via `--page N --page-size M` is also supported (handy with `--once`).

### Display

- Header with DB path and last refresh time
- Progress bar with `completed / total` and ETA derived from the average duration of completed tasks
- Status summary line, colour-coded (`running` cyan / `pending` dim / `failed` red / `completed` green)
- Tasks table with row number, variable, experiment, status, start time, live duration
- Failures panel with most recent error messages (truncated to 160 chars)
- Footer with keyboard hints (live mode only)

## Sample output

Live mode, rendered against a 15-task synthetic DB (6 completed / 3 running / 4 pending / 2 failed):

```text
╭──────────────────────────── ACCESS-MOPPy CMORisation Monitor ────────────────────────────╮
│ DB: /scratch/tm70/yz9299/cmor_output/cmor_tasks.db    refreshed: 2026-05-14 01:15:10     │
╰──────────────────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────── Progress ────────────────────────────────────────╮
│ ━━━━━━━━━━━━━━━━   40.0%   completed 6 / 15   ETA 01:11:14                               │
╰──────────────────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────── Summary ─────────────────────────────────────────╮
│   running 3   pending 4   failed 2   completed 6                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────── Tasks 1-10 of 15 ────────────────────────────────────╮
│ ┏━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓ │
│ ┃  # ┃ Variable          ┃ Experiment   ┃ Status     ┃ Started               ┃ Duration┃ │
│ ┡━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩ │
│ │  1 │ Omon.so           │ piControl    │ running    │ 2026-05-13T11:45:00   │ 13:30:10│ │
│ │  2 │ Omon.sos          │ piControl    │ running    │ 2026-05-13T11:45:00   │ 13:30:10│ │
│ │  3 │ Omon.thetao       │ piControl    │ running    │ 2026-05-13T11:45:00   │ 13:30:10│ │
│ │  4 │ Lmon.mrso         │ piControl    │ pending    │ —                     │        —│ │
│ │  5 │ Omon.mlotst       │ piControl    │ pending    │ —                     │        —│ │
│ │  6 │ SImon.siconc      │ piControl    │ pending    │ —                     │        —│ │
│ │  7 │ SImon.sitemptop   │ piControl    │ pending    │ —                     │        —│ │
│ │  8 │ Lmon.mrro         │ piControl    │ failed     │ 2026-05-13T12:00:00   │ 00:00:45│ │
│ │  9 │ SImon.sithick     │ piControl    │ failed     │ 2026-05-13T12:00:00   │ 00:01:30│ │
│ │ 10 │ Amon.pr           │ piControl    │ completed  │ 2026-05-13T12:00:00   │ 00:07:10│ │
│ └────┴───────────────────┴──────────────┴────────────┴───────────────────────┴─────────┘ │
╰──────────────────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────── Recent failures ─────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Variable      ┃ Experiment ┃ Error                                                   ┃ │
│ ┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │
│ │ SImon.sithick │ piControl  │ KeyError: 'hi_m' not found in input files; check        │ │
│ │               │            │ 'model_variables' in the mapping.                       │ │
│ │ Lmon.mrro     │ piControl  │ ValueError: Unsupported calculation type 'foo' for      │ │
│ │               │            │ 'Lmon.mrro'.                                            │ │
│ └───────────────┴────────────┴─────────────────────────────────────────────────────────┘ │
╰──────────────────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────────────────╮
│   j/↓ down  k/↑ up  n/Space pgDn  p/b pgUp  g top  G bottom  r refresh  q quit           │
╰──────────────────────────────────────────────────────────────────────────────────────────╯
```

In a real terminal, the status column is colour-coded (running cyan, pending dim, failed red, completed green) and the progress bar fills with the theme accent colour.

After filtering, the tasks-panel title changes to make the DB total explicit:

```text
╭──────────── Tasks 1-2 of 2 filtered (DB total 15) ─────────────╮
```

`--json` mode prints a single payload — easy to pipe into `jq`:

```json
{
  "db_path": "/scratch/tm70/yz9299/cmor_output/cmor_tasks.db",
  "refreshed_at": "2026-05-14T01:15:10",
  "summary": {"completed": 6, "failed": 2, "pending": 4, "running": 3},
  "total": 15,
  "completed": 6,
  "progress_fraction": 0.4,
  "avg_completed_seconds": 475.0,
  "eta_seconds": 4274.99,
  "tasks": [ /* ... */ ],
  "failures": [ /* ... */ ]
}
```

## Implementation notes

- **Read-only DB connection** (`sqlite3.connect(..., uri=True)` with `mode=ro`) — the CLI never contends with PBS workers writing to the tracker.
- **Stable sort:** `status → start_time → variable` so paging doesn't reshuffle rows on each refresh.
- **TTY-aware:** falls back to passive Live rendering when stdin is piped, so `moppy-tui | tee log.txt` does not hang.
- **Cbreak-mode raw keystroke reader using `os.read`**, deliberately bypassing Python's `TextIOWrapper` buffering — without this, multi-byte escape sequences like `ESC [ A` get split across reads and arrow keys are silently dropped.
- **Pure key→offset mapping** (`apply_key`) so pagination logic is fully unit-testable without a PTY.
- **In-memory pagination** with a 10 000-row load cap; well above any realistic batch size, avoids per-page SQL round trips.

## Test plan

```bash
# Unit tests
pytest tests/unit/test_cli_dashboard.py -v   # 24 passed

# Seed an 80-task synthetic DB and exercise paging
SMOKE_DB=$(mktemp -d)/smoke.db
python -c "
from access_moppy.tracking import TaskTracker
t = TaskTracker('$SMOKE_DB')
for i in range(80): t.add_task(f'var{i:03d}', 'piControl')
"

# Three modes
moppy-tui --once --db "$SMOKE_DB" --page-size 10 --page 4   # Tasks 31-40 of 80
moppy-tui --json --db "$SMOKE_DB" | jq .summary
moppy-tui --db "$SMOKE_DB"                                  # Live; try j/k/n/p/g/G/q
```

- [ ] Live mode renders header + progress + summary + tasks + failures panels
- [ ] Arrow keys, `j/k`, `n/p`, `Space/b`, `PgUp/PgDn`, `g/G`, `r`, `q` all behave as documented
- [ ] `--once` and `--page` emit the requested page; `--json` produces valid JSON
- [ ] Filtered title shows `... filtered (DB total N)`
- [ ] Piping (`moppy-tui | tee out.txt`) does not block on stdin

## Install / try locally

```bash
pip install -e '.[tui]'
moppy-tui --help
```

## Out of scope

- No changes to the Streamlit dashboard or to `batch_cmoriser.start_dashboard()`. The separate "Gadi remote-access friction" issue (login-node binding, port collisions, suppressed logs) tracks improvements to that path.
- No new core dependencies — `rich` is opt-in via the `[tui]` extra.
