### PR TITLE
fix variables in different realm mapping issue

### DIFF
--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -4552,6 +4552,7 @@
         },
         "masscello": {
             "dimensions": {
+                "time": "time",
                 "st_ocean": "lev",
                 "yt_ocean": "latitude",
                 "xt_ocean": "longitude"
@@ -4562,11 +4563,8 @@
                 "rho_dzt"
             ],
             "calculation": {
-                "type": "formula",
-                "operation": "drop_time_axis",
-                "args": [
-                    "rho_dzt"
-                ]
+                "type": "direct",
+                "formula": "rho_dzt"
             },
             "CF standard Name": "sea_water_mass_per_unit_area",
             "model_variable_units": {
@@ -5273,6 +5271,7 @@
         },
         "thkcello": {
             "dimensions": {
+                "time": "time",
                 "st_ocean": "lev",
                 "yt_ocean": "latitude",
                 "xt_ocean": "longitude"
@@ -5283,11 +5282,8 @@
                 "dzt"
             ],
             "calculation": {
-                "type": "formula",
-                "operation": "drop_time_axis",
-                "args": [
-                    "dzt"
-                ]
+                "type": "direct",
+                "formula": "dzt"
             },
             "CF standard Name": "cell_thickness",
             "model_variable_units": {

--- a/src/access_moppy/ocean.py
+++ b/src/access_moppy/ocean.py
@@ -53,6 +53,38 @@ class Ocean_CMORiser(CMORiser):
         """A abstract method to infer the grid type and memory mode based on present coordinates."""
         raise NotImplementedError("Subclasses must implement infer_grid_type.")
 
+    def _expected_dim_names(self) -> set:
+        """Return the set of dim names the active CMOR table expects for this variable.
+
+        Handles the format difference between CMIP6 (space-separated string) and
+        CMIP7 (list).
+        """
+        dims = self.vocab.variable.get("dimensions", "")
+        if isinstance(dims, str):
+            dims = dims.split()
+        return set(dims)
+
+    def _align_main_var_dims_with_vocab(self):
+        """Drop the time axis from the main variable when the CMOR table does not request it.
+
+        Lets a single mapping entry serve both a fixed-table (Ofx/fx) variant
+        and a time-dependent (Omon/Oday/Odec) variant of the same variable:
+        the mapping describes the time-aware form, and the time axis is
+        stripped only when the CMOR table requires no time.
+
+        Scope is intentionally minimal — only the main CMOR variable is
+        touched; orphan time coords on the dataset (if any) are left alone to
+        preserve existing behaviour of intermediate cleanup steps.
+        """
+        if self.cmor_name not in self.ds:
+            return
+        main_var = self.ds[self.cmor_name]
+        if "time" not in main_var.dims:
+            return
+        if "time" in self._expected_dim_names():
+            return
+        self.ds[self.cmor_name] = main_var.isel(time=0, drop=True)
+
     def _get_dim_rename(self):
         """A abstract method to get the dimension renaming mapping for the grid type."""
         raise NotImplementedError("Subclasses must implement _get_dim_rename.")
@@ -137,6 +169,11 @@ class Ocean_CMORiser(CMORiser):
             self.ds = custom_functions[func_name](self.ds, **calc.get("kwargs", {}))
         else:
             raise ValueError(f"Unsupported calculation type: {calc['type']}")
+
+        # Strip the time axis when the active CMOR table does not request it.
+        # Lets a single ocean mapping entry serve both fx and time-dependent
+        # tables of the same variable (e.g. Ofx.masscello vs Omon.masscello).
+        self._align_main_var_dims_with_vocab()
 
         self.grid_type, self.symmetric = self.infer_grid_type()
 

--- a/tests/unit/test_ocean.py
+++ b/tests/unit/test_ocean.py
@@ -852,7 +852,9 @@ class TestUpdateAttributes:
 # ---------------------------------------------------------------------------
 
 
-def _make_align_cmoriser(vocab_dims, compound_name, temp_dir, ds, cmor_name="masscello"):
+def _make_align_cmoriser(
+    vocab_dims, compound_name, temp_dir, ds, cmor_name="masscello"
+):
     """Build an Ocean_CMORiser_OM2 with a minimal vocab for dim-alignment tests."""
     vocab = Mock()
     vocab.source_id = "ACCESS-ESM1-5"
@@ -860,7 +862,9 @@ def _make_align_cmoriser(vocab_dims, compound_name, temp_dir, ds, cmor_name="mas
     vocab._get_nominal_resolution = Mock(return_value="1deg")
     vocab._get_axes = Mock(return_value=({}, {}))
     vocab._get_required_bounds_variables = Mock(return_value=({}, {}))
-    mapping = {cmor_name: {"model_variables": ["src"], "calculation": {"type": "direct"}}}
+    mapping = {
+        cmor_name: {"model_variables": ["src"], "calculation": {"type": "direct"}}
+    }
     with patch("access_moppy.ocean.Supergrid"):
         cmoriser = Ocean_CMORiser_OM2(
             input_paths=["test.nc"],

--- a/tests/unit/test_ocean.py
+++ b/tests/unit/test_ocean.py
@@ -845,3 +845,204 @@ class TestUpdateAttributes:
 
         for var in ("latitude", "longitude", "vertices_latitude", "vertices_longitude"):
             assert var in cmoriser.ds, f"'{var}' missing for spatial variable"
+
+
+# ---------------------------------------------------------------------------
+# TestAlignMainVarDimsWithVocab
+# ---------------------------------------------------------------------------
+
+
+def _make_align_cmoriser(vocab_dims, compound_name, temp_dir, ds, cmor_name="masscello"):
+    """Build an Ocean_CMORiser_OM2 with a minimal vocab for dim-alignment tests."""
+    vocab = Mock()
+    vocab.source_id = "ACCESS-ESM1-5"
+    vocab.variable = {"dimensions": vocab_dims, "units": "kg m-2", "type": "real"}
+    vocab._get_nominal_resolution = Mock(return_value="1deg")
+    vocab._get_axes = Mock(return_value=({}, {}))
+    vocab._get_required_bounds_variables = Mock(return_value=({}, {}))
+    mapping = {cmor_name: {"model_variables": ["src"], "calculation": {"type": "direct"}}}
+    with patch("access_moppy.ocean.Supergrid"):
+        cmoriser = Ocean_CMORiser_OM2(
+            input_paths=["test.nc"],
+            output_path=str(temp_dir),
+            compound_name=compound_name,
+            vocab=vocab,
+            variable_mapping=mapping,
+        )
+    cmoriser.ds = ds
+    return cmoriser
+
+
+class TestExpectedDimNames:
+    """Tests for Ocean_CMORiser._expected_dim_names (CMIP6 vs CMIP7 format)."""
+
+    @pytest.mark.unit
+    def test_cmip6_string_form(self, temp_dir):
+        """CMIP6 stores dimensions as a space-separated string."""
+        cmoriser = _make_align_cmoriser(
+            vocab_dims="longitude latitude olevel time",
+            compound_name="Omon.masscello",
+            temp_dir=temp_dir,
+            ds=xr.Dataset(),
+        )
+        assert cmoriser._expected_dim_names() == {
+            "longitude",
+            "latitude",
+            "olevel",
+            "time",
+        }
+
+    @pytest.mark.unit
+    def test_cmip7_list_form(self, temp_dir):
+        """CMIP7 stores dimensions as a list."""
+        cmoriser = _make_align_cmoriser(
+            vocab_dims=["longitude", "latitude", "olevel"],
+            compound_name="Ofx.masscello",
+            temp_dir=temp_dir,
+            ds=xr.Dataset(),
+        )
+        assert cmoriser._expected_dim_names() == {"longitude", "latitude", "olevel"}
+
+    @pytest.mark.unit
+    def test_missing_dimensions_key_returns_empty(self, temp_dir):
+        """Defensive: a vocab variable entry without 'dimensions' must not crash."""
+        cmoriser = _make_align_cmoriser(
+            vocab_dims="time",
+            compound_name="Omon.masscello",
+            temp_dir=temp_dir,
+            ds=xr.Dataset(),
+        )
+        # Remove the dimensions key entirely
+        cmoriser.vocab.variable = {"units": "K"}
+        assert cmoriser._expected_dim_names() == set()
+
+
+class TestAlignMainVarDimsWithVocab:
+    """Tests for Ocean_CMORiser._align_main_var_dims_with_vocab.
+
+    Verifies the core invariant of the fix: the time axis on the main CMOR
+    variable is dropped if and only if it exists on the data but is not part
+    of what the active CMOR table requests.
+    """
+
+    @staticmethod
+    def _ds_with_time(name="masscello"):
+        return xr.Dataset(
+            {
+                name: (
+                    ["time", "st_ocean", "yt_ocean", "xt_ocean"],
+                    np.ones((3, 2, 4, 5), dtype=np.float32),
+                ),
+            },
+            coords={
+                "time": ("time", np.arange(3, dtype=float)),
+                "st_ocean": ("st_ocean", np.arange(2, dtype=float)),
+                "yt_ocean": ("yt_ocean", np.arange(4, dtype=float)),
+                "xt_ocean": ("xt_ocean", np.arange(5, dtype=float)),
+            },
+        )
+
+    @staticmethod
+    def _ds_without_time(name="masscello"):
+        return xr.Dataset(
+            {
+                name: (
+                    ["st_ocean", "yt_ocean", "xt_ocean"],
+                    np.ones((2, 4, 5), dtype=np.float32),
+                ),
+            },
+            coords={
+                "st_ocean": ("st_ocean", np.arange(2, dtype=float)),
+                "yt_ocean": ("yt_ocean", np.arange(4, dtype=float)),
+                "xt_ocean": ("xt_ocean", np.arange(5, dtype=float)),
+            },
+        )
+
+    @pytest.mark.unit
+    def test_drops_time_when_vocab_does_not_request_it(self, temp_dir):
+        """Ofx-style: data has time, vocab doesn't → time is dropped from main var."""
+        cmoriser = _make_align_cmoriser(
+            vocab_dims="longitude latitude olevel",  # no time → Ofx
+            compound_name="Ofx.masscello",
+            temp_dir=temp_dir,
+            ds=self._ds_with_time(),
+        )
+        cmoriser._align_main_var_dims_with_vocab()
+
+        assert "time" not in cmoriser.ds["masscello"].dims
+        assert cmoriser.ds["masscello"].dims == ("st_ocean", "yt_ocean", "xt_ocean")
+
+    @pytest.mark.unit
+    def test_keeps_time_when_vocab_requests_it(self, temp_dir):
+        """Omon-style: data has time and vocab requests it → unchanged."""
+        cmoriser = _make_align_cmoriser(
+            vocab_dims="longitude latitude olevel time",  # includes time → Omon
+            compound_name="Omon.masscello",
+            temp_dir=temp_dir,
+            ds=self._ds_with_time(),
+        )
+        original_dims = cmoriser.ds["masscello"].dims
+
+        cmoriser._align_main_var_dims_with_vocab()
+
+        assert cmoriser.ds["masscello"].dims == original_dims
+        assert "time" in cmoriser.ds["masscello"].dims
+
+    @pytest.mark.unit
+    def test_noop_when_main_var_has_no_time(self, temp_dir):
+        """Data already lacks time → no change, regardless of vocab."""
+        cmoriser = _make_align_cmoriser(
+            vocab_dims="longitude latitude olevel",
+            compound_name="Ofx.masscello",
+            temp_dir=temp_dir,
+            ds=self._ds_without_time(),
+        )
+        original_dims = cmoriser.ds["masscello"].dims
+
+        cmoriser._align_main_var_dims_with_vocab()
+
+        assert cmoriser.ds["masscello"].dims == original_dims
+
+    @pytest.mark.unit
+    def test_noop_when_cmor_name_not_in_ds(self, temp_dir):
+        """Defensive: missing main variable on ds → no error, no change."""
+        cmoriser = _make_align_cmoriser(
+            vocab_dims="longitude latitude olevel",
+            compound_name="Ofx.masscello",
+            temp_dir=temp_dir,
+            ds=xr.Dataset(),
+        )
+        cmoriser._align_main_var_dims_with_vocab()  # must not raise
+
+        assert "masscello" not in cmoriser.ds
+
+    @pytest.mark.unit
+    def test_does_not_touch_other_data_vars(self, temp_dir):
+        """Scope guarantee: only the main CMOR variable is altered."""
+        ds = self._ds_with_time()
+        # Add an unrelated time-bearing variable that the helper must not touch.
+        ds["other"] = (("time", "st_ocean"), np.zeros((3, 2), dtype=np.float32))
+        cmoriser = _make_align_cmoriser(
+            vocab_dims="longitude latitude olevel",
+            compound_name="Ofx.masscello",
+            temp_dir=temp_dir,
+            ds=ds,
+        )
+        cmoriser._align_main_var_dims_with_vocab()
+
+        assert "time" not in cmoriser.ds["masscello"].dims
+        # The unrelated variable keeps its time axis
+        assert "time" in cmoriser.ds["other"].dims
+
+    @pytest.mark.unit
+    def test_cmip7_list_dims_form_also_drops_time(self, temp_dir):
+        """CMIP7-style list dimensions field is honoured by the helper."""
+        cmoriser = _make_align_cmoriser(
+            vocab_dims=["longitude", "latitude", "olevel"],
+            compound_name="Ofx.masscello",
+            temp_dir=temp_dir,
+            ds=self._ds_with_time(),
+        )
+        cmoriser._align_main_var_dims_with_vocab()
+
+        assert "time" not in cmoriser.ds["masscello"].dims

--- a/tests/unit/test_utilities_mappings.py
+++ b/tests/unit/test_utilities_mappings.py
@@ -209,3 +209,50 @@ def test_get_monthly_ocean_files_no_files_warns(tmp_path):
             result = get_monthly_ocean_files("Omon.so", root_folder=str(tmp_path))
 
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Mapping invariants for variables that exist in both Ofx and a time-bearing
+# table (Omon / Odec). The same mapping entry must serve every table; per-table
+# differences are resolved at runtime by Ocean_CMORiser._align_main_var_dims_with_vocab.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "cmor_name,source_var",
+    [
+        ("masscello", "rho_dzt"),
+        ("thkcello", "dzt"),
+    ],
+)
+def test_dual_table_mapping_uses_direct_calculation_and_keeps_time(
+    cmor_name, source_var
+):
+    """Mapping must describe the time-aware form so it works for both Ofx and Omon.
+
+    The historic shape (calculation.operation == 'drop_time_axis' and no 'time'
+    key in 'dimensions') would silently break the Omon variant of these
+    variables again; lock the new shape in.
+    """
+    mapping = load_model_mappings(f"Omon.{cmor_name}", model_id="ACCESS-ESM1.6")
+    assert mapping, f"No mapping found for Omon.{cmor_name}"
+    entry = mapping[cmor_name]
+
+    # Calculation must be a plain rename, not a time-stripping formula.
+    calc = entry["calculation"]
+    assert calc["type"] == "direct", (
+        f"{cmor_name} calculation type should be 'direct' so the time axis is "
+        f"preserved by default; got {calc!r}"
+    )
+    assert calc["formula"] == source_var
+
+    # dimensions must include time so the rename map sees it for Omon/Odec.
+    dims = entry["dimensions"]
+    assert "time" in dims and dims["time"] == "time", (
+        f"{cmor_name} mapping must declare 'time': 'time' in dimensions; "
+        f"got {dims!r}"
+    )
+    # Spatial dims must still be present.
+    for d in ("st_ocean", "yt_ocean", "xt_ocean"):
+        assert d in dims, f"{cmor_name} mapping missing spatial dim '{d}'"


### PR DESCRIPTION
# fix #380 

# Fix: drive time-axis presence from the CMOR table for dual-table ocean variables

Same-name variables in both an `fx` and a time-bearing CMIP table (e.g.
`Ofx.masscello` + `Omon.masscello`) cannot be CMORised from a single mapping
entry today. `load_model_mappings` keys mappings by `cmor_name` only, so both
tables share one entry — currently hardcoded to `drop_time_axis`. Result:
`Ofx.*` works, `Omon.*` / `Odec.*` are broken (mapping strips time, vocab
demands it). Same story for `thkcello`.

## Solution

Let the **CMOR table** decide whether `time` is required; the mapping
describes the time-aware form, and code aligns the data to the table.

### `src/access_moppy/ocean.py`

Two helpers on `Ocean_CMORiser`, called once in `select_and_process_variables`
between the calculation block and `infer_grid_type`:

```python
def _expected_dim_names(self) -> set:
    dims = self.vocab.variable.get("dimensions", "")
    if isinstance(dims, str):
        dims = dims.split()
    return set(dims)

def _align_main_var_dims_with_vocab(self):
    if self.cmor_name not in self.ds:
        return
    main_var = self.ds[self.cmor_name]
    if "time" not in main_var.dims:
        return
    if "time" in self._expected_dim_names():
        return
    self.ds[self.cmor_name] = main_var.isel(time=0, drop=True)
```

### `src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json`

`masscello` and `thkcello`:

- `calculation`: `formula / drop_time_axis(<src>)` → `direct / <src>`
- `dimensions`: add `"time": "time"`

## Behaviour matrix

| Compound name                              | Before                          | After                  |
| ------------------------------------------ | ------------------------------- | ---------------------- |
| `Ofx.masscello` / `Ofx.thkcello`           | strips time (correct)           | equivalent             |
| `Omon.masscello` / `Omon.thkcello`         | strips time (**broken**)        | keeps time (**fixed**) |
| Other `Ofx` vars (`deptho`, `areacello`…)  | mapping strips time             | no-op (equivalent)     |
| Other `Omon`/`Oday` vars                   | unchanged                       | no-op                  |
| Atmosphere / sea-ice / land                | unchanged                       | unaffected             |

## Tests (+11 unit tests, all pass)

- `TestExpectedDimNames` (3): CMIP6 string / CMIP7 list / missing key.
- `TestAlignMainVarDimsWithVocab` (6): drop / keep / two no-ops / scope guard / CMIP7 form.
- `test_dual_table_mapping_uses_direct_calculation_and_keeps_time`
  (parametrised over `masscello`, `thkcello`) — regression lock-in.

## Files touched

- `src/access_moppy/ocean.py`
- `src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json`
- `tests/unit/test_ocean.py`
- `tests/unit/test_utilities_mappings.py`
