### PR TITLE
Add esmvaltool integration support and related tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,13 @@ test = [
     "ruff",
     "f90nml"
 ]
+# pip install access_moppy[test-esmval]
+# Required for integration testing of the esmvaltool workflow.
+# esmvaltool is the full package; esmvalcore is the actual runtime dependency.
+test-esmval = [
+    "access_moppy[test]",
+    "esmvaltool>=2.14",
+]
 docs = [
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=1.3.0",

--- a/src/access_moppy/esmval/cli_commands.py
+++ b/src/access_moppy/esmval/cli_commands.py
@@ -37,13 +37,29 @@ All three accept the same core arguments:
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import logging
+import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
+
+import yaml
 
 logger = logging.getLogger(__name__)
+
+_ACCESS_DATASETS: frozenset[str] = frozenset({"ACCESS-ESM1-5", "ACCESS-ESM1-6"})
+_VERSION_DIR_RE = re.compile(r"^v\d{8}$")
+
+
+@dataclass(frozen=True)
+class PrepareResult:
+    """Result bundle returned by :func:`_prepare`."""
+
+    cfg_path: Path
+    recipe_to_run: Path
+    pinned_version: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +199,79 @@ def _configure_logging(verbose: bool) -> None:
             logging.getLogger(noisy).setLevel(logging.WARNING)
 
 
+def _extract_cmor_versions(results: Sequence[Any]) -> list[str]:
+    """Return sorted unique CMOR version directory names found in task outputs."""
+    versions: set[str] = set()
+    for result in results:
+        output_files = getattr(result, "output_files", []) or []
+        for out in output_files:
+            path = Path(out)
+            for part in path.parts:
+                if _VERSION_DIR_RE.match(part):
+                    versions.add(part)
+    return sorted(versions)
+
+
+def _collect_dataset_entries(recipe: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collect all dataset mapping entries from recipe-level/diag/var scopes."""
+    entries: list[dict[str, Any]] = []
+
+    def _add_from(value: Any) -> None:
+        if not isinstance(value, list):
+            return
+        for item in value:
+            if isinstance(item, dict):
+                entries.append(item)
+
+    _add_from(recipe.get("datasets"))
+
+    diagnostics = recipe.get("diagnostics")
+    if isinstance(diagnostics, dict):
+        for diag in diagnostics.values():
+            if not isinstance(diag, dict):
+                continue
+            _add_from(diag.get("additional_datasets"))
+
+            variables = diag.get("variables")
+            if not isinstance(variables, dict):
+                continue
+            for var in variables.values():
+                if isinstance(var, dict):
+                    _add_from(var.get("additional_datasets"))
+
+    return entries
+
+
+def _pin_recipe_dataset_version(
+    recipe_path: str | Path,
+    version: str,
+) -> tuple[Path | None, int]:
+    """Write a recipe copy with ACCESS dataset entries pinned to *version*."""
+    src = Path(recipe_path)
+    with open(src, encoding="utf-8") as fh:
+        recipe = yaml.safe_load(fh)
+
+    if not isinstance(recipe, dict):
+        return None, 0
+
+    updated = 0
+    for entry in _collect_dataset_entries(recipe):
+        project = str(entry.get("project", "CMIP6"))
+        dataset = str(entry.get("dataset", ""))
+        if project == "CMIP6" and dataset in _ACCESS_DATASETS:
+            if entry.get("version") != version:
+                entry["version"] = version
+                updated += 1
+
+    if updated == 0:
+        return None, 0
+
+    dest = src.with_name(f"{src.stem}.moppy-pinned{src.suffix}")
+    with open(dest, "w", encoding="utf-8") as fh:
+        yaml.dump(recipe, fh, default_flow_style=False, sort_keys=False)
+    return dest, updated
+
+
 # ---------------------------------------------------------------------------
 # Core prepare logic (shared between prepare and run)
 # ---------------------------------------------------------------------------
@@ -198,10 +287,10 @@ def _prepare(
     workers: int = 1,
     dry_run: bool = False,
     pattern_overrides: dict[str, str] | None = None,
-) -> Path:
+) -> PrepareResult:
     """Run the CMORisation step and write the ESMValCore config overlay.
 
-    Returns the path to the written config overlay file.
+    Returns the written config path and the recipe path that should be run.
     """
     from access_moppy.esmval.config_gen import (
         write_esmval_config,
@@ -247,6 +336,32 @@ def _prepare(
 
     print(f"\nESMValCore config written to: {cfg_path}", flush=True)
 
+    recipe_to_run = Path(recipe)
+    pinned_version: str | None = None
+    if not dry_run:
+        versions = _extract_cmor_versions(results)
+        if versions:
+            pinned_version = max(versions)
+            if len(versions) > 1:
+                logger.warning(
+                    "Multiple CMOR versions found in output files: %s; pinning recipe to latest %s.",
+                    ", ".join(versions),
+                    pinned_version,
+                )
+
+            pinned_recipe, updated_entries = _pin_recipe_dataset_version(
+                recipe_path=recipe,
+                version=pinned_version,
+            )
+            if pinned_recipe is not None:
+                recipe_to_run = pinned_recipe
+                logger.info(
+                    "Pinned %d ACCESS dataset entry/entries to version '%s' in recipe copy '%s'.",
+                    updated_entries,
+                    pinned_version,
+                    pinned_recipe,
+                )
+
     # In ESMValCore 2.14+ there is no --config flag.  Config files are loaded
     # from the user config directory.  If we wrote to the default location
     # (~/.config/esmvaltool/) no extra env var is needed; otherwise the user
@@ -255,12 +370,16 @@ def _prepare(
 
     config_dir = cfg_path.parent
     if config_dir.resolve() == _default_user_config_dir().resolve():
-        run_cmd = f"pixi run -e esmval esmvaltool run {recipe}"
+        run_cmd = f"pixi run -e esmval esmvaltool run {recipe_to_run}"
     else:
-        run_cmd = f"ESMVALTOOL_CONFIG_DIR={config_dir} pixi run -e esmval esmvaltool run {recipe}"
+        run_cmd = f"ESMVALTOOL_CONFIG_DIR={config_dir} pixi run -e esmval esmvaltool run {recipe_to_run}"
 
     print(f"Run ESMValTool with:\n  {run_cmd}", flush=True)
-    return cfg_path
+    return PrepareResult(
+        cfg_path=cfg_path,
+        recipe_to_run=recipe_to_run,
+        pinned_version=pinned_version,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +446,7 @@ def main_run(argv: Sequence[str] | None = None) -> int:
         return 1
 
     try:
-        cfg_path = _prepare(
+        prep_result = _prepare(
             recipe=args.recipe,
             input_root=args.input_root,
             cache_dir=args.cache_dir,
@@ -346,10 +465,18 @@ def main_run(argv: Sequence[str] | None = None) -> int:
         logger.info("[dry-run] would call: esmvaltool run %s", args.recipe)
         return 0
 
+    if isinstance(prep_result, PrepareResult):
+        cfg_path = prep_result.cfg_path
+        recipe_to_run = prep_result.recipe_to_run
+    else:
+        # Backward-compatibility for tests/mocks that still patch _prepare to return Path
+        cfg_path = Path(prep_result)
+        recipe_to_run = Path(args.recipe)
+
     from access_moppy.esmval.config_gen import _default_user_config_dir
 
     extra = args.esmvaltool_args.split() if args.esmvaltool_args else []
-    cmd = ["esmvaltool", "run", str(args.recipe)] + extra
+    cmd = ["esmvaltool", "run", str(recipe_to_run)] + extra
     env = None
     config_dir = cfg_path.parent
     if config_dir.resolve() != _default_user_config_dir().resolve():

--- a/src/access_moppy/esmval/cli_commands.py
+++ b/src/access_moppy/esmval/cli_commands.py
@@ -37,11 +37,11 @@ All three accept the same core arguments:
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
 import logging
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
 

--- a/src/access_moppy/esmval/orchestrator.py
+++ b/src/access_moppy/esmval/orchestrator.py
@@ -173,7 +173,9 @@ class CMORiseOrchestrator:
 
         return self.prepare_tasks(tasks)
 
-    def _append_systematic_areacella_tasks(self, tasks: list[CMORTask]) -> list[CMORTask]:
+    def _append_systematic_areacella_tasks(
+        self, tasks: list[CMORTask]
+    ) -> list[CMORTask]:
         """Append ``fx.areacella`` once per ACCESS dataset run context.
 
         Many diagnostics rely on atmospheric grid-cell area as an external

--- a/src/access_moppy/esmval/orchestrator.py
+++ b/src/access_moppy/esmval/orchestrator.py
@@ -33,6 +33,8 @@ from access_moppy.esmval.variable_mapper import VariableIndex
 
 logger = logging.getLogger(__name__)
 
+_AREACELLA_COMPOUND_NAME = "fx.areacella"
+
 
 # ---------------------------------------------------------------------------
 # Result dataclass
@@ -161,6 +163,8 @@ class CMORiseOrchestrator:
             )
             return []
 
+        tasks = self._append_systematic_areacella_tasks(tasks)
+
         logger.info(
             "Found %d CMORisation task(s) in recipe '%s'.",
             len(tasks),
@@ -168,6 +172,81 @@ class CMORiseOrchestrator:
         )
 
         return self.prepare_tasks(tasks)
+
+    def _append_systematic_areacella_tasks(self, tasks: list[CMORTask]) -> list[CMORTask]:
+        """Append ``fx.areacella`` once per ACCESS dataset run context.
+
+        Many diagnostics rely on atmospheric grid-cell area as an external
+        variable. Generating it during prepare avoids downstream dataset
+        discovery mixing with stale local versions.
+        """
+        contexts: set[tuple[str, str, str, str, str, str]] = set()
+        existing_keys = {
+            (
+                t.compound_name,
+                t.experiment_id,
+                t.variant_label,
+                t.source_id,
+                t.grid_label,
+                t.cmip_version,
+                t.activity_id,
+            )
+            for t in tasks
+        }
+
+        for task in tasks:
+            contexts.add(
+                (
+                    task.experiment_id,
+                    task.variant_label,
+                    task.source_id,
+                    task.grid_label,
+                    task.cmip_version,
+                    task.activity_id,
+                )
+            )
+
+        augmented = list(tasks)
+        added = 0
+        for (
+            exp,
+            variant,
+            source_id,
+            grid,
+            cmip_version,
+            activity_id,
+        ) in sorted(contexts):
+            areacella_key = (
+                _AREACELLA_COMPOUND_NAME,
+                exp,
+                variant,
+                source_id,
+                grid,
+                cmip_version,
+                activity_id,
+            )
+            if areacella_key in existing_keys:
+                continue
+
+            augmented.append(
+                CMORTask(
+                    compound_name=_AREACELLA_COMPOUND_NAME,
+                    short_name="areacella",
+                    mip="fx",
+                    experiment_id=exp,
+                    variant_label=variant,
+                    source_id=source_id,
+                    grid_label=grid,
+                    cmip_version=cmip_version,
+                    activity_id=activity_id,
+                )
+            )
+            existing_keys.add(areacella_key)
+            added += 1
+
+        if added:
+            logger.info("Added %d systematic fx.areacella task(s).", added)
+        return augmented
 
     def prepare_tasks(self, tasks: Sequence[CMORTask]) -> list[TaskResult]:
         """CMORise the given list of :class:`CMORTask` objects.

--- a/tests/unit/test_esmval_cli_commands.py
+++ b/tests/unit/test_esmval_cli_commands.py
@@ -14,10 +14,10 @@ from access_moppy.esmval.cli_commands import (
     CMORiseCommand,
     PrepareResult,
     _build_parser,
-    _extract_cmor_versions,
-    _pin_recipe_dataset_version,
     _configure_logging,
+    _extract_cmor_versions,
     _parse_pattern_overrides,
+    _pin_recipe_dataset_version,
     main_prepare,
     main_run,
 )
@@ -196,9 +196,18 @@ class TestConfigureLogging:
 
 class TestRecipeVersionPinningHelpers:
     def test_extract_cmor_versions_collects_unique_versions(self, tmp_path):
-        out_a = tmp_path / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/tas/gn/v20260514/tas_1.nc"
-        out_b = tmp_path / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/pr/gn/v20260515/pr_1.nc"
-        out_c = tmp_path / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/pr/gn/v20260515/pr_2.nc"
+        out_a = (
+            tmp_path
+            / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/tas/gn/v20260514/tas_1.nc"
+        )
+        out_b = (
+            tmp_path
+            / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/pr/gn/v20260515/pr_1.nc"
+        )
+        out_c = (
+            tmp_path
+            / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/pr/gn/v20260515/pr_2.nc"
+        )
         versions = _extract_cmor_versions(
             [
                 MagicMock(output_files=[out_a]),

--- a/tests/unit/test_esmval_cli_commands.py
+++ b/tests/unit/test_esmval_cli_commands.py
@@ -12,7 +12,10 @@ import pytest
 
 from access_moppy.esmval.cli_commands import (
     CMORiseCommand,
+    PrepareResult,
     _build_parser,
+    _extract_cmor_versions,
+    _pin_recipe_dataset_version,
     _configure_logging,
     _parse_pattern_overrides,
     main_prepare,
@@ -187,6 +190,68 @@ class TestConfigureLogging:
 
 
 # ---------------------------------------------------------------------------
+# Recipe version pinning helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRecipeVersionPinningHelpers:
+    def test_extract_cmor_versions_collects_unique_versions(self, tmp_path):
+        out_a = tmp_path / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/tas/gn/v20260514/tas_1.nc"
+        out_b = tmp_path / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/pr/gn/v20260515/pr_1.nc"
+        out_c = tmp_path / "CMIP6/CMIP/CSIRO/ACCESS-ESM1-6/historical/r1i1p1f1/Amon/pr/gn/v20260515/pr_2.nc"
+        versions = _extract_cmor_versions(
+            [
+                MagicMock(output_files=[out_a]),
+                MagicMock(output_files=[out_b, out_c]),
+            ]
+        )
+        assert versions == ["v20260514", "v20260515"]
+
+    def test_pin_recipe_dataset_version_writes_pinned_copy(self, tmp_path):
+        recipe = tmp_path / "recipe.yml"
+        recipe.write_text(
+            "datasets:\n"
+            "  - {dataset: ACCESS-ESM1-6, project: CMIP6, exp: historical, ensemble: r1i1p1f1, grid: gn}\n"
+            "  - {dataset: MPI-ESM1-2-HR, project: CMIP6, exp: historical, ensemble: r1i1p1f1, grid: gn}\n"
+            "diagnostics:\n"
+            "  d1:\n"
+            "    variables:\n"
+            "      tas:\n"
+            "        mip: Amon\n"
+            "    scripts:\n"
+            "      null: {script: null}\n"
+        )
+
+        pinned_path, updated = _pin_recipe_dataset_version(recipe, "v20260514")
+
+        assert pinned_path is not None
+        assert updated == 1
+        assert pinned_path.exists()
+        text = pinned_path.read_text()
+        assert "version: v20260514" in text
+
+    def test_pin_recipe_dataset_version_returns_none_when_no_access_dataset(
+        self, tmp_path
+    ):
+        recipe = tmp_path / "recipe.yml"
+        recipe.write_text(
+            "datasets:\n"
+            "  - {dataset: MPI-ESM1-2-HR, project: CMIP6, exp: historical, ensemble: r1i1p1f1, grid: gn}\n"
+            "diagnostics:\n"
+            "  d1:\n"
+            "    variables:\n"
+            "      tas:\n"
+            "        mip: Amon\n"
+            "    scripts:\n"
+            "      null: {script: null}\n"
+        )
+
+        pinned_path, updated = _pin_recipe_dataset_version(recipe, "v20260514")
+        assert pinned_path is None
+        assert updated == 0
+
+
+# ---------------------------------------------------------------------------
 # main_prepare
 # ---------------------------------------------------------------------------
 
@@ -334,6 +399,34 @@ class TestMainRun:
         cmd = mock_run.call_args[0][0]
         assert "esmvaltool" in cmd
         assert "run" in cmd
+
+    def test_uses_pinned_recipe_from_prepare_result(self, tmp_path):
+        recipe = tmp_path / "recipe.yml"
+        recipe.touch()
+        pinned_recipe = tmp_path / "recipe.moppy-pinned.yml"
+        pinned_recipe.touch()
+        fake_cfg = tmp_path / "cfg.yml"
+        fake_cfg.touch()
+        with (
+            patch(
+                "access_moppy.esmval.cli_commands._prepare",
+                return_value=PrepareResult(
+                    cfg_path=fake_cfg,
+                    recipe_to_run=pinned_recipe,
+                    pinned_version="v20260514",
+                ),
+            ),
+            patch(
+                "access_moppy.esmval.config_gen._default_user_config_dir",
+                return_value=tmp_path,
+            ),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            rc = main_run([str(recipe), "--input-root", "/in", "--cache-dir", "/cache"])
+        assert rc == 0
+        cmd = mock_run.call_args[0][0]
+        assert str(pinned_recipe) in cmd
 
     def test_no_env_when_config_in_default_dir(self, tmp_path):
         """When config is already in the default dir, env must be None."""

--- a/tests/unit/test_esmval_orchestrator.py
+++ b/tests/unit/test_esmval_orchestrator.py
@@ -164,6 +164,57 @@ class TestPrepareRecipe:
         assert len(results) == 1
         assert results[0].status == "skipped"
 
+    def test_prepare_recipe_adds_systematic_areacella_task(self, tmp_path):
+        recipe = tmp_path / "recipe.yml"
+        recipe.write_text(
+            "datasets:\n"
+            "  - {dataset: ACCESS-ESM1-6, project: CMIP6, exp: historical,"
+            " ensemble: r1i1p1f1, grid: gn}\n"
+            "diagnostics:\n"
+            "  d1:\n"
+            "    variables:\n"
+            "      tas:\n"
+            "        mip: Amon\n"
+            "    scripts:\n"
+            "      null: {script: null}\n"
+        )
+        orch = CMORiseOrchestrator(input_root=tmp_path, cache_dir=tmp_path)
+
+        with patch.object(orch, "prepare_tasks", return_value=[]) as mock_pt:
+            orch.prepare_recipe(recipe)
+
+        submitted_tasks = mock_pt.call_args.args[0]
+        compounds = [task.compound_name for task in submitted_tasks]
+        assert "Amon.tas" in compounds
+        assert "fx.areacella" in compounds
+
+    def test_prepare_recipe_does_not_duplicate_existing_areacella_task(self, tmp_path):
+        recipe = tmp_path / "recipe.yml"
+        recipe.write_text(
+            "datasets:\n"
+            "  - {dataset: ACCESS-ESM1-6, project: CMIP6, exp: historical,"
+            " ensemble: r1i1p1f1, grid: gn}\n"
+            "diagnostics:\n"
+            "  d1:\n"
+            "    variables:\n"
+            "      tas:\n"
+            "        mip: Amon\n"
+            "      areacella:\n"
+            "        mip: fx\n"
+            "    scripts:\n"
+            "      null: {script: null}\n"
+        )
+        orch = CMORiseOrchestrator(input_root=tmp_path, cache_dir=tmp_path)
+
+        with patch.object(orch, "prepare_tasks", return_value=[]) as mock_pt:
+            orch.prepare_recipe(recipe)
+
+        submitted_tasks = mock_pt.call_args.args[0]
+        areacella_count = sum(
+            task.compound_name == "fx.areacella" for task in submitted_tasks
+        )
+        assert areacella_count == 1
+
 
 # ---------------------------------------------------------------------------
 # prepare_tasks


### PR DESCRIPTION
- Introduced new optional dependency for esmvaltool in pyproject.toml.
- Enhanced cli_commands.py with functions for extracting CMOR versions and pinning dataset versions in recipes.
- Added unit tests for version extraction and recipe pinning functionality.