### PR TITLE
add batchprocessing monitor to avoid status mistracking in database

### DIFF
--- a/src/access_moppy/batch_cmoriser.py
+++ b/src/access_moppy/batch_cmoriser.py
@@ -1,5 +1,6 @@
 import os
 import shlex
+import signal
 import subprocess
 import sys
 import time
@@ -9,6 +10,151 @@ from pathlib import Path
 import yaml
 
 from access_moppy.tracking import TaskTracker
+
+
+SIDECAR_FILENAME = ".moppy_main.jobid"
+MONITOR_POLL_INTERVAL_SECONDS = 30
+
+
+def parse_walltime(s):
+    """Convert 'HH:MM:SS' or 'MM:SS' to total seconds."""
+    parts = str(s).strip().split(":")
+    if len(parts) == 3:
+        h, m, sec = parts
+    elif len(parts) == 2:
+        h, m, sec = "0", parts[0], parts[1]
+    else:
+        raise ValueError(f"Invalid walltime: {s}")
+    return int(h) * 3600 + int(m) * 60 + int(sec)
+
+
+def format_walltime(seconds):
+    h, rem = divmod(int(seconds), 3600)
+    m, s = divmod(rem, 60)
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def compute_monitor_walltime(config):
+    """Monitor walltime = max(sub walltime) + 30 minutes.
+
+    Sub walltimes come from `walltime` (default) and `variable_resources[var].walltime`
+    overrides in the batch config.
+    """
+    default_wt = config.get("walltime", "02:00:00")
+    var_resources = config.get("variable_resources", {})
+    longest = parse_walltime(default_wt)
+    for var in config["variables"]:
+        wt = var_resources.get(var, {}).get("walltime", default_wt)
+        longest = max(longest, parse_walltime(wt))
+    return format_walltime(longest + 30 * 60)
+
+
+def qstat_full(job_id):
+    """Return a dict of `qstat -fx <job_id>` attributes, or None if unavailable.
+
+    Handles PBS Pro continuation lines (subsequent lines starting with whitespace
+    are appended to the previous key's value).
+    """
+    try:
+        result = subprocess.run(  # noqa: S603  # nosec B603
+            ["qstat", "-fx", str(job_id)],
+            capture_output=True,
+            text=True,
+            check=False,
+            shell=False,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    info = {}
+    current_key = None
+    for raw in result.stdout.splitlines():
+        if not raw or raw.startswith("Job Id:"):
+            current_key = None
+            continue
+        if (raw.startswith(" ") or raw.startswith("\t")) and "=" not in raw and current_key:
+            info[current_key] += raw.strip()
+            continue
+        if "=" in raw:
+            key, _, val = raw.partition("=")
+            current_key = key.strip()
+            info[current_key] = val.strip()
+    return info
+
+
+def qstat_state(info):
+    """Extract job_state from a qstat_full() dict. Returns 'gone' if info is None."""
+    if not info:
+        return "gone"
+    return info.get("job_state", "gone")
+
+
+def format_pbs_error(variable, job_id, info, script_dir):
+    """Build a rich error message from qstat info + .err file tail."""
+    if info is None:
+        return f"job {job_id}: vanished from PBS history before reconciliation"
+
+    parts = [f"job {job_id}"]
+    exit_status = info.get("Exit_status")
+    if exit_status is not None:
+        parts.append(f"exit_status={exit_status}")
+    comment = info.get("comment")
+    if comment:
+        parts.append(f"pbs_comment='{comment}'")
+    mem_used = info.get("resources_used.mem")
+    if mem_used:
+        parts.append(f"mem_used={mem_used}")
+    wt_used = info.get("resources_used.walltime")
+    if wt_used:
+        parts.append(f"walltime_used={wt_used}")
+
+    err_path = Path(script_dir) / variable.replace(".", "_") / f"cmor_{variable.replace('.', '_')}.err"
+    if err_path.exists():
+        try:
+            tail = subprocess.run(  # noqa: S603  # nosec B603
+                ["tail", "-20", str(err_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+                shell=False,
+                timeout=10,
+            ).stdout
+            if tail.strip():
+                parts.append(f"err_tail:\n{tail.strip()}")
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+    return " | ".join(parts)
+
+
+def reconcile_one(tracker, variable, experiment_id, job_id, info, script_dir):
+    """Reconcile DB state for a finished sub-job.
+
+    - exit_status == 0: trust the worker (it should have written 'completed' itself);
+      only backfill if DB still says 'running'/'pending'.
+    - exit_status != 0 (or missing): if DB is not already in a terminal state,
+      mark as failed with a rich error message.
+    """
+    current = tracker.get_status(variable, experiment_id)
+    exit_raw = info.get("Exit_status") if info else None
+    try:
+        exit_code = int(exit_raw) if exit_raw is not None else None
+    except (TypeError, ValueError):
+        exit_code = None
+
+    if exit_code == 0:
+        if current != "completed":
+            tracker.mark_completed(variable, experiment_id)
+        return
+
+    if current in ("completed", "failed"):
+        return
+
+    msg = format_pbs_error(variable, job_id, info, script_dir)
+    tracker.mark_failed(variable, experiment_id, msg)
 
 
 def start_dashboard(dashboard_path: str, db_path: str):
@@ -235,12 +381,183 @@ def wait_for_jobs(job_ids, poll_interval=30):
     print("All jobs completed!")
 
 
+def create_monitor_script(config, config_path, db_path, script_dir):
+    """Create the monitor PBS script that supervises all sub-jobs."""
+    from jinja2 import Template
+
+    template_path = files("access_moppy.templates").joinpath("cmor_monitor_script.j2")
+    with template_path.open() as f:
+        template_content = f.read()
+
+    monitor_walltime = compute_monitor_walltime(config)
+
+    rendered = Template(template_content).render(
+        config=config,
+        config_path=str(config_path),
+        db_path=str(db_path),
+        script_dir=str(script_dir),
+        monitor_walltime=monitor_walltime,
+    )
+
+    monitor_path = Path(script_dir) / "moppy_monitor.sh"
+    with open(monitor_path, "w") as f:
+        f.write(rendered)
+    os.chmod(monitor_path, 0o755)
+    return monitor_path
+
+
+def monitor_main():
+    """Monitor PBS job entry point.
+
+    Runs on a compute node. Reads config from $MOPPY_CONFIG_PATH, submits a sub-job
+    per variable, then polls until all sub-jobs are accounted for. Reconciles DB
+    state for any sub-job that finished without writing its own terminal status.
+    """
+    config_path = os.environ.get("MOPPY_CONFIG_PATH")
+    db_path = os.environ.get("MOPPY_DB_PATH")
+    script_dir_env = os.environ.get("MOPPY_SCRIPT_DIR")
+
+    if not config_path or not db_path:
+        print(
+            "Error: monitor requires MOPPY_CONFIG_PATH and MOPPY_DB_PATH env vars",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    config_path = Path(config_path)
+    db_path = Path(db_path)
+    with config_path.open() as f:
+        config = yaml.safe_load(f)
+
+    experiment_id = config["experiment_id"]
+    script_dir = Path(script_dir_env) if script_dir_env else Path(
+        config.get("script_dir", "cmor_job_scripts")
+    )
+    script_dir.mkdir(parents=True, exist_ok=True)
+
+    tracker = TaskTracker(db_path)
+
+    job_map = {}  # job_id -> variable
+    for variable in config["variables"]:
+        if tracker.is_done(variable, experiment_id):
+            print(f"Skipped (already completed): {variable}")
+            continue
+
+        try:
+            script_path = create_job_script(
+                variable, config, str(db_path), script_dir
+            )
+        except Exception as e:
+            tracker.mark_failed(
+                variable, experiment_id, f"monitor: failed to create script: {e}"
+            )
+            print(f"Failed to create script for {variable}: {e}", file=sys.stderr)
+            continue
+
+        job_id = submit_job(script_path)
+        if job_id is None:
+            tracker.mark_failed(
+                variable, experiment_id, "monitor: qsub returned no job id"
+            )
+            print(f"Failed to submit job for {variable}", file=sys.stderr)
+            continue
+
+        tracker.set_pbs_job_id(variable, experiment_id, job_id)
+        job_map[job_id] = variable
+        print(f"Submitted {variable} as job {job_id}")
+
+    if not job_map:
+        print("No sub-jobs to monitor.")
+        finalize_monitor(tracker, config, experiment_id, db_path)
+        return
+
+    def shutdown_handler(sig, _frame):
+        print(f"Monitor received signal {sig}; marking still-running sub-jobs as failed.")
+        for jid, var in list(job_map.items()):
+            try:
+                cur = tracker.get_status(var, experiment_id)
+                if cur in ("running", "pending"):
+                    tracker.mark_failed(
+                        var,
+                        experiment_id,
+                        f"monitor terminated (sig={sig}); job {jid} outcome unknown",
+                    )
+            except Exception:
+                pass
+        sys.exit(143)
+
+    signal.signal(signal.SIGTERM, shutdown_handler)
+
+    monitor_loop(tracker, job_map, experiment_id, script_dir)
+    finalize_monitor(tracker, config, experiment_id, db_path)
+
+
+def monitor_loop(tracker, job_map, experiment_id, script_dir):
+    """Poll PBS until every sub-job leaves the queue."""
+    pending = set(job_map.keys())
+    print(f"Monitoring {len(pending)} sub-jobs (poll interval {MONITOR_POLL_INTERVAL_SECONDS}s)")
+
+    while pending:
+        time.sleep(MONITOR_POLL_INTERVAL_SECONDS)
+        for job_id in list(pending):
+            info = qstat_full(job_id)
+            state = qstat_state(info)
+            if state in ("Q", "R", "H", "S", "T", "W"):
+                continue
+            # 'F' (finished), 'X' (expired), or 'gone' (history purged) -> reconcile
+            variable = job_map[job_id]
+            reconcile_one(tracker, variable, experiment_id, job_id, info, script_dir)
+            pending.discard(job_id)
+            print(f"Sub-job done: {variable} (job {job_id}, state={state})")
+
+
+def finalize_monitor(tracker, config, experiment_id, db_path):
+    """Final consistency sweep + summary + sidecar cleanup."""
+    summary = {"completed": 0, "failed": 0, "pending": 0, "fixed_stuck": 0}
+    for variable in config["variables"]:
+        status = tracker.get_status(variable, experiment_id)
+        if status == "running":
+            tracker.mark_failed(
+                variable,
+                experiment_id,
+                "monitor finalize: sub finished but DB stayed in running state",
+            )
+            summary["failed"] += 1
+            summary["fixed_stuck"] += 1
+        elif status == "pending":
+            tracker.mark_failed(
+                variable,
+                experiment_id,
+                "monitor finalize: variable never moved out of pending",
+            )
+            summary["failed"] += 1
+        elif status == "completed":
+            summary["completed"] += 1
+        elif status == "failed":
+            summary["failed"] += 1
+
+    print(
+        f"Batch monitor done. completed={summary['completed']}, "
+        f"failed={summary['failed']}, fixed_stuck={summary['fixed_stuck']}"
+    )
+
+    sidecar = Path(db_path).parent / SIDECAR_FILENAME
+    try:
+        sidecar.unlink()
+    except FileNotFoundError:
+        pass
+
+
 def main():
+    if len(sys.argv) >= 2 and sys.argv[1] == "--monitor":
+        monitor_main()
+        return
+
     if len(sys.argv) != 2:
         print("Usage: moppy-cmorise path/to/batch_config.yml")
         sys.exit(1)
 
-    config_path = Path(sys.argv[1])
+    config_path = Path(sys.argv[1]).resolve()
     if not config_path.exists():
         print(f"Error: config file not found: {config_path}")
         sys.exit(1)
@@ -276,39 +593,33 @@ def main():
     script_dir = Path(config_data.get("script_dir", "cmor_job_scripts"))
     script_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create and submit job scripts for each variable
-    job_ids = []
-    variables = config_data["variables"]
+    # Submit a single monitor PBS job. The monitor runs on a compute node and is
+    # responsible for qsub-ing the per-variable sub-jobs, polling them, and
+    # reconciling DB state for any sub-job that exits without writing its own
+    # terminal status (e.g. OOM-killed by PBS).
+    monitor_script = create_monitor_script(
+        config_data, config_path, db_path, script_dir
+    )
+    print(f"Created monitor script: {monitor_script}")
 
-    print(f"Submitting {len(variables)} CMORisation jobs...")
-
-    for variable in variables:
-        # Create job script - pass the scratch database path
-        script_path = create_job_script(variable, config_data, str(db_path), script_dir)
-        print(f"Created job script: {script_path}")
-
-        # Submit job
-        job_id = submit_job(script_path)
-        if job_id:
-            job_ids.append(job_id)
-            print(f"Submitted job {job_id} for variable {variable}")
-        else:
-            print(f"Failed to submit job for variable {variable}")
-
-    if job_ids:
-        print(f"\nSubmitted {len(job_ids)} jobs successfully:")
-        for i, (var, job_id) in enumerate(zip(variables[: len(job_ids)], job_ids)):
-            print(f"  {var}: {job_id}")
-
-        print(f"\nMonitor jobs with: qstat {' '.join(job_ids)}")
-        print("Dashboard available at: http://localhost:8501")
-
-        # Optionally wait for all jobs to complete
-        if config_data.get("wait_for_completion", False):
-            wait_for_jobs(job_ids)
-    else:
-        print("No jobs were submitted successfully")
+    monitor_job_id = submit_job(monitor_script)
+    if not monitor_job_id:
+        print("Failed to submit monitor job; falling back to direct submission.")
         sys.exit(1)
+
+    # Sidecar: lets the dashboard / a successor monitor / users find the live monitor.
+    sidecar = output_dir / SIDECAR_FILENAME
+    sidecar.write_text(f"{monitor_job_id}\n{time.strftime('%Y-%m-%dT%H:%M:%S')}\n")
+
+    print(f"\nSubmitted monitor job {monitor_job_id}")
+    print(f"  Watches {len(config_data['variables'])} variables")
+    print(f"  Sub-jobs are qsub'd from the monitor (see {script_dir}/moppy_monitor.out)")
+    print(f"  Sidecar file: {sidecar}")
+    print(f"  Track progress: qstat -x {monitor_job_id}")
+    print("Dashboard available at: http://localhost:8501")
+
+    if config_data.get("wait_for_completion", False):
+        wait_for_jobs([monitor_job_id])
 
 
 if __name__ == "__main__":

--- a/src/access_moppy/batch_cmoriser.py
+++ b/src/access_moppy/batch_cmoriser.py
@@ -11,12 +11,17 @@ import yaml
 
 from access_moppy.tracking import TaskTracker
 
+# Sidecar file dropped in output_folder so the dashboard / a successor monitor
+# can find the PBS jobid of the live monitor without scanning qstat.
 SIDECAR_FILENAME = ".moppy_main.jobid"
+
+# How often the monitor polls PBS for sub-job state. 30s keeps qstat load low
+# while still detecting OOM kills within a poll cycle.
 MONITOR_POLL_INTERVAL_SECONDS = 30
 
 
 def parse_walltime(s):
-    """Convert 'HH:MM:SS' or 'MM:SS' to total seconds."""
+    """Parse an 'HH:MM:SS' or 'MM:SS' walltime string into seconds."""
     parts = str(s).strip().split(":")
     if len(parts) == 3:
         h, m, sec = parts
@@ -28,16 +33,18 @@ def parse_walltime(s):
 
 
 def format_walltime(seconds):
+    """Render an integer second count as a zero-padded 'HH:MM:SS' string."""
     h, rem = divmod(int(seconds), 3600)
     m, s = divmod(rem, 60)
     return f"{h:02d}:{m:02d}:{s:02d}"
 
 
 def compute_monitor_walltime(config):
-    """Monitor walltime = max(sub walltime) + 30 minutes.
+    """Pick a walltime for the monitor job from the batch config.
 
-    Sub walltimes come from `walltime` (default) and `variable_resources[var].walltime`
-    overrides in the batch config.
+    The monitor only needs to outlive the slowest sub-job, so we take the
+    largest walltime across the default and any per-variable override and
+    add a 30-minute buffer for queue wait and final reconciliation.
     """
     default_wt = config.get("walltime", "02:00:00")
     var_resources = config.get("variable_resources", {})
@@ -49,10 +56,12 @@ def compute_monitor_walltime(config):
 
 
 def qstat_full(job_id):
-    """Return a dict of `qstat -fx <job_id>` attributes, or None if unavailable.
+    """Run `qstat -fx <job_id>` and parse the result into a dict.
 
-    Handles PBS Pro continuation lines (subsequent lines starting with whitespace
-    are appended to the previous key's value).
+    Returns None on timeout, missing binary, or empty output (the latter
+    happens once a job has been purged from PBS history). PBS Pro wraps long
+    attribute values onto continuation lines starting with whitespace; those
+    are appended to the previous key so the caller sees the full value.
     """
     try:
         result = subprocess.run(  # noqa: S603  # nosec B603
@@ -90,14 +99,25 @@ def qstat_full(job_id):
 
 
 def qstat_state(info):
-    """Extract job_state from a qstat_full() dict. Returns 'gone' if info is None."""
+    """Return the PBS job_state letter from a qstat_full() dict.
+
+    Returns 'gone' when info is None (job no longer visible to PBS) or when
+    the dict has no job_state field — both cases are treated as 'finished'
+    by the poll loop.
+    """
     if not info:
         return "gone"
     return info.get("job_state", "gone")
 
 
 def format_pbs_error(variable, job_id, info, script_dir):
-    """Build a rich error message from qstat info + .err file tail."""
+    """Assemble a single-line failure message for a dead sub-job.
+
+    Pulls exit_status, the PBS comment (often the reason a job was killed),
+    and final resource usage out of `info`, then appends the last 20 lines
+    of the worker's .err file if it exists. The result is what ends up in
+    the cmor_tasks.error_message column.
+    """
     if info is None:
         return f"job {job_id}: vanished from PBS history before reconciliation"
 
@@ -138,18 +158,22 @@ def format_pbs_error(variable, job_id, info, script_dir):
 
 
 def reconcile_one(tracker, variable, experiment_id, job_id, info, script_dir):
-    """Reconcile DB state for a finished sub-job.
+    """Decide what to write to the DB for one finished sub-job.
 
-    - exit_status == 0: trust the worker (it should have written 'completed' itself);
-      only backfill if DB still says 'running'/'pending'.
-    - exit_status != 0 (or missing): if DB is not already in a terminal state,
-      mark as failed with a rich error message.
+    The worker normally writes its own terminal status. The monitor only
+    intervenes when the worker had no chance to (SIGKILL / OOM / node crash):
+
+    - exit 0 and DB not already 'completed': backfill 'completed'.
+    - non-zero exit and DB still 'running' or 'pending': mark 'failed' with
+      a message built from qstat plus the worker's stderr tail.
+    - DB already in a terminal state: leave it alone — the worker beat us.
     """
     current = tracker.get_status(variable, experiment_id)
     exit_raw = info.get("Exit_status") if info else None
     try:
         exit_code = int(exit_raw) if exit_raw is not None else None
     except (TypeError, ValueError):
+        # Garbled exit status (rare PBS bug) is treated as failure.
         exit_code = None
 
     if exit_code == 0:
@@ -389,7 +413,12 @@ def wait_for_jobs(job_ids, poll_interval=30):
 
 
 def create_monitor_script(config, config_path, db_path, script_dir):
-    """Create the monitor PBS script that supervises all sub-jobs."""
+    """Render the PBS script for the monitor job and write it to script_dir.
+
+    The script is tiny (1 CPU, 4 GB) — it just submits sub-jobs and polls
+    qstat. Walltime is derived from compute_monitor_walltime so the monitor
+    outlives every sub-job it spawns.
+    """
     from jinja2 import Template
 
     template_path = files("access_moppy.templates").joinpath("cmor_monitor_script.j2")
@@ -414,11 +443,16 @@ def create_monitor_script(config, config_path, db_path, script_dir):
 
 
 def monitor_main():
-    """Monitor PBS job entry point.
+    """Entry point for the monitor PBS job, invoked via `--monitor`.
 
-    Runs on a compute node. Reads config from $MOPPY_CONFIG_PATH, submits a sub-job
-    per variable, then polls until all sub-jobs are accounted for. Reconciles DB
-    state for any sub-job that finished without writing its own terminal status.
+    Runs on a compute node. Reads the batch config from $MOPPY_CONFIG_PATH,
+    qsubs one sub-job per variable, records each job id in the DB, then
+    polls qstat in monitor_loop. When the loop exits, finalize_monitor does
+    a consistency sweep and the job ends cleanly with exit 0.
+
+    Sub-jobs that fail at qsub time, or whose script can't even be rendered,
+    are marked 'failed' immediately and the monitor moves on to the next
+    variable rather than aborting the whole batch.
     """
     config_path = os.environ.get("MOPPY_CONFIG_PATH")
     db_path = os.environ.get("MOPPY_DB_PATH")
@@ -446,7 +480,9 @@ def monitor_main():
 
     tracker = TaskTracker(db_path)
 
-    job_map = {}  # job_id -> variable
+    # job_map maps the PBS jobid we got back from qsub to the variable it
+    # processes. monitor_loop iterates this map to poll qstat per sub-job.
+    job_map = {}
     for variable in config["variables"]:
         if tracker.is_done(variable, experiment_id):
             print(f"Skipped (already completed): {variable}")
@@ -479,6 +515,10 @@ def monitor_main():
         return
 
     def shutdown_handler(sig, _frame):
+        # PBS sends SIGTERM before SIGKILL on walltime exceedance or qdel.
+        # Best-effort: any sub still in a non-terminal state had its outcome
+        # cut short from our perspective, so mark it failed. SIGKILL would
+        # of course bypass this entirely.
         print(
             f"Monitor received signal {sig}; marking still-running sub-jobs as failed."
         )
@@ -492,6 +532,7 @@ def monitor_main():
                         f"monitor terminated (sig={sig}); job {jid} outcome unknown",
                     )
             except Exception:
+                # Never let a DB hiccup stop the monitor from exiting.
                 pass
         sys.exit(143)
 
@@ -502,7 +543,12 @@ def monitor_main():
 
 
 def monitor_loop(tracker, job_map, experiment_id, script_dir):
-    """Poll PBS until every sub-job leaves the queue."""
+    """Poll qstat for each pending sub-job and reconcile when it finishes.
+
+    Exits once every sub-job has left the queue (state no longer in
+    Q/R/H/S/T/W). 'F' (finished), 'X' (expired) and 'gone' (history purged)
+    all trigger reconciliation against the DB.
+    """
     pending = set(job_map.keys())
     print(
         f"Monitoring {len(pending)} sub-jobs (poll interval {MONITOR_POLL_INTERVAL_SECONDS}s)"
@@ -515,7 +561,6 @@ def monitor_loop(tracker, job_map, experiment_id, script_dir):
             state = qstat_state(info)
             if state in ("Q", "R", "H", "S", "T", "W"):
                 continue
-            # 'F' (finished), 'X' (expired), or 'gone' (history purged) -> reconcile
             variable = job_map[job_id]
             reconcile_one(tracker, variable, experiment_id, job_id, info, script_dir)
             pending.discard(job_id)
@@ -523,7 +568,13 @@ def monitor_loop(tracker, job_map, experiment_id, script_dir):
 
 
 def finalize_monitor(tracker, config, experiment_id, db_path):
-    """Final consistency sweep + summary + sidecar cleanup."""
+    """Run a last-pass consistency check, print a summary, remove the sidecar.
+
+    Catches the rare case where monitor_loop saw a sub finish but the DB
+    write was lost (status still 'running'), and the case where a variable
+    never moved out of 'pending' because qsub itself failed early. Both are
+    reclassified as 'failed' so no row is left in a non-terminal state.
+    """
     summary = {"completed": 0, "failed": 0, "pending": 0, "fixed_stuck": 0}
     for variable in config["variables"]:
         status = tracker.get_status(variable, experiment_id)
@@ -560,6 +611,17 @@ def finalize_monitor(tracker, config, experiment_id, db_path):
 
 
 def main():
+    """CLI entry point for `moppy-cmorise`.
+
+    Two invocation modes:
+      moppy-cmorise <config.yml>   — login-side: init DB, qsub the monitor.
+      moppy-cmorise --monitor      — runs inside the monitor PBS job itself.
+
+    The login-side path is intentionally thin: it pre-populates the task
+    table, launches the dashboard, and submits exactly one PBS job (the
+    monitor). The monitor takes over from there on a compute node, so the
+    workflow survives the login shell disconnecting.
+    """
     if len(sys.argv) >= 2 and sys.argv[1] == "--monitor":
         monitor_main()
         return

--- a/src/access_moppy/batch_cmoriser.py
+++ b/src/access_moppy/batch_cmoriser.py
@@ -11,7 +11,6 @@ import yaml
 
 from access_moppy.tracking import TaskTracker
 
-
 SIDECAR_FILENAME = ".moppy_main.jobid"
 MONITOR_POLL_INTERVAL_SECONDS = 30
 
@@ -76,7 +75,11 @@ def qstat_full(job_id):
         if not raw or raw.startswith("Job Id:"):
             current_key = None
             continue
-        if (raw.startswith(" ") or raw.startswith("\t")) and "=" not in raw and current_key:
+        if (
+            (raw.startswith(" ") or raw.startswith("\t"))
+            and "=" not in raw
+            and current_key
+        ):
             info[current_key] += raw.strip()
             continue
         if "=" in raw:
@@ -112,7 +115,11 @@ def format_pbs_error(variable, job_id, info, script_dir):
     if wt_used:
         parts.append(f"walltime_used={wt_used}")
 
-    err_path = Path(script_dir) / variable.replace(".", "_") / f"cmor_{variable.replace('.', '_')}.err"
+    err_path = (
+        Path(script_dir)
+        / variable.replace(".", "_")
+        / f"cmor_{variable.replace('.', '_')}.err"
+    )
     if err_path.exists():
         try:
             tail = subprocess.run(  # noqa: S603  # nosec B603
@@ -430,8 +437,10 @@ def monitor_main():
         config = yaml.safe_load(f)
 
     experiment_id = config["experiment_id"]
-    script_dir = Path(script_dir_env) if script_dir_env else Path(
-        config.get("script_dir", "cmor_job_scripts")
+    script_dir = (
+        Path(script_dir_env)
+        if script_dir_env
+        else Path(config.get("script_dir", "cmor_job_scripts"))
     )
     script_dir.mkdir(parents=True, exist_ok=True)
 
@@ -444,9 +453,7 @@ def monitor_main():
             continue
 
         try:
-            script_path = create_job_script(
-                variable, config, str(db_path), script_dir
-            )
+            script_path = create_job_script(variable, config, str(db_path), script_dir)
         except Exception as e:
             tracker.mark_failed(
                 variable, experiment_id, f"monitor: failed to create script: {e}"
@@ -472,7 +479,9 @@ def monitor_main():
         return
 
     def shutdown_handler(sig, _frame):
-        print(f"Monitor received signal {sig}; marking still-running sub-jobs as failed.")
+        print(
+            f"Monitor received signal {sig}; marking still-running sub-jobs as failed."
+        )
         for jid, var in list(job_map.items()):
             try:
                 cur = tracker.get_status(var, experiment_id)
@@ -495,7 +504,9 @@ def monitor_main():
 def monitor_loop(tracker, job_map, experiment_id, script_dir):
     """Poll PBS until every sub-job leaves the queue."""
     pending = set(job_map.keys())
-    print(f"Monitoring {len(pending)} sub-jobs (poll interval {MONITOR_POLL_INTERVAL_SECONDS}s)")
+    print(
+        f"Monitoring {len(pending)} sub-jobs (poll interval {MONITOR_POLL_INTERVAL_SECONDS}s)"
+    )
 
     while pending:
         time.sleep(MONITOR_POLL_INTERVAL_SECONDS)
@@ -613,7 +624,9 @@ def main():
 
     print(f"\nSubmitted monitor job {monitor_job_id}")
     print(f"  Watches {len(config_data['variables'])} variables")
-    print(f"  Sub-jobs are qsub'd from the monitor (see {script_dir}/moppy_monitor.out)")
+    print(
+        f"  Sub-jobs are qsub'd from the monitor (see {script_dir}/moppy_monitor.out)"
+    )
     print(f"  Sidecar file: {sidecar}")
     print(f"  Track progress: qstat -x {monitor_job_id}")
     print("Dashboard available at: http://localhost:8501")

--- a/src/access_moppy/templates/cmor_monitor_script.j2
+++ b/src/access_moppy/templates/cmor_monitor_script.j2
@@ -1,0 +1,24 @@
+#!/bin/bash
+#PBS -N moppy_monitor
+#PBS -q {{ config.get('queue', 'normal') }}
+#PBS -l ncpus=1
+#PBS -l mem=4GB
+#PBS -l wd
+#PBS -l walltime={{ monitor_walltime }}
+#PBS -o {{ script_dir }}/moppy_monitor.out
+#PBS -e {{ script_dir }}/moppy_monitor.err
+{{ config.get('scheduler_options', '#PBS -P your_project') }}
+{% if config.get('storage') %}#PBS -l storage={{ config.get('storage') }}{% endif %}
+
+{{ config.get('worker_init', 'module load python3') }}
+
+export MOPPY_CONFIG_PATH="{{ config_path }}"
+export MOPPY_DB_PATH="{{ db_path }}"
+export MOPPY_SCRIPT_DIR="{{ script_dir }}"
+
+echo "Monitor starting at $(date)"
+echo "Config: $MOPPY_CONFIG_PATH"
+echo "Database: $MOPPY_DB_PATH"
+echo "PBS_JOBID: $PBS_JOBID"
+
+python -m access_moppy.batch_cmoriser --monitor

--- a/src/access_moppy/templates/cmor_monitor_script.j2
+++ b/src/access_moppy/templates/cmor_monitor_script.j2
@@ -1,4 +1,8 @@
 #!/bin/bash
+# PBS script for the moppy monitor job. Submitted once per batch by the
+# login-side `moppy-cmorise <config>` command. The monitor itself qsubs the
+# per-variable sub-jobs and polls qstat; it needs minimal resources because
+# all heavy lifting happens in the sub-jobs.
 #PBS -N moppy_monitor
 #PBS -q {{ config.get('queue', 'normal') }}
 #PBS -l ncpus=1
@@ -12,6 +16,8 @@
 
 {{ config.get('worker_init', 'module load python3') }}
 
+# Paths the monitor needs to find on the compute node. Passed via env so
+# the same Python entry point can be reused without parsing argv.
 export MOPPY_CONFIG_PATH="{{ config_path }}"
 export MOPPY_DB_PATH="{{ db_path }}"
 export MOPPY_SCRIPT_DIR="{{ script_dir }}"
@@ -21,4 +27,6 @@ echo "Config: $MOPPY_CONFIG_PATH"
 echo "Database: $MOPPY_DB_PATH"
 echo "PBS_JOBID: $PBS_JOBID"
 
+# Dispatches to batch_cmoriser.monitor_main(); see that function for the
+# submit-then-poll loop.
 python -m access_moppy.batch_cmoriser --monitor

--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -58,6 +58,8 @@ class TaskTracker:
                     self.conn.execute(
                         "CREATE UNIQUE INDEX IF NOT EXISTS idx_var_exp ON cmor_tasks(variable, experiment_id)"
                     )
+                    # Migrate databases created before pbs_job_id existed.
+                    # ALTER TABLE has no IF NOT EXISTS, so check first.
                     existing = {
                         row[1]
                         for row in self.conn.execute(
@@ -131,12 +133,18 @@ class TaskTracker:
         return self.get_status(variable, experiment_id) == "completed"
 
     def set_pbs_job_id(self, variable: str, experiment_id: str, job_id: str):
+        """Record the PBS job id that the monitor submitted for this variable.
+
+        Stored so the monitor (or a successor) can later query PBS for the
+        outcome of a sub-job that died without writing its own terminal state.
+        """
         self._execute_with_retry(
             "UPDATE cmor_tasks SET pbs_job_id=? WHERE variable=? AND experiment_id=?",
             (job_id, variable, experiment_id),
         )
 
     def get_pbs_job_id(self, variable: str, experiment_id: str) -> Optional[str]:
+        """Return the PBS job id recorded for this variable, or None if unset."""
         cur = self._execute_with_retry(
             "SELECT pbs_job_id FROM cmor_tasks WHERE variable=? AND experiment_id=?",
             (variable, experiment_id),
@@ -145,7 +153,11 @@ class TaskTracker:
         return row[0] if row is not None else None
 
     def list_unfinished(self, experiment_id: str):
-        """Return [(variable, status, pbs_job_id), ...] for tasks not yet in a terminal state."""
+        """Return rows for tasks that have not reached a terminal state.
+
+        Used when a monitor restarts and needs to rebuild its watch set from
+        the database. Each row is (variable, status, pbs_job_id).
+        """
         cur = self._execute_with_retry(
             "SELECT variable, status, pbs_job_id FROM cmor_tasks "
             "WHERE experiment_id=? AND status NOT IN ('completed','failed')",

--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -50,13 +50,24 @@ class TaskTracker:
                             status TEXT CHECK(status IN ('pending', 'running', 'completed', 'failed')) NOT NULL DEFAULT 'pending',
                             start_time TEXT,
                             end_time TEXT,
-                            error_message TEXT
+                            error_message TEXT,
+                            pbs_job_id TEXT
                         )
                         """
                     )
                     self.conn.execute(
                         "CREATE UNIQUE INDEX IF NOT EXISTS idx_var_exp ON cmor_tasks(variable, experiment_id)"
                     )
+                    existing = {
+                        row[1]
+                        for row in self.conn.execute(
+                            "PRAGMA table_info(cmor_tasks)"
+                        ).fetchall()
+                    }
+                    if "pbs_job_id" not in existing:
+                        self.conn.execute(
+                            "ALTER TABLE cmor_tasks ADD COLUMN pbs_job_id TEXT"
+                        )
                 return
             except sqlite3.OperationalError as e:
                 if any(msg in str(e) for msg in _TRANSIENT) and attempt < 4:
@@ -118,6 +129,29 @@ class TaskTracker:
 
     def is_done(self, variable: str, experiment_id: str) -> bool:
         return self.get_status(variable, experiment_id) == "completed"
+
+    def set_pbs_job_id(self, variable: str, experiment_id: str, job_id: str):
+        self._execute_with_retry(
+            "UPDATE cmor_tasks SET pbs_job_id=? WHERE variable=? AND experiment_id=?",
+            (job_id, variable, experiment_id),
+        )
+
+    def get_pbs_job_id(self, variable: str, experiment_id: str) -> Optional[str]:
+        cur = self._execute_with_retry(
+            "SELECT pbs_job_id FROM cmor_tasks WHERE variable=? AND experiment_id=?",
+            (variable, experiment_id),
+        )
+        row = cur.fetchone()
+        return row[0] if row is not None else None
+
+    def list_unfinished(self, experiment_id: str):
+        """Return [(variable, status, pbs_job_id), ...] for tasks not yet in a terminal state."""
+        cur = self._execute_with_retry(
+            "SELECT variable, status, pbs_job_id FROM cmor_tasks "
+            "WHERE experiment_id=? AND status NOT IN ('completed','failed')",
+            (experiment_id,),
+        )
+        return cur.fetchall()
 
     def _db_execute(self, query, params=()):
         return self.conn.execute(query, params)

--- a/tests/unit/test_batch_cmoriser.py
+++ b/tests/unit/test_batch_cmoriser.py
@@ -1074,3 +1074,167 @@ class TestMainDispatch:
 
         main()
         assert called == ["ok"]
+
+
+class TestMonitorShutdownHandler:
+    """Tests for the SIGTERM handler registered inside monitor_main.
+
+    The handler is a closure over (tracker, job_map, experiment_id) defined
+    locally; we capture it by mocking signal.signal and then invoke it
+    directly to verify behavior, which is the only way to exercise the
+    handler without sending real signals.
+    """
+
+    @staticmethod
+    def _setup_monitor(temp_dir, monkeypatch, variables, completed=()):
+        """Common scaffolding: prime DB + config + mocks, return (db_path, captured)."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        for var in variables:
+            tracker.add_task(var, "historical")
+        for var in completed:
+            tracker.mark_completed(var, "historical")
+        tracker.conn.close()
+
+        config_path = temp_dir / "config.yml"
+        var_lines = "\n".join(f"  - {v}" for v in variables)
+        config_path.write_text(f"experiment_id: historical\nvariables:\n{var_lines}\n")
+        monkeypatch.setenv("MOPPY_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv("MOPPY_DB_PATH", str(db_path))
+        monkeypatch.setenv("MOPPY_SCRIPT_DIR", str(temp_dir / "scripts"))
+
+        # Submit returns deterministic per-variable job IDs
+        ids = iter(f"{1000 + i}.gadi-pbs" for i in range(len(variables)))
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.create_job_script",
+            lambda *a, **k: temp_dir / "x.sh",
+        )
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.submit_job", lambda p: next(ids)
+        )
+
+        # Capture the signal handler instead of actually registering it
+        captured = {}
+        monkeypatch.setattr(
+            "signal.signal", lambda sig, handler: captured.update({sig: handler})
+        )
+        return db_path, captured
+
+    @pytest.mark.unit
+    def test_handler_marks_running_subs_as_failed(self, temp_dir, monkeypatch):
+        """SIGTERM mid-batch: any sub still in 'running' state gets marked failed."""
+        import signal as _signal
+
+        db_path, captured = self._setup_monitor(
+            temp_dir, monkeypatch, variables=["Amon.tas", "Amon.pr"]
+        )
+
+        # Fire SIGTERM as soon as the monitor loop is reached
+        def fake_loop(*_args, **_kwargs):
+            captured[_signal.SIGTERM](_signal.SIGTERM, None)
+
+        monkeypatch.setattr("access_moppy.batch_cmoriser.monitor_loop", fake_loop)
+
+        with pytest.raises(SystemExit) as excinfo:
+            monitor_main()
+        assert excinfo.value.code == 143  # 128 + SIGTERM
+
+        verify = TaskTracker(db_path)
+        assert verify.get_status("Amon.tas", "historical") == "failed"
+        assert verify.get_status("Amon.pr", "historical") == "failed"
+        verify.conn.close()
+
+    @pytest.mark.unit
+    def test_handler_error_message_includes_signal_and_job_id(
+        self, temp_dir, monkeypatch
+    ):
+        """Error message records both the signal number and the PBS job id."""
+        import signal as _signal
+
+        db_path, captured = self._setup_monitor(
+            temp_dir, monkeypatch, variables=["Amon.tas"]
+        )
+
+        def fake_loop(*_args, **_kwargs):
+            captured[_signal.SIGTERM](_signal.SIGTERM, None)
+
+        monkeypatch.setattr("access_moppy.batch_cmoriser.monitor_loop", fake_loop)
+
+        with pytest.raises(SystemExit):
+            monitor_main()
+
+        verify = TaskTracker(db_path)
+        row = verify.conn.execute(
+            "SELECT error_message FROM cmor_tasks WHERE variable='Amon.tas'"
+        ).fetchone()
+        assert "monitor terminated" in row[0]
+        assert f"sig={int(_signal.SIGTERM)}" in row[0]
+        assert "1000.gadi-pbs" in row[0]  # first submit id from _setup_monitor
+        verify.conn.close()
+
+    @pytest.mark.unit
+    def test_handler_does_not_overwrite_completed(self, temp_dir, monkeypatch):
+        """A sub that finished cleanly before SIGTERM must keep its 'completed' state."""
+        import signal as _signal
+
+        db_path, captured = self._setup_monitor(
+            temp_dir,
+            monkeypatch,
+            variables=["Amon.tas", "Amon.done"],
+            completed=["Amon.done"],
+        )
+
+        def fake_loop(*_args, **_kwargs):
+            captured[_signal.SIGTERM](_signal.SIGTERM, None)
+
+        monkeypatch.setattr("access_moppy.batch_cmoriser.monitor_loop", fake_loop)
+
+        with pytest.raises(SystemExit):
+            monitor_main()
+
+        verify = TaskTracker(db_path)
+        assert verify.get_status("Amon.done", "historical") == "completed"
+        assert verify.get_status("Amon.tas", "historical") == "failed"
+        verify.conn.close()
+
+    @pytest.mark.unit
+    def test_handler_tolerates_db_errors(self, temp_dir, monkeypatch):
+        """If mark_failed inside the handler raises, the handler still calls
+        sys.exit(143) — DB hiccups must not block PBS termination."""
+        import signal as _signal
+
+        db_path, captured = self._setup_monitor(
+            temp_dir, monkeypatch, variables=["Amon.tas"]
+        )
+
+        def fake_loop(*_args, **_kwargs):
+            # Break mark_failed (the exact failure point inside the handler)
+            with patch.object(
+                TaskTracker,
+                "mark_failed",
+                side_effect=RuntimeError("DB unavailable"),
+            ):
+                captured[_signal.SIGTERM](_signal.SIGTERM, None)
+
+        monkeypatch.setattr("access_moppy.batch_cmoriser.monitor_loop", fake_loop)
+
+        with pytest.raises(SystemExit) as excinfo:
+            monitor_main()
+        assert excinfo.value.code == 143
+
+    @pytest.mark.unit
+    def test_handler_registered_for_sigterm(self, temp_dir, monkeypatch):
+        """Sanity: monitor_main must register a SIGTERM handler before looping."""
+        import signal as _signal
+
+        _, captured = self._setup_monitor(temp_dir, monkeypatch, variables=["Amon.tas"])
+
+        # Make the loop a no-op so monitor_main exits normally
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.monitor_loop", lambda *a, **k: None
+        )
+
+        monitor_main()
+
+        assert _signal.SIGTERM in captured
+        assert callable(captured[_signal.SIGTERM])

--- a/tests/unit/test_batch_cmoriser.py
+++ b/tests/unit/test_batch_cmoriser.py
@@ -987,3 +987,90 @@ class TestMonitorMain:
         ).fetchone()
         assert "qsub" in row[0]
         verify.conn.close()
+
+
+class TestMainDispatch:
+    """Tests for the argument-parsing branches at the top of main()."""
+
+    @pytest.mark.unit
+    def test_monitor_flag_delegates_to_monitor_main(self, monkeypatch):
+        """`moppy-cmorise --monitor` invokes monitor_main and returns without
+        running the login-side path (no config file is parsed)."""
+        monkeypatch.setattr("sys.argv", ["moppy-cmorise", "--monitor"])
+
+        called = {"monitor_main": 0, "yaml_load": 0}
+
+        def fake_monitor_main():
+            called["monitor_main"] += 1
+
+        def fake_yaml_load(*args, **kwargs):
+            called["yaml_load"] += 1
+            return {}
+
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.monitor_main", fake_monitor_main
+        )
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.yaml.safe_load", fake_yaml_load
+        )
+
+        main()  # should not raise; should not call yaml.safe_load
+
+        assert called["monitor_main"] == 1
+        assert called["yaml_load"] == 0  # login-side path never reached
+
+    @pytest.mark.unit
+    def test_no_args_exits_with_usage(self, monkeypatch, capsys):
+        """`moppy-cmorise` with no arg prints usage to stdout and exits 1."""
+        monkeypatch.setattr("sys.argv", ["moppy-cmorise"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Usage:" in captured.out
+
+    @pytest.mark.unit
+    def test_too_many_args_exits_with_usage(self, monkeypatch, capsys):
+        """Extra positional args trigger the usage error too."""
+        monkeypatch.setattr("sys.argv", ["moppy-cmorise", "config.yml", "extra-arg"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Usage:" in captured.out
+
+    @pytest.mark.unit
+    def test_nonexistent_config_exits_with_error(self, monkeypatch, tmp_path, capsys):
+        """Pointing main() at a missing config file exits 1 with a clear message."""
+        missing = tmp_path / "does_not_exist.yml"
+        monkeypatch.setattr("sys.argv", ["moppy-cmorise", str(missing)])
+
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "config file not found" in captured.out
+        # Resolved absolute path appears in the error
+        assert str(missing) in captured.out
+
+    @pytest.mark.unit
+    def test_monitor_flag_with_extra_args_still_dispatches(self, monkeypatch):
+        """The --monitor branch uses `>=2` so extra args (e.g. config_path
+        forwarded by the launcher) don't fall into the usage-error path."""
+        monkeypatch.setattr(
+            "sys.argv", ["moppy-cmorise", "--monitor", "/some/config.yml"]
+        )
+
+        called = []
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.monitor_main",
+            lambda: called.append("ok"),
+        )
+
+        main()
+        assert called == ["ok"]

--- a/tests/unit/test_batch_cmoriser.py
+++ b/tests/unit/test_batch_cmoriser.py
@@ -5,17 +5,31 @@
 # bandit: skip
 # semgrep: skip
 
+from pathlib import Path
 from unittest.mock import Mock, mock_open, patch
 
 import pytest
 
 from access_moppy.batch_cmoriser import (
+    SIDECAR_FILENAME,
+    compute_monitor_walltime,
     create_job_script,
+    create_monitor_script,
+    finalize_monitor,
+    format_pbs_error,
+    format_walltime,
     main,
+    monitor_loop,
+    monitor_main,
+    parse_walltime,
+    qstat_full,
+    qstat_state,
+    reconcile_one,
     start_dashboard,
     submit_job,
     wait_for_jobs,
 )
+from access_moppy.tracking import TaskTracker
 from tests.mocks.mock_pbs import MockPBSManager, mock_qsub_success
 
 
@@ -297,3 +311,679 @@ class TestMainScriptDir:
         self._run_main(config, tmp_path, monkeypatch)
 
         assert (tmp_path / "my_scripts").is_dir()
+
+
+class TestWalltimeHelpers:
+    """Unit tests for walltime parsing and monitor walltime computation."""
+
+    @pytest.mark.unit
+    def test_parse_walltime_hms(self):
+        assert parse_walltime("02:30:45") == 2 * 3600 + 30 * 60 + 45
+
+    @pytest.mark.unit
+    def test_parse_walltime_ms(self):
+        """Two-component form is interpreted as MM:SS."""
+        assert parse_walltime("05:30") == 5 * 60 + 30
+
+    @pytest.mark.unit
+    def test_parse_walltime_zero(self):
+        assert parse_walltime("00:00:00") == 0
+
+    @pytest.mark.unit
+    def test_parse_walltime_invalid(self):
+        with pytest.raises(ValueError):
+            parse_walltime("not-a-walltime")
+
+    @pytest.mark.unit
+    def test_format_walltime_round_trip(self):
+        for s in ("00:00:00", "01:00:00", "04:30:00", "23:59:59"):
+            assert format_walltime(parse_walltime(s)) == s
+
+    @pytest.mark.unit
+    def test_format_walltime_zero_pads(self):
+        assert format_walltime(65) == "00:01:05"
+
+    @pytest.mark.unit
+    def test_compute_monitor_walltime_default_only(self):
+        """All variables use the top-level default walltime."""
+        cfg = {
+            "walltime": "02:00:00",
+            "variables": ["Amon.tas", "Omon.tos"],
+        }
+        # max = 2h, +30min = 2:30
+        assert compute_monitor_walltime(cfg) == "02:30:00"
+
+    @pytest.mark.unit
+    def test_compute_monitor_walltime_with_override(self):
+        """variable_resources override is used when longer than default."""
+        cfg = {
+            "walltime": "02:00:00",
+            "variables": ["Amon.tas", "Amon.cl"],
+            "variable_resources": {"Amon.cl": {"walltime": "04:00:00"}},
+        }
+        # max = 4h (override), +30min = 4:30
+        assert compute_monitor_walltime(cfg) == "04:30:00"
+
+    @pytest.mark.unit
+    def test_compute_monitor_walltime_override_shorter_than_default(self):
+        """A shorter per-variable override is not used; default still wins."""
+        cfg = {
+            "walltime": "04:00:00",
+            "variables": ["Amon.tas", "Amon.cl"],
+            "variable_resources": {"Amon.cl": {"walltime": "01:00:00"}},
+        }
+        assert compute_monitor_walltime(cfg) == "04:30:00"
+
+    @pytest.mark.unit
+    def test_compute_monitor_walltime_no_walltime_in_config(self):
+        """Without 'walltime' key, the helper falls back to its 02:00:00 default."""
+        cfg = {"variables": ["Amon.tas"]}
+        assert compute_monitor_walltime(cfg) == "02:30:00"
+
+
+class TestQstatHelpers:
+    """Unit tests for qstat parsing and PBS error formatting."""
+
+    SAMPLE_QSTAT = (
+        "Job Id: 12345.gadi-pbs\n"
+        "    Job_Name = cmor_Omon_zostoga\n"
+        "    job_state = F\n"
+        "    Exit_status = 271\n"
+        "    comment = job killed: vmem 192GB exceeded limit 190GB\n"
+        "    resources_used.mem = 186465316kb\n"
+        "    resources_used.walltime = 00:34:18\n"
+    )
+
+    @pytest.mark.unit
+    def test_qstat_full_parses_well_formed(self):
+        result = Mock(returncode=0, stdout=self.SAMPLE_QSTAT)
+        with patch("subprocess.run", return_value=result):
+            info = qstat_full("12345.gadi-pbs")
+        assert info["job_state"] == "F"
+        assert info["Exit_status"] == "271"
+        assert info["comment"].startswith("job killed")
+        assert info["resources_used.walltime"] == "00:34:18"
+
+    @pytest.mark.unit
+    def test_qstat_full_returns_none_on_nonzero_returncode(self):
+        result = Mock(returncode=153, stdout="")
+        with patch("subprocess.run", return_value=result):
+            assert qstat_full("12345.gadi-pbs") is None
+
+    @pytest.mark.unit
+    def test_qstat_full_returns_none_on_empty_stdout(self):
+        result = Mock(returncode=0, stdout="")
+        with patch("subprocess.run", return_value=result):
+            assert qstat_full("12345.gadi-pbs") is None
+
+    @pytest.mark.unit
+    def test_qstat_full_returns_none_on_timeout(self):
+        import subprocess
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["qstat"], timeout=30),
+        ):
+            assert qstat_full("12345.gadi-pbs") is None
+
+    @pytest.mark.unit
+    def test_qstat_full_handles_continuation_lines(self):
+        """PBS Pro wraps long values onto continuation lines starting with whitespace."""
+        output = (
+            "Job Id: 12345.gadi-pbs\n"
+            "    comment = job killed: this is a very long comment that\n"
+            "\twraps onto a second line because PBS Pro breaks long strings\n"
+            "    job_state = F\n"
+        )
+        result = Mock(returncode=0, stdout=output)
+        with patch("subprocess.run", return_value=result):
+            info = qstat_full("12345.gadi-pbs")
+        assert "wraps onto a second line" in info["comment"]
+        assert info["job_state"] == "F"
+
+    @pytest.mark.unit
+    def test_qstat_state_handles_none(self):
+        assert qstat_state(None) == "gone"
+
+    @pytest.mark.unit
+    def test_qstat_state_returns_job_state(self):
+        assert qstat_state({"job_state": "R"}) == "R"
+        assert qstat_state({"job_state": "F"}) == "F"
+
+    @pytest.mark.unit
+    def test_qstat_state_handles_missing_field(self):
+        assert qstat_state({"Job_Name": "x"}) == "gone"
+
+    @pytest.mark.unit
+    def test_format_pbs_error_with_full_info(self, tmp_path):
+        info = {
+            "Exit_status": "271",
+            "comment": "job killed: memory exceeded",
+            "resources_used.mem": "186465316kb",
+            "resources_used.walltime": "00:34:18",
+        }
+        msg = format_pbs_error("Omon.zostoga", "12345.gadi-pbs", info, tmp_path)
+        assert "12345.gadi-pbs" in msg
+        assert "exit_status=271" in msg
+        assert "memory exceeded" in msg
+        assert "mem_used=" in msg
+        assert "walltime_used=00:34:18" in msg
+
+    @pytest.mark.unit
+    def test_format_pbs_error_with_none_info(self, tmp_path):
+        msg = format_pbs_error("Omon.zostoga", "12345.gadi-pbs", None, tmp_path)
+        assert "vanished" in msg
+        assert "12345.gadi-pbs" in msg
+
+    @pytest.mark.unit
+    def test_format_pbs_error_includes_err_tail_when_file_exists(self, tmp_path):
+        """If the worker's .err file exists, the tail is appended."""
+        var_dir = tmp_path / "Omon_zostoga"
+        var_dir.mkdir()
+        err_path = var_dir / "cmor_Omon_zostoga.err"
+        err_path.write_text("\n".join(f"line {i}" for i in range(1, 25)))
+
+        info = {"Exit_status": "1", "comment": "task failed"}
+        msg = format_pbs_error("Omon.zostoga", "12345", info, tmp_path)
+        assert "err_tail:" in msg
+        # tail -20 returns the last 20 lines
+        assert "line 24" in msg
+        assert "line 1\n" not in msg  # earliest lines dropped
+
+    @pytest.mark.unit
+    def test_format_pbs_error_skips_missing_fields(self, tmp_path):
+        """When optional fields are absent, they are simply omitted."""
+        info = {"Exit_status": "1"}  # no comment, no resources_used
+        msg = format_pbs_error("Amon.tas", "12345", info, tmp_path)
+        assert "exit_status=1" in msg
+        assert "pbs_comment" not in msg
+        assert "mem_used" not in msg
+        assert "walltime_used" not in msg
+
+
+class TestReconcileOne:
+    """Unit tests for reconcile_one — the DB write decision logic."""
+
+    @pytest.mark.unit
+    def test_exit_zero_with_completed_db_is_noop(self, temp_dir):
+        """Worker successfully wrote 'completed'; reconcile does nothing."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+        tracker.mark_completed("Amon.tas", "historical")
+
+        info = {"Exit_status": "0", "job_state": "F"}
+        reconcile_one(tracker, "Amon.tas", "historical", "12345", info, temp_dir)
+
+        assert tracker.get_status("Amon.tas", "historical") == "completed"
+
+    @pytest.mark.unit
+    def test_exit_zero_with_stale_running_backfills_completed(self, temp_dir):
+        """Worker exited 0 but mark_done failed; reconcile backfills 'completed'."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+
+        info = {"Exit_status": "0", "job_state": "F"}
+        reconcile_one(tracker, "Amon.tas", "historical", "12345", info, temp_dir)
+
+        assert tracker.get_status("Amon.tas", "historical") == "completed"
+
+    @pytest.mark.unit
+    def test_exit_nonzero_with_running_marks_failed(self, temp_dir):
+        """SIGKILL/OOM case: worker died mid-task, DB still 'running'."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Omon.zostoga", "historical")
+        tracker.mark_running("Omon.zostoga", "historical")
+
+        info = {"Exit_status": "271", "comment": "job killed: memory exceeded"}
+        reconcile_one(
+            tracker, "Omon.zostoga", "historical", "12345.gadi-pbs", info, temp_dir
+        )
+
+        assert tracker.get_status("Omon.zostoga", "historical") == "failed"
+        # Error message captures the PBS detail
+        row = tracker.conn.execute(
+            "SELECT error_message FROM cmor_tasks WHERE variable=?",
+            ("Omon.zostoga",),
+        ).fetchone()
+        assert "exit_status=271" in row[0]
+        assert "memory exceeded" in row[0]
+
+    @pytest.mark.unit
+    def test_failed_terminal_state_is_not_overwritten(self, temp_dir):
+        """Once worker has written 'failed', reconcile must not clobber it."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_failed("Amon.tas", "historical", "worker-reported error")
+
+        info = {"Exit_status": "1"}
+        reconcile_one(tracker, "Amon.tas", "historical", "12345", info, temp_dir)
+
+        row = tracker.conn.execute(
+            "SELECT error_message FROM cmor_tasks WHERE variable=?",
+            ("Amon.tas",),
+        ).fetchone()
+        # Original error survives — reconcile_one bailed out
+        assert row[0] == "worker-reported error"
+
+    @pytest.mark.unit
+    def test_missing_info_marks_failed_with_vanished_message(self, temp_dir):
+        """PBS history purged: info is None → record as failed with 'vanished'."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+
+        reconcile_one(tracker, "Amon.tas", "historical", "12345", None, temp_dir)
+
+        assert tracker.get_status("Amon.tas", "historical") == "failed"
+        row = tracker.conn.execute(
+            "SELECT error_message FROM cmor_tasks WHERE variable=?",
+            ("Amon.tas",),
+        ).fetchone()
+        assert "vanished" in row[0]
+
+    @pytest.mark.unit
+    def test_non_integer_exit_status_treated_as_failure(self, temp_dir):
+        """Garbled Exit_status (e.g. PBS bug) is treated as failure, not success."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+
+        info = {"Exit_status": "not-a-number"}
+        reconcile_one(tracker, "Amon.tas", "historical", "12345", info, temp_dir)
+
+        assert tracker.get_status("Amon.tas", "historical") == "failed"
+
+
+class TestCreateMonitorScript:
+    """Unit tests for monitor PBS script generation."""
+
+    BASE_CONFIG = {
+        "variables": ["Amon.tas"],
+        "walltime": "02:00:00",
+        "queue": "normal",
+        "storage": "gdata/tm70",
+        "scheduler_options": "#PBS -P abc",
+        "worker_init": "module load python",
+    }
+
+    @pytest.mark.unit
+    def test_writes_script_with_correct_walltime(self, tmp_path):
+        """The rendered script includes the computed monitor walltime."""
+        path = create_monitor_script(
+            self.BASE_CONFIG,
+            tmp_path / "config.yml",
+            tmp_path / "db.db",
+            tmp_path,
+        )
+        content = path.read_text()
+        # max sub walltime is 2h, so monitor gets 2:30:00
+        assert "#PBS -l walltime=02:30:00" in content
+
+    @pytest.mark.unit
+    def test_script_executable(self, tmp_path):
+        import stat as _stat
+
+        path = create_monitor_script(
+            self.BASE_CONFIG,
+            tmp_path / "config.yml",
+            tmp_path / "db.db",
+            tmp_path,
+        )
+        mode = path.stat().st_mode
+        assert mode & _stat.S_IXUSR
+
+    @pytest.mark.unit
+    def test_script_exports_required_env_vars(self, tmp_path):
+        path = create_monitor_script(
+            self.BASE_CONFIG,
+            tmp_path / "config.yml",
+            tmp_path / "db.db",
+            tmp_path,
+        )
+        content = path.read_text()
+        assert "MOPPY_CONFIG_PATH=" in content
+        assert "MOPPY_DB_PATH=" in content
+        assert "python -m access_moppy.batch_cmoriser --monitor" in content
+
+    @pytest.mark.unit
+    def test_script_includes_storage_and_scheduler_options(self, tmp_path):
+        path = create_monitor_script(
+            self.BASE_CONFIG,
+            tmp_path / "config.yml",
+            tmp_path / "db.db",
+            tmp_path,
+        )
+        content = path.read_text()
+        assert "#PBS -P abc" in content
+        assert "#PBS -l storage=gdata/tm70" in content
+
+
+class TestMonitorLoop:
+    """Unit tests for the main poll-and-reconcile loop."""
+
+    @pytest.mark.unit
+    def test_loop_exits_when_all_jobs_finished(self, temp_dir, monkeypatch):
+        """One sub-job, immediately in F state → loop exits after one iteration."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+
+        job_map = {"12345.gadi-pbs": "Amon.tas"}
+
+        # qstat reports F with exit 0 immediately
+        finished_info = {"job_state": "F", "Exit_status": "0"}
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.qstat_full",
+            lambda jid: finished_info,
+        )
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        monitor_loop(tracker, job_map, "historical", temp_dir)
+
+        assert tracker.get_status("Amon.tas", "historical") == "completed"
+
+    @pytest.mark.unit
+    def test_loop_keeps_polling_while_state_is_running(self, temp_dir, monkeypatch):
+        """Jobs in R state stay pending until they transition to F."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+
+        job_map = {"12345.gadi-pbs": "Amon.tas"}
+
+        # First three polls return R, then F (sub-job exits cleanly)
+        states = iter(
+            [
+                {"job_state": "R"},
+                {"job_state": "R"},
+                {"job_state": "R"},
+                {"job_state": "F", "Exit_status": "0"},
+            ]
+        )
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.qstat_full",
+            lambda jid: next(states),
+        )
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        monitor_loop(tracker, job_map, "historical", temp_dir)
+        assert tracker.get_status("Amon.tas", "historical") == "completed"
+
+    @pytest.mark.unit
+    def test_loop_marks_failed_on_nonzero_exit(self, temp_dir, monkeypatch):
+        """SIGKILL/OOM end-to-end: sub-job finishes with exit 271, DB ends 'failed'."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Omon.zostoga", "historical")
+        tracker.mark_running("Omon.zostoga", "historical")
+
+        job_map = {"168282805.gadi-pbs": "Omon.zostoga"}
+
+        info = {
+            "job_state": "F",
+            "Exit_status": "271",
+            "comment": "job killed: memory exceeded",
+        }
+        monkeypatch.setattr("access_moppy.batch_cmoriser.qstat_full", lambda jid: info)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        monitor_loop(tracker, job_map, "historical", temp_dir)
+        assert tracker.get_status("Omon.zostoga", "historical") == "failed"
+
+    @pytest.mark.unit
+    def test_loop_treats_gone_qstat_as_finished(self, temp_dir, monkeypatch):
+        """If qstat returns None (history purged), the job is reconciled as gone."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+
+        job_map = {"12345.gadi-pbs": "Amon.tas"}
+
+        monkeypatch.setattr("access_moppy.batch_cmoriser.qstat_full", lambda jid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        monitor_loop(tracker, job_map, "historical", temp_dir)
+        # qstat_state(None) returns "gone" which is not in Q/R/H, so reconcile fires
+        assert tracker.get_status("Amon.tas", "historical") == "failed"
+
+
+class TestFinalizeMonitor:
+    """Unit tests for finalize_monitor: consistency sweep + sidecar cleanup."""
+
+    @pytest.mark.unit
+    def test_finalize_marks_stale_running_as_failed(self, temp_dir):
+        """Any 'running' rows at finalize time are corrected to 'failed'."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+
+        config = {"variables": ["Amon.tas"]}
+        finalize_monitor(tracker, config, "historical", db_path)
+
+        assert tracker.get_status("Amon.tas", "historical") == "failed"
+        row = tracker.conn.execute(
+            "SELECT error_message FROM cmor_tasks WHERE variable=?",
+            ("Amon.tas",),
+        ).fetchone()
+        assert "finalize" in row[0]
+
+    @pytest.mark.unit
+    def test_finalize_marks_pending_as_failed(self, temp_dir):
+        """Variables that never left 'pending' (qsub failed early) are marked failed."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")  # stays pending
+
+        config = {"variables": ["Amon.tas"]}
+        finalize_monitor(tracker, config, "historical", db_path)
+
+        assert tracker.get_status("Amon.tas", "historical") == "failed"
+
+    @pytest.mark.unit
+    def test_finalize_preserves_completed_and_failed(self, temp_dir):
+        """Terminal-state rows are not touched."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.done", "historical")
+        tracker.mark_completed("Amon.done", "historical")
+        tracker.add_task("Amon.bad", "historical")
+        tracker.mark_failed("Amon.bad", "historical", "previously failed")
+
+        config = {"variables": ["Amon.done", "Amon.bad"]}
+        finalize_monitor(tracker, config, "historical", db_path)
+
+        assert tracker.get_status("Amon.done", "historical") == "completed"
+        # Original error message survives
+        row = tracker.conn.execute(
+            "SELECT error_message FROM cmor_tasks WHERE variable=?",
+            ("Amon.bad",),
+        ).fetchone()
+        assert row[0] == "previously failed"
+
+    @pytest.mark.unit
+    def test_finalize_removes_sidecar_file(self, temp_dir):
+        """Sidecar file is deleted on successful finalize."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        sidecar = temp_dir / SIDECAR_FILENAME
+        sidecar.write_text("12345.gadi-pbs\n2026-05-15T00:00:00\n")
+
+        finalize_monitor(tracker, {"variables": []}, "historical", db_path)
+        assert not sidecar.exists()
+
+    @pytest.mark.unit
+    def test_finalize_tolerates_missing_sidecar(self, temp_dir):
+        """No exception when sidecar was already deleted (or never created)."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        # No sidecar to begin with — should not raise
+        finalize_monitor(tracker, {"variables": []}, "historical", db_path)
+
+
+class TestMonitorMain:
+    """Unit tests for monitor_main entry point: env validation and submit flow."""
+
+    @pytest.mark.unit
+    def test_exits_with_code_2_when_env_missing(self, monkeypatch):
+        """monitor_main bails out cleanly if MOPPY_CONFIG_PATH or MOPPY_DB_PATH absent."""
+        monkeypatch.delenv("MOPPY_CONFIG_PATH", raising=False)
+        monkeypatch.delenv("MOPPY_DB_PATH", raising=False)
+
+        with pytest.raises(SystemExit) as excinfo:
+            monitor_main()
+        assert excinfo.value.code == 2
+
+    @pytest.mark.unit
+    def test_monitor_submits_one_job_per_variable(self, temp_dir, monkeypatch):
+        """Each variable in the config gets one qsub call and one pbs_job_id stored."""
+        db_path = temp_dir / "test.db"
+
+        # Real DB so we can verify pbs_job_id storage
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.add_task("Amon.pr", "historical")
+        tracker.conn.close()
+
+        config_path = temp_dir / "config.yml"
+        config_path.write_text(
+            "experiment_id: historical\n" "variables:\n  - Amon.tas\n  - Amon.pr\n"
+        )
+
+        monkeypatch.setenv("MOPPY_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv("MOPPY_DB_PATH", str(db_path))
+        monkeypatch.setenv("MOPPY_SCRIPT_DIR", str(temp_dir / "scripts"))
+
+        # Mock the script-creation + qsub + qstat layer
+        job_ids = iter(["111.gadi-pbs", "222.gadi-pbs"])
+        submit_calls = []
+
+        def fake_create_job_script(variable, config, db_path, script_dir):
+            return (
+                Path(script_dir)
+                / variable.replace(".", "_")
+                / f"cmor_{variable.replace('.', '_')}.sh"
+            )
+
+        def fake_submit_job(path):
+            submit_calls.append(path)
+            return next(job_ids)
+
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.create_job_script", fake_create_job_script
+        )
+        monkeypatch.setattr("access_moppy.batch_cmoriser.submit_job", fake_submit_job)
+        # Sub-jobs immediately finish OK so the loop terminates
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.qstat_full",
+            lambda jid: {"job_state": "F", "Exit_status": "0"},
+        )
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        monitor_main()
+
+        # Both variables submitted
+        assert len(submit_calls) == 2
+
+        # pbs_job_id stored for each variable
+        verify = TaskTracker(db_path)
+        assert verify.get_pbs_job_id("Amon.tas", "historical") in (
+            "111.gadi-pbs",
+            "222.gadi-pbs",
+        )
+        assert verify.get_pbs_job_id("Amon.pr", "historical") in (
+            "111.gadi-pbs",
+            "222.gadi-pbs",
+        )
+        # Both end up completed
+        assert verify.get_status("Amon.tas", "historical") == "completed"
+        assert verify.get_status("Amon.pr", "historical") == "completed"
+        verify.conn.close()
+
+    @pytest.mark.unit
+    def test_monitor_skips_already_completed(self, temp_dir, monkeypatch):
+        """Variables already marked 'completed' are not re-submitted."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_completed("Amon.tas", "historical")
+        tracker.add_task("Amon.pr", "historical")
+        tracker.conn.close()
+
+        config_path = temp_dir / "config.yml"
+        config_path.write_text(
+            "experiment_id: historical\nvariables:\n  - Amon.tas\n  - Amon.pr\n"
+        )
+        monkeypatch.setenv("MOPPY_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv("MOPPY_DB_PATH", str(db_path))
+        monkeypatch.setenv("MOPPY_SCRIPT_DIR", str(temp_dir / "scripts"))
+
+        submitted = []
+
+        def fake_create_job_script(variable, config, db_path, script_dir):
+            return Path(script_dir) / "x.sh"
+
+        def fake_submit_job(path):
+            submitted.append(path)
+            return "999.gadi-pbs"
+
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.create_job_script", fake_create_job_script
+        )
+        monkeypatch.setattr("access_moppy.batch_cmoriser.submit_job", fake_submit_job)
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.qstat_full",
+            lambda jid: {"job_state": "F", "Exit_status": "0"},
+        )
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        monitor_main()
+
+        # Only Amon.pr should have been submitted; Amon.tas was already done
+        assert len(submitted) == 1
+
+    @pytest.mark.unit
+    def test_monitor_marks_failed_when_qsub_returns_none(self, temp_dir, monkeypatch):
+        """When submit_job returns None (qsub failed), DB row is set to 'failed'."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.conn.close()
+
+        config_path = temp_dir / "config.yml"
+        config_path.write_text("experiment_id: historical\nvariables:\n  - Amon.tas\n")
+        monkeypatch.setenv("MOPPY_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv("MOPPY_DB_PATH", str(db_path))
+        monkeypatch.setenv("MOPPY_SCRIPT_DIR", str(temp_dir / "scripts"))
+
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.create_job_script",
+            lambda *a, **k: temp_dir / "x.sh",
+        )
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.submit_job",
+            lambda p: None,  # qsub failed
+        )
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        monitor_main()
+
+        verify = TaskTracker(db_path)
+        assert verify.get_status("Amon.tas", "historical") == "failed"
+        row = verify.conn.execute(
+            "SELECT error_message FROM cmor_tasks WHERE variable=?",
+            ("Amon.tas",),
+        ).fetchone()
+        assert "qsub" in row[0]
+        verify.conn.close()

--- a/tests/unit/test_batch_cmoriser.py
+++ b/tests/unit/test_batch_cmoriser.py
@@ -312,6 +312,134 @@ class TestMainScriptDir:
 
         assert (tmp_path / "my_scripts").is_dir()
 
+    @pytest.mark.unit
+    def test_main_exits_when_monitor_submit_returns_none(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """If qsub-ing the monitor fails (submit_job returns None), main exits 1
+        with an explanatory message."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("")
+        config = {**self.BASE_CONFIG, "output_folder": str(tmp_path / "output")}
+
+        monkeypatch.setattr("sys.argv", ["moppy-cmorise", str(config_file)])
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch("access_moppy.batch_cmoriser.yaml.safe_load", return_value=config),
+            patch("access_moppy.batch_cmoriser.TaskTracker"),
+            patch("access_moppy.batch_cmoriser.start_dashboard"),
+            patch("access_moppy.batch_cmoriser.files"),
+            patch(
+                "access_moppy.batch_cmoriser.create_monitor_script",
+                return_value=tmp_path / "moppy_monitor.sh",
+            ),
+            patch(
+                "access_moppy.batch_cmoriser.submit_job",
+                return_value=None,  # qsub fails
+            ),
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Failed to submit monitor job" in captured.out
+
+    @pytest.mark.unit
+    def test_main_does_not_wait_by_default(self, tmp_path, monkeypatch):
+        """Without wait_for_completion in config, main exits without polling."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("")
+        config = {**self.BASE_CONFIG, "output_folder": str(tmp_path / "output")}
+
+        monkeypatch.setattr("sys.argv", ["moppy-cmorise", str(config_file)])
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch("access_moppy.batch_cmoriser.yaml.safe_load", return_value=config),
+            patch("access_moppy.batch_cmoriser.TaskTracker"),
+            patch("access_moppy.batch_cmoriser.start_dashboard"),
+            patch("access_moppy.batch_cmoriser.files"),
+            patch(
+                "access_moppy.batch_cmoriser.create_monitor_script",
+                return_value=tmp_path / "moppy_monitor.sh",
+            ),
+            patch(
+                "access_moppy.batch_cmoriser.submit_job",
+                return_value="42.gadi-pbs",
+            ),
+            patch("access_moppy.batch_cmoriser.wait_for_jobs") as mock_wait,
+        ):
+            main()
+
+        mock_wait.assert_not_called()
+
+    @pytest.mark.unit
+    def test_main_waits_when_config_requests_it(self, tmp_path, monkeypatch):
+        """When wait_for_completion=true, main calls wait_for_jobs for the monitor's
+        PBS job ID (not for each sub-job — the monitor handles those internally)."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("")
+        config = {
+            **self.BASE_CONFIG,
+            "output_folder": str(tmp_path / "output"),
+            "wait_for_completion": True,
+        }
+
+        monkeypatch.setattr("sys.argv", ["moppy-cmorise", str(config_file)])
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch("access_moppy.batch_cmoriser.yaml.safe_load", return_value=config),
+            patch("access_moppy.batch_cmoriser.TaskTracker"),
+            patch("access_moppy.batch_cmoriser.start_dashboard"),
+            patch("access_moppy.batch_cmoriser.files"),
+            patch(
+                "access_moppy.batch_cmoriser.create_monitor_script",
+                return_value=tmp_path / "moppy_monitor.sh",
+            ),
+            patch(
+                "access_moppy.batch_cmoriser.submit_job",
+                return_value="42.gadi-pbs",
+            ),
+            patch("access_moppy.batch_cmoriser.wait_for_jobs") as mock_wait,
+        ):
+            main()
+
+        mock_wait.assert_called_once_with(["42.gadi-pbs"])
+
+    @pytest.mark.unit
+    def test_main_writes_sidecar_file(self, tmp_path, monkeypatch):
+        """The sidecar file is written after the monitor is qsub'd."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("")
+        config = {**self.BASE_CONFIG, "output_folder": str(tmp_path / "output")}
+
+        monkeypatch.setattr("sys.argv", ["moppy-cmorise", str(config_file)])
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch("access_moppy.batch_cmoriser.yaml.safe_load", return_value=config),
+            patch("access_moppy.batch_cmoriser.TaskTracker"),
+            patch("access_moppy.batch_cmoriser.start_dashboard"),
+            patch("access_moppy.batch_cmoriser.files"),
+            patch(
+                "access_moppy.batch_cmoriser.create_monitor_script",
+                return_value=tmp_path / "moppy_monitor.sh",
+            ),
+            patch(
+                "access_moppy.batch_cmoriser.submit_job",
+                return_value="42.gadi-pbs",
+            ),
+        ):
+            main()
+
+        sidecar = tmp_path / "output" / SIDECAR_FILENAME
+        assert sidecar.exists()
+        contents = sidecar.read_text().splitlines()
+        assert contents[0] == "42.gadi-pbs"
+
 
 class TestWalltimeHelpers:
     """Unit tests for walltime parsing and monitor walltime computation."""
@@ -499,6 +627,44 @@ class TestQstatHelpers:
         assert "pbs_comment" not in msg
         assert "mem_used" not in msg
         assert "walltime_used" not in msg
+
+    @pytest.mark.unit
+    def test_format_pbs_error_swallows_tail_timeout(self, tmp_path):
+        """If `tail` subprocess times out, the error string is still returned,
+        just without the err_tail section. The exception must not propagate."""
+        import subprocess
+
+        # err file exists so the tail path is entered
+        var_dir = tmp_path / "Amon_tas"
+        var_dir.mkdir()
+        (var_dir / "cmor_Amon_tas.err").write_text("some error log")
+
+        info = {"Exit_status": "1", "comment": "task failed"}
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["tail"], timeout=10),
+        ):
+            msg = format_pbs_error("Amon.tas", "12345", info, tmp_path)
+
+        # Other fields still rendered
+        assert "exit_status=1" in msg
+        assert "task failed" in msg
+        # tail content omitted because of timeout
+        assert "err_tail" not in msg
+
+    @pytest.mark.unit
+    def test_format_pbs_error_swallows_tail_missing_binary(self, tmp_path):
+        """If `tail` binary is not on PATH (FileNotFoundError), result is still sane."""
+        var_dir = tmp_path / "Amon_tas"
+        var_dir.mkdir()
+        (var_dir / "cmor_Amon_tas.err").write_text("some error log")
+
+        info = {"Exit_status": "1"}
+        with patch("subprocess.run", side_effect=FileNotFoundError("tail not found")):
+            msg = format_pbs_error("Amon.tas", "12345", info, tmp_path)
+
+        assert "exit_status=1" in msg
+        assert "err_tail" not in msg
 
 
 class TestReconcileOne:
@@ -952,6 +1118,64 @@ class TestMonitorMain:
 
         # Only Amon.pr should have been submitted; Amon.tas was already done
         assert len(submitted) == 1
+
+    @pytest.mark.unit
+    def test_monitor_marks_failed_when_create_job_script_raises(
+        self, temp_dir, monkeypatch
+    ):
+        """When create_job_script raises for one variable, monitor marks that
+        variable as failed and continues to the next rather than aborting the batch."""
+        db_path = temp_dir / "test.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.broken", "historical")
+        tracker.add_task("Amon.ok", "historical")
+        tracker.conn.close()
+
+        config_path = temp_dir / "config.yml"
+        config_path.write_text(
+            "experiment_id: historical\n" "variables:\n  - Amon.broken\n  - Amon.ok\n"
+        )
+        monkeypatch.setenv("MOPPY_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv("MOPPY_DB_PATH", str(db_path))
+        monkeypatch.setenv("MOPPY_SCRIPT_DIR", str(temp_dir / "scripts"))
+
+        submitted = []
+
+        def flaky_create_job_script(variable, *args, **kwargs):
+            if variable == "Amon.broken":
+                raise RuntimeError("jinja template missing")
+            return temp_dir / "x.sh"
+
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.create_job_script",
+            flaky_create_job_script,
+        )
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.submit_job",
+            lambda p: submitted.append(p) or "999.gadi-pbs",
+        )
+        monkeypatch.setattr(
+            "access_moppy.batch_cmoriser.qstat_full",
+            lambda jid: {"job_state": "F", "Exit_status": "0"},
+        )
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        monitor_main()
+
+        verify = TaskTracker(db_path)
+        # Broken variable: hit the except branch → failed with descriptive message
+        assert verify.get_status("Amon.broken", "historical") == "failed"
+        row = verify.conn.execute(
+            "SELECT error_message FROM cmor_tasks WHERE variable=?",
+            ("Amon.broken",),
+        ).fetchone()
+        assert "failed to create script" in row[0]
+        assert "jinja template missing" in row[0]
+
+        # The `continue` after the except let the next variable proceed normally
+        assert verify.get_status("Amon.ok", "historical") == "completed"
+        assert len(submitted) == 1
+        verify.conn.close()
 
     @pytest.mark.unit
     def test_monitor_marks_failed_when_qsub_returns_none(self, temp_dir, monkeypatch):

--- a/tests/unit/test_batch_cmoriser.py
+++ b/tests/unit/test_batch_cmoriser.py
@@ -274,6 +274,10 @@ class TestMainScriptDir:
                 return_value=tmp_path / "job.sh",
             ),
             patch(
+                "access_moppy.batch_cmoriser.create_monitor_script",
+                return_value=tmp_path / "moppy_monitor.sh",
+            ),
+            patch(
                 "access_moppy.batch_cmoriser.submit_job", return_value="12345.gadi-pbs"
             ),
         ):

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -278,3 +278,137 @@ class TestTaskTracker:
                 tracker._execute_with_retry("SELECT 1", ())
 
         assert call_count == 1  # raised immediately, no retry
+
+    @pytest.mark.unit
+    def test_pbs_job_id_round_trip(self, temp_dir):
+        """set_pbs_job_id stores a value that get_pbs_job_id reads back unchanged."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+
+        # Before set, the column is NULL
+        assert tracker.get_pbs_job_id("Amon.tas", "historical") is None
+
+        tracker.set_pbs_job_id("Amon.tas", "historical", "12345.gadi-pbs")
+        assert tracker.get_pbs_job_id("Amon.tas", "historical") == "12345.gadi-pbs"
+
+        # Overwrite is allowed (e.g. monitor resubmits a failed job)
+        tracker.set_pbs_job_id("Amon.tas", "historical", "67890.gadi-pbs")
+        assert tracker.get_pbs_job_id("Amon.tas", "historical") == "67890.gadi-pbs"
+
+    @pytest.mark.unit
+    def test_get_pbs_job_id_for_unknown_task_returns_none(self, temp_dir):
+        """get_pbs_job_id returns None when the (variable, experiment) row is absent."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+        assert tracker.get_pbs_job_id("nonexistent.var", "historical") is None
+
+    @pytest.mark.unit
+    def test_list_unfinished_excludes_terminal_states(self, temp_dir):
+        """list_unfinished returns only pending/running rows, not completed/failed."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+
+        # pending (never touched after add)
+        tracker.add_task("Amon.pending", "historical")
+        # running
+        tracker.add_task("Amon.running", "historical")
+        tracker.mark_running("Amon.running", "historical")
+        # completed
+        tracker.add_task("Amon.done", "historical")
+        tracker.mark_completed("Amon.done", "historical")
+        # failed
+        tracker.add_task("Amon.bad", "historical")
+        tracker.mark_failed("Amon.bad", "historical", "test error")
+
+        rows = tracker.list_unfinished("historical")
+        returned = sorted(r[0] for r in rows)
+        assert returned == ["Amon.pending", "Amon.running"]
+
+    @pytest.mark.unit
+    def test_list_unfinished_returns_status_and_pbs_job_id(self, temp_dir):
+        """list_unfinished tuple format is (variable, status, pbs_job_id)."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_running("Amon.tas", "historical")
+        tracker.set_pbs_job_id("Amon.tas", "historical", "12345.gadi-pbs")
+
+        rows = tracker.list_unfinished("historical")
+        assert rows == [("Amon.tas", "running", "12345.gadi-pbs")]
+
+    @pytest.mark.unit
+    def test_list_unfinished_scoped_to_experiment(self, temp_dir):
+        """list_unfinished filters by experiment_id, never bleeding across experiments."""
+        db_path = temp_dir / "test_tracker.db"
+        tracker = TaskTracker(db_path)
+
+        tracker.add_task("Amon.tas", "historical")  # stays pending
+        tracker.add_task("Amon.tas", "piControl")
+        tracker.mark_completed("Amon.tas", "piControl")  # terminal in piControl
+
+        assert [r[0] for r in tracker.list_unfinished("historical")] == ["Amon.tas"]
+        assert tracker.list_unfinished("piControl") == []
+
+    @pytest.mark.unit
+    def test_schema_migration_adds_pbs_job_id_column(self, temp_dir):
+        """Opening an old-schema DB auto-adds pbs_job_id via ALTER TABLE."""
+        db_path = temp_dir / "old.db"
+
+        # Hand-build a pre-migration DB lacking the pbs_job_id column
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """
+            CREATE TABLE cmor_tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                variable TEXT NOT NULL,
+                experiment_id TEXT NOT NULL,
+                status TEXT DEFAULT 'pending',
+                start_time TEXT, end_time TEXT, error_message TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO cmor_tasks (variable, experiment_id, status) "
+            "VALUES ('Omon.zostoga', 'historical', 'running')"
+        )
+        conn.commit()
+        conn.close()
+
+        tracker = TaskTracker(db_path)
+
+        columns = {
+            row[1]
+            for row in tracker.conn.execute("PRAGMA table_info(cmor_tasks)").fetchall()
+        }
+        assert "pbs_job_id" in columns
+
+        # Existing rows are preserved by the migration
+        assert tracker.get_status("Omon.zostoga", "historical") == "running"
+
+        # The new column functions correctly on the migrated DB
+        tracker.set_pbs_job_id("Omon.zostoga", "historical", "168282805.gadi-pbs")
+        assert (
+            tracker.get_pbs_job_id("Omon.zostoga", "historical") == "168282805.gadi-pbs"
+        )
+
+    @pytest.mark.unit
+    def test_schema_migration_idempotent(self, temp_dir):
+        """Re-opening a DB that already has pbs_job_id does not duplicate the column."""
+        db_path = temp_dir / "test_tracker.db"
+
+        # First open: creates schema with pbs_job_id
+        t1 = TaskTracker(db_path)
+        t1.add_task("Amon.tas", "historical")
+        t1.set_pbs_job_id("Amon.tas", "historical", "12345.gadi-pbs")
+        t1.conn.close()
+
+        # Second open: migration path should be a no-op
+        t2 = TaskTracker(db_path)
+        columns = [
+            row[1]
+            for row in t2.conn.execute("PRAGMA table_info(cmor_tasks)").fetchall()
+        ]
+        assert columns.count("pbs_job_id") == 1
+        # Data preserved across reopens
+        assert t2.get_pbs_job_id("Amon.tas", "historical") == "12345.gadi-pbs"


### PR DESCRIPTION
# Add batchprocessing monitor to avoid status mistracking in database

## Background

When a CMORisation sub-job is killed by PBS (OOM, walltime exceeded, node crash, `qdel -W force`), the worker process is terminated via **SIGKILL**, which cannot be caught by Python. As a result:

- `try / except` block does not run → `mark_failed()` never called
- `finally` block does not run → no cleanup
- `atexit` handlers do not run

The `cmor_tasks` database entry stays as `running` forever, even though the job has actually ended.

### Example

`Omon.zostoga` in batch run:

- PBS job exceeded memory allocation (`rss=186 GB / limit=190 GB`) and was SIGKILL'd
- PBS state: `F` (Finished)
- Database state: `Omon.zostoga | historical | running | start_time=2026-05-13 13:20:01 | end_time=NULL`

There was no mechanism to reconcile this divergence — neither in the worker (cannot run after SIGKILL), nor in `batch_cmoriser.wait_for_jobs()` (only runs when `wait_for_completion: true`, dies if the login session disconnects).

## Solution

Introduce a dedicated **monitor PBS job** that supervises all sub-jobs and reconciles the database when a sub-job dies without writing its own terminal status.

### Workflow change

Before:

```
moppy-cmorise config.yml      (login node)
    └── qsub × N              (sub-jobs)
    └── exit                  (no further supervision in default mode)
```

After:

```
moppy-cmorise config.yml           (login node, ~seconds; exits after submitting monitor)
    └── qsub moppy_monitor.sh
            └── monitor PBS job    (compute node, walltime = max(sub) + 30 min)
                    ├── qsub × N   (sub-jobs)
                    └── poll qstat -fx every 30 s
                            └── on sub finish with exit ≠ 0 → mark_failed(...)
                    └── all sub-jobs done → finalize → exit 0
```

The monitor lives on a compute node, so it survives login session disconnects. It is structurally separate from sub-jobs, so OOM in a sub-job cannot kill the monitor.

### Why a dedicated PBS job (not a heartbeat thread)?

A heartbeat thread inside each worker would require background threads, a reaper script, staleness thresholds, and is vulnerable to GIL contention causing false positives. The monitor pattern is more elegant: a single, lightweight, externally-observable process that uses PBS itself as the source of truth.

## Implementation

### 1. `src/access_moppy/tracking.py` — schema extension

- New column: `pbs_job_id TEXT`
- Automatic `ALTER TABLE` migration for pre-existing databases (backward compatible)
- New methods:
  - `set_pbs_job_id(variable, experiment_id, job_id)`
  - `get_pbs_job_id(variable, experiment_id)`
  - `list_unfinished(experiment_id)`

### 2. `src/access_moppy/batch_cmoriser.py` — split into login + monitor

#### Login-side `main()`
Now thin: parse config, init DB, start dashboard, qsub **only** the monitor job, write sidecar file, exit.

#### Monitor-side `monitor_main()`
New entry point invoked via `python -m access_moppy.batch_cmoriser --monitor`. Runs on the compute node:

1. Read config from `$MOPPY_CONFIG_PATH`
2. For each variable: create script + `qsub`, record `pbs_job_id` in DB
3. Install SIGTERM handler (graceful shutdown on walltime warning / `qdel`)
4. Enter `monitor_loop`: poll `qstat -fx <jobid>` every 30 s
5. When a sub-job leaves `Q/R/H` state → call `reconcile_one` to read exit status and rich PBS metadata
6. When all sub-jobs accounted for → `finalize_monitor` (consistency sweep, summary, delete sidecar), exit 0

#### New helpers

| Helper | Purpose |
|---|---|
| `parse_walltime` / `format_walltime` | Convert `HH:MM:SS` strings to seconds and back |
| `compute_monitor_walltime` | `max(sub walltime) + 30 minutes`, reading from `walltime` and `variable_resources[var].walltime` in the YAML config |
| `qstat_full(job_id)` | Parse `qstat -fx` output (handles PBS Pro continuation lines) |
| `qstat_state(info)` | Extract `job_state` (`R`/`Q`/`F`/etc.) or `gone` if history purged |
| `format_pbs_error` | Compose rich error message from `Exit_status`, `comment`, `resources_used.mem`, `resources_used.walltime`, plus `.err` file tail |
| `reconcile_one` | Decide DB update based on PBS exit status, never overwriting an existing terminal state |
| `create_monitor_script` | Render the monitor PBS script via Jinja2 |
| `finalize_monitor` | Final consistency sweep, summary print, sidecar cleanup |

#### Error message format

When a sub-job dies without writing its terminal status, the DB error_message now looks like:

```
job 168282805.gadi-pbs | exit_status=271
| pbs_comment='job killed: memory limit exceeded'
| mem_used=186.5GB | walltime_used=00:34:18
| err_tail:
  Job 168282805 has exceeded memory allocation on node gadi-cpu-clx-0803.gadi.nci.org.au
  Process "python", pid 1259699, rss 186469367808, vmem 219695304704
```

### 3. `src/access_moppy/templates/cmor_monitor_script.j2` (new)

Minimal PBS script for the monitor: 1 CPU, 4 GB memory, computed walltime, executes `python -m access_moppy.batch_cmoriser --monitor`. Inherits queue / scheduler_options / storage / worker_init from the batch config.

### 4. Sidecar file

`<output_folder>/.moppy_main.jobid` records the monitor's PBS job ID and start time. This lets the dashboard or a successor monitor / `moppy-reconcile` CLI find the live monitor.

### 5. `tests/unit/test_batch_cmoriser.py`

Added `create_monitor_script` mock to `TestMainScriptDir._run_main` since the login-side `main()` now calls it.

## Walltime sizing

```
monitor_walltime = max(sub walltime) + 30 minutes
```

Sub walltimes come from the YAML config:
- Default: top-level `walltime` (e.g. `02:00:00`)
- Per-variable override: `variable_resources[var].walltime` (e.g. `Amon.cl: walltime: 04:00:00`)

Example: with `Amon.cl` at 4 h and other defaults at 2 h, the monitor gets `04:30:00`.

This sizing is intentionally conservative — the monitor only needs to outlive the longest single sub-job's execution, since on Gadi `normal` queue `max_run_per_user` is large enough that almost all sub-jobs run concurrently rather than serially.

## Resource use

The monitor itself is tiny:

- `#PBS -l ncpus=1`
- `#PBS -l mem=4GB`
- Polling work: one `qstat -fx <jobid>` call per pending sub-job per 30 s

For a 90-variable batch, this is ~3 qstat calls/second sustained — well within PBS server tolerance.

## Backward compatibility

All preserved:

- **Worker scripts (`cmor_python_script.j2`) are unchanged.** Workers still call `mark_done` / `mark_failed` on their own; the monitor only acts when the worker had no chance to.
- **`wait_for_completion: true` still works** — login now waits for the monitor job to finish (instead of polling individual sub-jobs).
- **Dashboard, `create_job_script`, `submit_job`, `wait_for_jobs`** — all retained with original behavior.
- **`is_done` skip logic** — preserved; the monitor honors completed-already entries.
- **Pre-existing databases** — auto-migrated via `ALTER TABLE` on first open.

## Death modes now handled

| Failure mode | Before | After |
|---|---|---|
| Python exception in worker | ✅ (worker writes `failed`) | ✅ |
| Worker `sys.exit(1)` | ✅ | ✅ |
| **SIGKILL (OOM)** | ❌ DB stuck `running` | ✅ Monitor reads `Exit_status=137`, writes `failed` with rich detail |
| Walltime exceeded | ❌ (SIGKILL after grace) | ✅ Same as above |
| `qdel -W force` | ❌ | ✅ |
| Node crash | ❌ | ✅ Monitor sees `F` state when PBS reports it |
| Login session disconnect | ❌ (`wait_for_jobs` dies) | ✅ Monitor lives on compute node |
| Monitor itself walltime-out | n/a | ✅ SIGTERM handler marks unfinished subs as failed before exit |
| Monitor itself SIGKILL | n/a | ❌ Sidecar remains; requires manual `moppy-reconcile` (out of scope) |

## Testing

- **`tests/unit/test_batch_cmoriser.py`**: 15/15 pass

## Files changed

| File | Change |
|---|---|
| `src/access_moppy/tracking.py` | +37 lines (column + 3 methods + migration) |
| `src/access_moppy/batch_cmoriser.py` | +250 lines (helpers + monitor_main + login refactor) |
| `src/access_moppy/templates/cmor_monitor_script.j2` | new file |
| `tests/unit/test_batch_cmoriser.py` | +4 lines (mock for `create_monitor_script`) |