### PR TITLE
add time coords attrs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: recursive
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.39.5
+          pixi-version: v0.49.0
       - name: Run pre-commit
         run: pixi run -e dev pre-commit run --all-files
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.39.5
+          pixi-version: v0.49.0
           environments: test
 
       - name: Create default config file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.49.0
+          pixi-version: latest
       - name: Run pre-commit
         run: pixi run -e dev pre-commit run --all-files
 
@@ -41,9 +41,9 @@ jobs:
           submodules: recursive
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.49.0
+          pixi-version: latest
           environments: test
 
       - name: Create default config file

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -27,9 +27,9 @@ jobs:
           submodules: recursive
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@b92f01076d41831104bdb4786cfe1f0a5462a1ce # v0.9.0
+        uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.49.0
+          pixi-version: latest
 
       - name: Create default config file
         run: |

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@b92f01076d41831104bdb4786cfe1f0a5462a1ce # v0.9.0
         with:
-          pixi-version: v0.39.5
+          pixi-version: v0.49.0
 
       - name: Create default config file
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ quote-style = "double"  # Use double quotes
 "test_mop.py" = ["I001"]
 
 [tool.pixi.workspace]
+requires-pixi = ">=0.49"
 channels = ["conda-forge", { channel = "accessnri", exclude-newer = "0d" }]
 exclude-newer = "7d"
 platforms = ["linux-64"]

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -16,6 +16,7 @@ from access_moppy.utilities import (
     FrequencyMismatchError,
     IncompatibleFrequencyError,
     ResamplingRequiredWarning,
+    normalize_cf_time_units,
     type_mapping,
     validate_and_resample_if_needed,
     validate_cmip6_frequency_compatibility,
@@ -831,6 +832,21 @@ class CMORiser:
 
         Automatically handles character/string coordinates with proper NetCDF encoding.
         """
+        # ========== Normalize CF Time-Coordinate Units ==========
+        # Source models differ in how they write the reference datetime: the UM
+        # atmosphere and CABLE land models omit the seconds field (e.g.
+        # "days since 0001-01-01 00:00"), which fails the WCRP units pattern
+        # check, whereas the ocean/sea-ice models write the full HH:MM:SS form.
+        # Re-emit any CF time units in canonical form here — the sole write path
+        # for every realm — so all variables are normalized uniformly.  This is
+        # meaning-preserving, so the numeric time values are unaffected.
+        for var in self.ds.variables:
+            units = self.ds[var].attrs.get("units")
+            normalized = normalize_cf_time_units(units)
+            if normalized != units:
+                self.ds[var].attrs["units"] = normalized
+                logger.debug("Normalized '%s' units: %r -> %r", var, units, normalized)
+
         # ========== Prepare String Coordinates ==========
         # Detect and prepare all string/character coordinates before writing
         string_coords_info = self._prepare_string_coordinates()

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -638,6 +638,36 @@ class CMORiser:
                 if d.day > 30:
                     raise ValueError(f"360_day calendar has day > 30: {d}")
 
+    def _apply_time_coordinate_attributes(self):
+        """Apply CF time-coordinate attributes from the active CMOR table.
+
+        Ocean and sea-ice CMORisers build their coordinate set manually rather
+        than via the atmosphere's axis loop, so the time coordinate would
+        otherwise keep only whatever the model file provided (ocean files carry
+        ``axis`` but no ``standard_name``; sea-ice files carry neither). Time
+        values, units and calendar are left untouched here — they are managed by
+        time decoding and ``_check_calendar``.
+        """
+        if "time" not in self.ds:
+            return
+        time_meta = next(
+            (
+                m
+                for m in self.vocab.axes.values()
+                if m.get("out_name") == "time" and m.get("standard_name") == "time"
+            ),
+            None,
+        )
+        if time_meta is None:
+            return
+        self.ds["time"].attrs.update(
+            {
+                k: time_meta[k]
+                for k in ("standard_name", "long_name", "axis")
+                if time_meta.get(k) not in (None, "")
+            }
+        )
+
     def _check_range(self, var: str, vmin: float, vmax: float):
         arr = self.ds[var]
         if hasattr(arr.data, "map_blocks"):

--- a/src/access_moppy/ocean.py
+++ b/src/access_moppy/ocean.py
@@ -298,6 +298,10 @@ class Ocean_CMORiser(CMORiser):
             self.type_mapping.get(var_type, np.float64)
         )
 
+        # Apply CF time-coordinate attributes (standard_name, axis, long_name)
+        # from the CMOR table; the manual coordinate build above does not.
+        self._apply_time_coordinate_attributes()
+
         # Check calendar and units
         if "time" in self.ds.dims:
             self._check_calendar("time")

--- a/src/access_moppy/sea_ice.py
+++ b/src/access_moppy/sea_ice.py
@@ -293,6 +293,10 @@ class SeaIce_CMORiser(Ocean_CMORiser):
             self.type_mapping.get(var_type, np.float64)
         )
 
+        # Apply CF time-coordinate attributes (standard_name, axis, long_name)
+        # from the CMOR table; the manual coordinate build above does not.
+        self._apply_time_coordinate_attributes()
+
         # Check calendar and units
         if "time" in self.ds.dims:
             self._check_calendar("time")

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -1,6 +1,7 @@
 import importlib.metadata as importlib_metadata
 import json
 import logging
+import re
 import warnings
 from datetime import timedelta
 from importlib.resources import files
@@ -2052,6 +2053,47 @@ def validate_and_resample_if_needed(
     )
 
     return ds_resampled, True
+
+
+# CF time-coordinate units take the form "<interval> since <reference datetime>".
+# The WCRP ATTR004 check requires the reference datetime to be either a bare date
+# or a full "YYYY-MM-DD HH:MM:SS"; partial forms such as
+# "days since 0001-01-01 00:00" (no seconds — written by the UM atmosphere and
+# CABLE land models) fail the check.  This pattern captures the components so the
+# reference instant can be re-emitted in canonical form.
+_CF_TIME_UNITS_RE = re.compile(
+    r"^(?P<interval>\w+)\s+since\s+"
+    r"(?P<year>\d{1,4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})"
+    r"(?:[ T](?P<hour>\d{1,2}):(?P<minute>\d{1,2})(?::(?P<second>\d{1,2}(?:\.\d+)?))?)?"
+    r"\s*$",
+    re.IGNORECASE,
+)
+
+
+def normalize_cf_time_units(units: Optional[str]) -> Optional[str]:
+    """Return *units* with its reference datetime padded to canonical CF form.
+
+    Converts partial or date-only reference datetimes to a full
+    ``"<interval> since YYYY-MM-DD HH:MM:SS"`` string, e.g.
+    ``"days since 0001-01-01 00:00"`` -> ``"days since 0001-01-01 00:00:00"``.
+
+    The reference *instant* is preserved (an absent or partial time-of-day is
+    midnight either way), so any numeric time values measured against these units
+    remain correct.  Strings that are not recognisable CF time units — including
+    those carrying a timezone offset — are returned unchanged.
+    """
+    if not isinstance(units, str):
+        return units
+    match = _CF_TIME_UNITS_RE.match(units.strip())
+    if match is None:
+        return units
+    g = match.groupdict()
+    return (
+        f"{g['interval']} since "
+        f"{int(g['year']):04d}-{int(g['month']):02d}-{int(g['day']):02d} "
+        f"{int(g['hour'] or 0):02d}:{int(g['minute'] or 0):02d}:"
+        f"{int(float(g['second'] or 0)):02d}"
+    )
 
 
 def calculate_time_bounds(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -760,6 +760,72 @@ class TestCMIP6CMORiserWrite:
                 ds_out.close()
 
     @pytest.mark.unit
+    def test_write_normalizes_partial_time_units(
+        self, mock_vocab, mock_mapping, temp_dir
+    ):
+        """write() pads a partial CF time-units string to the full canonical form.
+
+        Regression test for the WCRP ATTR004 failure: UM atmosphere/land source
+        files write "days since YYYY-MM-DD 00:00" (no seconds), which must be
+        re-emitted as "...00:00:00".  Non-time units must be left untouched, and
+        the numeric time values must not change (meaning-preserving).
+        """
+        original_time = np.arange(3).astype(float)
+        ds = xr.Dataset(
+            {
+                "tas": (
+                    ["time", "lat", "lon"],
+                    np.random.rand(3, 4, 5).astype(np.float32),
+                    {"_FillValue": 1e20, "units": "K"},
+                ),
+            },
+            coords={
+                "time": (
+                    "time",
+                    original_time,
+                    {"units": "days since 2000-01-01 00:00", "calendar": "standard"},
+                ),
+                "lat": ("lat", np.arange(4)),
+                "lon": ("lon", np.arange(5)),
+            },
+            attrs={
+                "variable_id": "tas",
+                "table_id": "Amon",
+                "source_id": "ACCESS-ESM1-5",
+                "experiment_id": "historical",
+                "variant_label": "r1i1p1f1",
+                "grid_label": "gn",
+            },
+        )
+        cmoriser = CMORiser(
+            input_paths=["test.nc"],
+            output_path=str(temp_dir),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="Amon.tas",
+        )
+        cmoriser.ds = ds
+        cmoriser.cmor_name = "tas"
+
+        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
+            mock_mem.return_value = MagicMock(
+                total=32 * 1024**3, available=16 * 1024**3
+            )
+            cmoriser.write()
+
+        output_files = list(Path(temp_dir).glob("*.nc"))
+        ds_out = xr.open_dataset(output_files[0], decode_cf=False)
+        try:
+            # time units padded to full HH:MM:SS (the normalized branch)
+            assert ds_out["time"].attrs["units"] == "days since 2000-01-01 00:00:00"
+            # non-time units left untouched (the unchanged branch)
+            assert ds_out["tas"].attrs["units"] == "K"
+            # numeric time values preserved
+            np.testing.assert_array_equal(ds_out["time"].values, original_time)
+        finally:
+            ds_out.close()
+
+    @pytest.mark.unit
     def test_write_bounds_attribute_handling(self, cmoriser_with_dataset, temp_dir):
         """
         Regression test for CF §7.1 bounds attribute handling in write().

--- a/tests/unit/test_ocean.py
+++ b/tests/unit/test_ocean.py
@@ -868,6 +868,36 @@ class TestUpdateAttributes:
         assert cmoriser.ds["time"].attrs["standard_name"] == "time"
         assert cmoriser.ds["time"].attrs["axis"] == "T"
 
+    @pytest.mark.unit
+    def test_apply_time_coord_attrs_noop_without_time(
+        self, mock_vocab, spatial_mapping, temp_dir
+    ):
+        """No-op when the dataset has no time coordinate (e.g. fx variables)."""
+        ds = xr.Dataset(
+            {"tos": (["j", "i"], np.ones((4, 5), dtype=np.float32))},
+            coords={"i": ("i", np.arange(5)), "j": ("j", np.arange(4))},
+        )
+        cmoriser = _make_cmoriser(mock_vocab, spatial_mapping, "Ofx.tos", temp_dir, ds)
+
+        cmoriser._apply_time_coordinate_attributes()
+
+        assert "time" not in cmoriser.ds
+
+    @pytest.mark.unit
+    def test_apply_time_coord_attrs_noop_without_time_axis_in_vocab(
+        self, mock_vocab, spatial_mapping, temp_dir
+    ):
+        """No-op when vocab.axes declares no time axis; existing attrs untouched."""
+        cmoriser = _make_cmoriser(
+            mock_vocab, spatial_mapping, "Omon.tos", temp_dir, _spatial_ds()
+        )
+        cmoriser.vocab.axes = {"lat": {"out_name": "lat"}}  # no time entry
+
+        cmoriser._apply_time_coordinate_attributes()
+
+        assert "standard_name" not in cmoriser.ds["time"].attrs
+        assert "axis" not in cmoriser.ds["time"].attrs
+
 
 # ---------------------------------------------------------------------------
 # TestAlignMainVarDimsWithVocab

--- a/tests/unit/test_ocean.py
+++ b/tests/unit/test_ocean.py
@@ -761,6 +761,14 @@ class TestUpdateAttributes:
         vocab.get_required_global_attributes = Mock(return_value={})
         vocab._get_axes = Mock(return_value=({}, {}))
         vocab._get_required_bounds_variables = Mock(return_value=({}, {}))
+        vocab.axes = {
+            "time": {
+                "out_name": "time",
+                "standard_name": "time",
+                "long_name": "time",
+                "axis": "T",
+            }
+        }
         return vocab
 
     @pytest.fixture
@@ -845,6 +853,20 @@ class TestUpdateAttributes:
 
         for var in ("latitude", "longitude", "vertices_latitude", "vertices_longitude"):
             assert var in cmoriser.ds, f"'{var}' missing for spatial variable"
+
+    @pytest.mark.unit
+    def test_time_coordinate_gets_cf_attributes(
+        self, mock_vocab, spatial_mapping, temp_dir
+    ):
+        """time must carry standard_name and axis from the CMOR table (wcrp_cmip6)."""
+        cmoriser = _make_cmoriser(
+            mock_vocab, spatial_mapping, "Omon.tos", temp_dir, _spatial_ds()
+        )
+        with patch.object(cmoriser, "_check_calendar"):
+            cmoriser.update_attributes()
+
+        assert cmoriser.ds["time"].attrs["standard_name"] == "time"
+        assert cmoriser.ds["time"].attrs["axis"] == "T"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sea_ice.py
+++ b/tests/unit/test_sea_ice.py
@@ -198,3 +198,67 @@ class TestSeaIceCMORiser:
             msg = str(exc_info.value)
             assert "SeaIce_CMORiser" in msg
             assert "ACCESS-" in msg
+
+    @pytest.mark.unit
+    def test_update_attributes_sets_time_cf_attributes(self, temp_dir):
+        """Sea-ice time must gain both standard_name and axis from the CMOR table."""
+        ny, nx, nt = 2, 4, 3
+        vocab = Mock()
+        vocab.source_id = "ACCESS-ESM1.6"
+        vocab.variable = {"units": "1", "type": "real"}
+        vocab._get_nominal_resolution = Mock(return_value="1deg")
+        vocab.get_required_global_attributes = Mock(return_value={})
+        vocab.axes = {
+            "time": {
+                "out_name": "time",
+                "standard_name": "time",
+                "long_name": "time",
+                "axis": "T",
+            }
+        }
+        mapping = {
+            "siconc": {
+                "model_variables": ["ice_conc"],
+                "calculation": {"type": "direct"},
+            }
+        }
+        ds = xr.Dataset(
+            {"siconc": (["time", "j", "i"], np.ones((nt, ny, nx), dtype=np.float32))},
+            coords={
+                "time": ("time", pd.date_range("2000-01-01", periods=nt, freq="ME")),
+                "i": ("i", np.arange(nx)),
+                "j": ("j", np.arange(ny)),
+            },
+        )
+        grid_info = {
+            "i": np.arange(nx),
+            "j": np.arange(ny),
+            "vertices": np.arange(4),
+            "latitude": xr.DataArray(np.ones((ny, nx)), dims=("j", "i")),
+            "longitude": xr.DataArray(np.ones((ny, nx)), dims=("j", "i")),
+            "vertices_latitude": xr.DataArray(
+                np.ones((ny, nx, 4)), dims=("j", "i", "vertices")
+            ),
+            "vertices_longitude": xr.DataArray(
+                np.ones((ny, nx, 4)), dims=("j", "i", "vertices")
+            ),
+        }
+        with patch("access_moppy.sea_ice.Supergrid"):
+            cmoriser = SeaIce_CMORiser(
+                input_paths=["test.nc"],
+                output_path=str(temp_dir),
+                compound_name="SImon.siconc",
+                vocab=vocab,
+                variable_mapping=mapping,
+            )
+        cmoriser.ds = ds
+        cmoriser.grid_type = "T"
+        cmoriser.symmetric = None
+        cmoriser.supergrid = Mock()
+        cmoriser.supergrid.extract_grid.return_value = grid_info
+
+        with patch.object(cmoriser, "_check_calendar"):
+            cmoriser.update_attributes()
+
+        assert cmoriser.ds["time"].attrs["standard_name"] == "time"
+        assert cmoriser.ds["time"].attrs["axis"] == "T"

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -25,6 +25,7 @@ from access_moppy.utilities import (
     create_ilamb_observational_symlinks,
     detect_time_frequency_lazy,
     get_requested_variables_from_data_request,
+    normalize_cf_time_units,
 )
 
 
@@ -1406,3 +1407,73 @@ class TestDetectFrequencyFromBoundsCrossValidation:
             result = _detect_frequency_from_bounds(ds, "time")
         assert result is None
         assert any("unexpected shape" in str(warning.message) for warning in w)
+
+
+class TestNormalizeCfTimeUnits:
+    """Tests for normalize_cf_time_units (WCRP time-units pattern compliance)."""
+
+    # WCRP ATTR004 pattern for the 'time' coordinate's units attribute.
+    WCRP_PATTERN = (
+        r"^days since [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}" r"( [0-9]{2}:[0-9]{2}:[0-9]{2})?$"
+    )
+
+    def test_pads_partial_time_to_seconds(self):
+        # The UM atmosphere/land bug: "00:00" lacks the seconds field.
+        assert (
+            normalize_cf_time_units("days since 0001-01-01 00:00")
+            == "days since 0001-01-01 00:00:00"
+        )
+
+    def test_pads_date_only_to_full_midnight(self):
+        assert (
+            normalize_cf_time_units("days since 1850-01-01")
+            == "days since 1850-01-01 00:00:00"
+        )
+
+    def test_leaves_full_form_unchanged(self):
+        units = "days since 0001-01-01 00:00:00"
+        assert normalize_cf_time_units(units) == units
+
+    def test_preserves_nonzero_time_of_day(self):
+        assert (
+            normalize_cf_time_units("days since 1850-01-01 12:30")
+            == "days since 1850-01-01 12:30:00"
+        )
+
+    def test_normalizes_iso_t_separator(self):
+        assert (
+            normalize_cf_time_units("days since 0001-01-01T00:00:00")
+            == "days since 0001-01-01 00:00:00"
+        )
+
+    def test_zero_pads_unpadded_date(self):
+        assert (
+            normalize_cf_time_units("seconds since 1970-1-1")
+            == "seconds since 1970-01-01 00:00:00"
+        )
+
+    @pytest.mark.parametrize(
+        "units", ["K", "m s-1", "degrees_north", "1", "kg m-2 s-1"]
+    )
+    def test_non_time_units_untouched(self, units):
+        assert normalize_cf_time_units(units) == units
+
+    def test_units_with_timezone_offset_untouched(self):
+        # A trailing timezone offset is not a clean CF datetime; leave it alone
+        # rather than risk silently shifting the reference instant.
+        units = "days since 1850-01-01 00:00:00 0:00"
+        assert normalize_cf_time_units(units) == units
+
+    @pytest.mark.parametrize("value", [None, 1.0, 42])
+    def test_non_string_passthrough(self, value):
+        assert normalize_cf_time_units(value) == value
+
+    def test_output_matches_wcrp_pattern(self):
+        import re
+
+        for raw in (
+            "days since 0001-01-01 00:00",
+            "days since 1850-01-01",
+            "days since 0001-01-01 00:00:00",
+        ):
+            assert re.match(self.WCRP_PATTERN, normalize_cf_time_units(raw))


### PR DESCRIPTION
# Add `time` coordinate CF attributes for ocean and sea-ice variables

## Problem

`compliance-checker --test wcrp_cmip6:1.0` reports missing `time` coordinate
attributes, confined to `Omon` and `SImon`/`SIday` variables:

- **Ocean (`Omon`)** — missing `time:standard_name` (16 files)
- **Sea-ice (`SImon`/`SIday`)** — missing both `time:standard_name` and `time:axis` (8 files)

All atmosphere/land variables already pass.

## Root cause

`Atmosphere_CMORiser.update_attributes()` loops over `self.vocab.axes` and stamps
`standard_name`/`axis`/`long_name` onto every coordinate, including `time`.
`Ocean_CMORiser` and `SeaIce_CMORiser` override `update_attributes()` with
hand-built coordinate logic that never applies the time-axis metadata — they only
call `_check_calendar("time")`.

So `time` kept only what the model file provided:

- MOM (ocean) files carry `axis = "T"` but no `standard_name`
- CICE (sea-ice) files carry neither

## Fix

Add one shared helper `CMORiser._apply_time_coordinate_attributes()` that pulls
`standard_name`, `long_name`, and `axis` from the active CMOR table (`self.vocab.axes`)
and applies them to `time`. Call it from both `Ocean_CMORiser.update_attributes()`
and `SeaIce_CMORiser.update_attributes()`.

The helper is intentionally narrow:

- No-op when there is no `time` coordinate (e.g. `fx`/`Ofx`).
- Only fires when the CMOR table actually declares a time axis
  (`out_name == "time"` and `standard_name == "time"`), so stray scalar time
  coords are never touched.
- Leaves time **values, units, and calendar** alone — those remain owned by time
  decoding and `_check_calendar`.

## Closed
Close #392  