### PR TITLE
fix: normalize CF time units to canonical HH:MM:SS for WCRP ATTR004

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -16,6 +16,7 @@ from access_moppy.utilities import (
     FrequencyMismatchError,
     IncompatibleFrequencyError,
     ResamplingRequiredWarning,
+    normalize_cf_time_units,
     type_mapping,
     validate_and_resample_if_needed,
     validate_cmip6_frequency_compatibility,
@@ -801,6 +802,23 @@ class CMORiser:
 
         Automatically handles character/string coordinates with proper NetCDF encoding.
         """
+        # ========== Normalize CF Time-Coordinate Units ==========
+        # Source models differ in how they write the reference datetime: the UM
+        # atmosphere and CABLE land models omit the seconds field (e.g.
+        # "days since 0001-01-01 00:00"), which fails the WCRP units pattern
+        # check, whereas the ocean/sea-ice models write the full HH:MM:SS form.
+        # Re-emit any CF time units in canonical form here — the sole write path
+        # for every realm — so all variables are normalized uniformly.  This is
+        # meaning-preserving, so the numeric time values are unaffected.
+        for var in self.ds.variables:
+            units = self.ds[var].attrs.get("units")
+            normalized = normalize_cf_time_units(units)
+            if normalized != units:
+                self.ds[var].attrs["units"] = normalized
+                logger.debug(
+                    "Normalized '%s' units: %r -> %r", var, units, normalized
+                )
+
         # ========== Prepare String Coordinates ==========
         # Detect and prepare all string/character coordinates before writing
         string_coords_info = self._prepare_string_coordinates()

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -815,9 +815,7 @@ class CMORiser:
             normalized = normalize_cf_time_units(units)
             if normalized != units:
                 self.ds[var].attrs["units"] = normalized
-                logger.debug(
-                    "Normalized '%s' units: %r -> %r", var, units, normalized
-                )
+                logger.debug("Normalized '%s' units: %r -> %r", var, units, normalized)
 
         # ========== Prepare String Coordinates ==========
         # Detect and prepare all string/character coordinates before writing

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -1,6 +1,7 @@
 import importlib.metadata as importlib_metadata
 import json
 import logging
+import re
 import warnings
 from datetime import timedelta
 from importlib.resources import files
@@ -2052,6 +2053,47 @@ def validate_and_resample_if_needed(
     )
 
     return ds_resampled, True
+
+
+# CF time-coordinate units take the form "<interval> since <reference datetime>".
+# The WCRP ATTR004 check requires the reference datetime to be either a bare date
+# or a full "YYYY-MM-DD HH:MM:SS"; partial forms such as
+# "days since 0001-01-01 00:00" (no seconds — written by the UM atmosphere and
+# CABLE land models) fail the check.  This pattern captures the components so the
+# reference instant can be re-emitted in canonical form.
+_CF_TIME_UNITS_RE = re.compile(
+    r"^(?P<interval>\w+)\s+since\s+"
+    r"(?P<year>\d{1,4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})"
+    r"(?:[ T](?P<hour>\d{1,2}):(?P<minute>\d{1,2})(?::(?P<second>\d{1,2}(?:\.\d+)?))?)?"
+    r"\s*$",
+    re.IGNORECASE,
+)
+
+
+def normalize_cf_time_units(units: Optional[str]) -> Optional[str]:
+    """Return *units* with its reference datetime padded to canonical CF form.
+
+    Converts partial or date-only reference datetimes to a full
+    ``"<interval> since YYYY-MM-DD HH:MM:SS"`` string, e.g.
+    ``"days since 0001-01-01 00:00"`` -> ``"days since 0001-01-01 00:00:00"``.
+
+    The reference *instant* is preserved (an absent or partial time-of-day is
+    midnight either way), so any numeric time values measured against these units
+    remain correct.  Strings that are not recognisable CF time units — including
+    those carrying a timezone offset — are returned unchanged.
+    """
+    if not isinstance(units, str):
+        return units
+    match = _CF_TIME_UNITS_RE.match(units.strip())
+    if match is None:
+        return units
+    g = match.groupdict()
+    return (
+        f"{g['interval']} since "
+        f"{int(g['year']):04d}-{int(g['month']):02d}-{int(g['day']):02d} "
+        f"{int(g['hour'] or 0):02d}:{int(g['minute'] or 0):02d}:"
+        f"{int(float(g['second'] or 0)):02d}"
+    )
 
 
 def calculate_time_bounds(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -760,6 +760,72 @@ class TestCMIP6CMORiserWrite:
                 ds_out.close()
 
     @pytest.mark.unit
+    def test_write_normalizes_partial_time_units(
+        self, mock_vocab, mock_mapping, temp_dir
+    ):
+        """write() pads a partial CF time-units string to the full canonical form.
+
+        Regression test for the WCRP ATTR004 failure: UM atmosphere/land source
+        files write "days since YYYY-MM-DD 00:00" (no seconds), which must be
+        re-emitted as "...00:00:00".  Non-time units must be left untouched, and
+        the numeric time values must not change (meaning-preserving).
+        """
+        original_time = np.arange(3).astype(float)
+        ds = xr.Dataset(
+            {
+                "tas": (
+                    ["time", "lat", "lon"],
+                    np.random.rand(3, 4, 5).astype(np.float32),
+                    {"_FillValue": 1e20, "units": "K"},
+                ),
+            },
+            coords={
+                "time": (
+                    "time",
+                    original_time,
+                    {"units": "days since 2000-01-01 00:00", "calendar": "standard"},
+                ),
+                "lat": ("lat", np.arange(4)),
+                "lon": ("lon", np.arange(5)),
+            },
+            attrs={
+                "variable_id": "tas",
+                "table_id": "Amon",
+                "source_id": "ACCESS-ESM1-5",
+                "experiment_id": "historical",
+                "variant_label": "r1i1p1f1",
+                "grid_label": "gn",
+            },
+        )
+        cmoriser = CMORiser(
+            input_paths=["test.nc"],
+            output_path=str(temp_dir),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="Amon.tas",
+        )
+        cmoriser.ds = ds
+        cmoriser.cmor_name = "tas"
+
+        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
+            mock_mem.return_value = MagicMock(
+                total=32 * 1024**3, available=16 * 1024**3
+            )
+            cmoriser.write()
+
+        output_files = list(Path(temp_dir).glob("*.nc"))
+        ds_out = xr.open_dataset(output_files[0], decode_cf=False)
+        try:
+            # time units padded to full HH:MM:SS (the normalized branch)
+            assert ds_out["time"].attrs["units"] == "days since 2000-01-01 00:00:00"
+            # non-time units left untouched (the unchanged branch)
+            assert ds_out["tas"].attrs["units"] == "K"
+            # numeric time values preserved
+            np.testing.assert_array_equal(ds_out["time"].values, original_time)
+        finally:
+            ds_out.close()
+
+    @pytest.mark.unit
     def test_write_bounds_attribute_handling(self, cmoriser_with_dataset, temp_dir):
         """
         Regression test for CF §7.1 bounds attribute handling in write().

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -25,6 +25,7 @@ from access_moppy.utilities import (
     create_ilamb_observational_symlinks,
     detect_time_frequency_lazy,
     get_requested_variables_from_data_request,
+    normalize_cf_time_units,
 )
 
 
@@ -1406,3 +1407,74 @@ class TestDetectFrequencyFromBoundsCrossValidation:
             result = _detect_frequency_from_bounds(ds, "time")
         assert result is None
         assert any("unexpected shape" in str(warning.message) for warning in w)
+
+
+class TestNormalizeCfTimeUnits:
+    """Tests for normalize_cf_time_units (WCRP time-units pattern compliance)."""
+
+    # WCRP ATTR004 pattern for the 'time' coordinate's units attribute.
+    WCRP_PATTERN = (
+        r"^days since [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}"
+        r"( [0-9]{2}:[0-9]{2}:[0-9]{2})?$"
+    )
+
+    def test_pads_partial_time_to_seconds(self):
+        # The UM atmosphere/land bug: "00:00" lacks the seconds field.
+        assert (
+            normalize_cf_time_units("days since 0001-01-01 00:00")
+            == "days since 0001-01-01 00:00:00"
+        )
+
+    def test_pads_date_only_to_full_midnight(self):
+        assert (
+            normalize_cf_time_units("days since 1850-01-01")
+            == "days since 1850-01-01 00:00:00"
+        )
+
+    def test_leaves_full_form_unchanged(self):
+        units = "days since 0001-01-01 00:00:00"
+        assert normalize_cf_time_units(units) == units
+
+    def test_preserves_nonzero_time_of_day(self):
+        assert (
+            normalize_cf_time_units("days since 1850-01-01 12:30")
+            == "days since 1850-01-01 12:30:00"
+        )
+
+    def test_normalizes_iso_t_separator(self):
+        assert (
+            normalize_cf_time_units("days since 0001-01-01T00:00:00")
+            == "days since 0001-01-01 00:00:00"
+        )
+
+    def test_zero_pads_unpadded_date(self):
+        assert (
+            normalize_cf_time_units("seconds since 1970-1-1")
+            == "seconds since 1970-01-01 00:00:00"
+        )
+
+    @pytest.mark.parametrize(
+        "units", ["K", "m s-1", "degrees_north", "1", "kg m-2 s-1"]
+    )
+    def test_non_time_units_untouched(self, units):
+        assert normalize_cf_time_units(units) == units
+
+    def test_units_with_timezone_offset_untouched(self):
+        # A trailing timezone offset is not a clean CF datetime; leave it alone
+        # rather than risk silently shifting the reference instant.
+        units = "days since 1850-01-01 00:00:00 0:00"
+        assert normalize_cf_time_units(units) == units
+
+    @pytest.mark.parametrize("value", [None, 1.0, 42])
+    def test_non_string_passthrough(self, value):
+        assert normalize_cf_time_units(value) == value
+
+    def test_output_matches_wcrp_pattern(self):
+        import re
+
+        for raw in (
+            "days since 0001-01-01 00:00",
+            "days since 1850-01-01",
+            "days since 0001-01-01 00:00:00",
+        ):
+            assert re.match(self.WCRP_PATTERN, normalize_cf_time_units(raw))

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -1414,8 +1414,7 @@ class TestNormalizeCfTimeUnits:
 
     # WCRP ATTR004 pattern for the 'time' coordinate's units attribute.
     WCRP_PATTERN = (
-        r"^days since [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}"
-        r"( [0-9]{2}:[0-9]{2}:[0-9]{2})?$"
+        r"^days since [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}" r"( [0-9]{2}:[0-9]{2}:[0-9]{2})?$"
     )
 
     def test_pads_partial_time_to_seconds(self):


### PR DESCRIPTION
# Fix: normalize CF time units to canonical `HH:MM:SS` for WCRP ATTR004

## Problem

55 of 86 CMORised files fail the WCRP compliance check
`[ATTR004] Coordinate Variable 'time' attribute 'units' pattern check`
(HIGH, weight = 3). The stored value is written as
`days since 0001-01-01 00:00` — a partial time-of-day with no seconds field —
which does not match the required pattern:

```text
^days since [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}( [0-9]{2}:[0-9]{2}:[0-9]{2})?$
```

The failure is confined to the UM atmosphere / CABLE land tables (`Amon`,
`Lmon`, `LImon`). Ocean (`Omon`), sea-ice (`SImon`/`SIday`) and fixed-field
(`fx`) files are unaffected.

## Root cause

The malformed units come straight from the **source model files** and are
passed through verbatim:

1. All realms open inputs with `decode_cf=False`
   (`base.py` `load_dataset`), so `time.units` is kept as the raw source string.
2. UM atmosphere / CABLE land output writes the reference datetime without
   seconds (e.g. `days since 0001-01-01 00:00`); MOM5 / CICE write the full
   `00:00:00` form — hence ocean/sea-ice pass.
3. The atmosphere path copies the source units verbatim when substituting the
   CMOR `"days since ?"` placeholder (`atmosphere.py:377-380`); the ocean path
   never touches `time.units`. **Neither path normalizes the format.**
4. `write()` writes the attribute back verbatim via `setncattr`, so the
   malformed string lands in the output.

Verified directly on the raw input `aiihca.pa-*_mon.nc`
(`time.units = 'days since 0001-01-01 00:00'`) and on a produced `pr_Amon`
output (identical string → ATTR004 fail), versus `sos_Omon`
(`days since 1900-01-01 00:00:00` → pass).

## Solution

Add a single, realm-agnostic normalization at the **sole write chokepoint**.
`write()` is inherited unchanged by every realm via `run()` and is the only
NetCDF write path (no `.to_netcdf()`, no other write-mode `nc.Dataset` open), so
one place normalizes all variables uniformly.

The fix is **meaning-preserving**: an absent or partial time-of-day is midnight
either way, so padding to `HH:MM:SS` leaves the reference instant — and every
numeric time value — unchanged.

### `src/access_moppy/utilities.py`

New pure helper alongside the other time helpers:

```python
_CF_TIME_UNITS_RE = re.compile(
    r"^(?P<interval>\w+)\s+since\s+"
    r"(?P<year>\d{1,4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})"
    r"(?:[ T](?P<hour>\d{1,2}):(?P<minute>\d{1,2})(?::(?P<second>\d{1,2}(?:\.\d+)?))?)?"
    r"\s*$",
    re.IGNORECASE,
)


def normalize_cf_time_units(units):
    """Return *units* with its reference datetime padded to canonical CF form."""
    if not isinstance(units, str):
        return units
    match = _CF_TIME_UNITS_RE.match(units.strip())
    if match is None:
        return units
    g = match.groupdict()
    return (
        f"{g['interval']} since "
        f"{int(g['year']):04d}-{int(g['month']):02d}-{int(g['day']):02d} "
        f"{int(g['hour'] or 0):02d}:{int(g['minute'] or 0):02d}:"
        f"{int(float(g['second'] or 0)):02d}"
    )
```

### `src/access_moppy/base.py`

Normalize every variable's `units` at the top of `write()`:

```python
for var in self.ds.variables:
    units = self.ds[var].attrs.get("units")
    normalized = normalize_cf_time_units(units)
    if normalized != units:
        self.ds[var].attrs["units"] = normalized
        logger.debug("Normalized '%s' units: %r -> %r", var, units, normalized)
```

## Behaviour matrix

| Input `time.units`                       | Output                           | Note                       |
| ---------------------------------------- | -------------------------------- | -------------------------- |
| `days since 0001-01-01 00:00`            | `days since 0001-01-01 00:00:00` | the bug — padded           |
| `days since 1850-01-01`                  | `days since 1850-01-01 00:00:00` | date-only — padded         |
| `days since 0001-01-01 00:00:00`         | unchanged                        | already valid              |
| `days since 1850-01-01 12:30`            | `days since 1850-01-01 12:30:00` | non-zero time preserved    |
| `K`, `m s-1`, `degrees_north`            | unchanged                        | non-time units untouched   |
| `days since 1850-01-01 00:00:00 0:00`    | unchanged                        | timezone form left alone   |
| Ocean / sea-ice (full form)              | unchanged                        | no-op                      |

## Risk

- Meaning-preserving: only reformats the string; numeric values never change.
- Strings carrying a timezone offset or any non-clean datetime do not match the
  pattern and are returned untouched — no silent instant shifts.
- No existing test depends on the malformed/partial form (all assertions use the
  full `00:00:00` form).
- `atmosphere.py:377-380` is left as-is (still transfers the reference
  date/calendar correctly); `write()` only canonicalizes the format afterwards.

## Tests (+17, all pass)

- `TestNormalizeCfTimeUnits` (16) in `tests/unit/test_utilities.py`: seconds
  padding, date-only padding, idempotence on the full form, non-zero time-of-day,
  ISO `T` separator, unpadded date, non-time units, timezone form, non-string
  passthrough, and WCRP-pattern conformance of outputs.
- `test_write_normalizes_partial_time_units` in `tests/unit/test_base.py`:
  drives the real `write()` path and asserts the output `time.units` is padded to
  `00:00:00`, a non-time `units` (`K`) is untouched, and numeric time values are
  unchanged.

## Files touched

- `src/access_moppy/utilities.py`
- `src/access_moppy/base.py`
- `tests/unit/test_utilities.py`
- `tests/unit/test_base.py`

## Branch

`fix_time_coords_units_issue`