### PR TITLE
fix missing atttributes issue in coordinates

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -991,10 +991,13 @@ class CMORiser:
 
                     # Set attributes
                     for a, val in vdat.attrs.items():
-                        if a in ("_FillValue", "bounds"):
+                        if a == "_FillValue":
                             continue
-                        if var.endswith("_bnds") and a == "coordinates":
-                            continue  # strip stale auxiliary coordinates reference on bounds
+                        # CF §7.1: bounds variables themselves must not carry a
+                        # "bounds" or stale "coordinates" attribute; but the parent
+                        # coordinate must keep its "bounds" pointer to the _bnds var.
+                        if var.endswith("_bnds") and a in ("bounds", "coordinates"):
+                            continue
                         v.setncattr(a, val)
 
                         # ========== Add coordinates attribute for main data variable ==========

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -759,6 +759,50 @@ class TestCMIP6CMORiserWrite:
             finally:
                 ds_out.close()
 
+    @pytest.mark.unit
+    def test_write_bounds_attribute_handling(self, cmoriser_with_dataset, temp_dir):
+        """
+        Regression test for CF §7.1 bounds attribute handling in write().
+
+        Verifies two related behaviours of the attribute filter:
+        1. Parent coordinate variables (lat/lon/time) keep their "bounds"
+           attribute pointing to the bounds variable.
+        2. The "_bnds" variable itself does NOT carry a stale "bounds" or
+           "coordinates" attribute (CF §7.1).
+
+        Covers the `var.endswith("_bnds") and a in ("bounds", "coordinates")`
+        branch in CMORiser.write().
+        """
+        # Set up the input dataset so that:
+        # - time has a legitimate "bounds" pointer to time_bnds
+        # - time_bnds carries stale "bounds" and "coordinates" attrs that
+        #   the write() filter must strip
+        cmoriser_with_dataset.ds["time"].attrs["bounds"] = "time_bnds"
+        cmoriser_with_dataset.ds["time_bnds"].attrs["bounds"] = "stale_ref"
+        cmoriser_with_dataset.ds["time_bnds"].attrs["coordinates"] = "stale_aux"
+
+        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
+            mock_mem.return_value = MagicMock(
+                total=32 * 1024**3,
+                available=16 * 1024**3,
+            )
+
+            cmoriser_with_dataset.write()
+
+        output_files = list(Path(temp_dir).glob("*.nc"))
+        assert len(output_files) == 1
+
+        # Use raw netCDF4 to inspect attributes (xarray may hide some)
+        with nc.Dataset(output_files[0], "r") as ds_nc:
+            # Parent coordinate must keep its bounds pointer
+            assert "bounds" in ds_nc.variables["time"].ncattrs()
+            assert ds_nc.variables["time"].getncattr("bounds") == "time_bnds"
+
+            # Bounds variable must NOT carry stale bounds/coordinates attrs
+            bnds_attrs = ds_nc.variables["time_bnds"].ncattrs()
+            assert "bounds" not in bnds_attrs
+            assert "coordinates" not in bnds_attrs
+
     # ==================== Chunked Write Tests ====================
 
     @pytest.mark.unit


### PR DESCRIPTION
## Fix missing `bounds` attributes during NetCDF write stage

### Root cause

The root cause of the missing `bounds` attributes is not in the processing workflow of `atmosphere.py`, but in the file writing stage in `base.py`.

The processing pipeline actually preserves the `bounds` attributes correctly:

- `atmosphere.py:71-72`
  
  `calculate_missing_bounds_variables()` explicitly sets:

  ```python
  self.ds[coord_name].attrs["bounds"] = bnds_var
  ```

- `atmosphere.py:393`
  
  ```python
  updated.attrs.update(coord_attrs)
  ```

  This uses `update()` rather than overwriting attributes, so the `bounds` attribute is preserved correctly.

---

## Actual issue

The real bug exists in `base.py:993-998` during the NetCDF write stage:

```python
for a, val in vdat.attrs.items():
    if a in ("_FillValue", "bounds"):
        continue
    if var.endswith("_bnds") and a == "coordinates":
        continue
    v.setncattr(a, val)
```

The original intention was likely to follow CF §7.1, where `_bnds` variables themselves should not contain `bounds` attributes.

However, the current implementation filters out `bounds` attributes for **all variables**, which unintentionally strips the valid `bounds` references from parent coordinates such as:

- `time`
- `lat`
- `lon`

As a result, the generated files lose links to:

- `time_bnds`
- `lat_bnds`
- `lon_bnds`

---

## Solution

Restrict the filtering logic so that only `_bnds` variables themselves remove `bounds` and `coordinates` attributes.

Updated implementation (`base.py:993-998`):

```python
for a, val in vdat.attrs.items():
    if a == "_FillValue":
        continue

    # CF §7.1 — bounds variables themselves must not have
    # bounds/coordinates attributes, but parent coordinates
    # must retain the bounds pointer to their *_bnds variables.
    if var.endswith("_bnds") and a in ("bounds", "coordinates"):
        continue

    v.setncattr(a, val)
```

This preserves valid `bounds` attributes on parent coordinate variables while remaining CF-compliant for `_bnds` variables themselves.