### PR TITLE
delete redundant height_0 in variables coordinates attrs

### DIFF
--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -1046,34 +1046,33 @@ class CMORiser:
                             continue
                         v.setncattr(a, val)
 
-                        # ========== Add coordinates attribute for main data variable ==========
-                        # For CF compliance, auxiliary coordinates (scalar and non-dimension coords)
-                        # must be declared in the main data variable's 'coordinates' attribute
-                        if var == self.cmor_name and aux_coords:
-                            # Get existing coordinates attribute if present
-                            existing_coords = vdat.attrs.get("coordinates", "")
-
-                            # Add string coordinates that aren't already in the attribute
-                            coords_to_add = [
-                                c for c in aux_coords if c != existing_coords
+                        # ========== Set coordinates attribute for main data variable ==========
+                        # CF compliance: auxiliary coordinates (scalar and non-dimension
+                        # coords) must be declared in the main data variable's
+                        # 'coordinates' attribute. Tokens inherited from the raw input
+                        # that no longer refer to a variable in the dataset (e.g. a stale
+                        # 'height_0' carried over from UM output) are dropped to avoid
+                        # emitting dangling coordinate references.
+                        if var == self.cmor_name:
+                            existing_tokens = vdat.attrs.get("coordinates", "").split()
+                            valid_existing = [
+                                t for t in existing_tokens if t in self.ds.variables
                             ]
-
-                            if coords_to_add:
-                                if existing_coords:
-                                    # Append to existing coordinates
-                                    new_coords = (
-                                        existing_coords + " " + " ".join(coords_to_add)
-                                    )
-                                else:
-                                    # Create new coordinates attribute
-                                    new_coords = " ".join(coords_to_add)
-
+                            merged = list(
+                                dict.fromkeys(valid_existing + list(aux_coords))
+                            )
+                            if merged:
+                                new_coords = " ".join(merged)
                                 v.setncattr("coordinates", new_coords)
                                 logger.debug(
-                                    "  Added coordinates attribute to '%s': '%s'",
+                                    "  Set coordinates attribute on '%s': '%s'",
                                     var,
                                     new_coords,
                                 )
+                            elif "coordinates" in v.ncattrs():
+                                # All inherited tokens were stale and no aux coords —
+                                # drop the attribute rather than leave a dangling ref.
+                                v.delncattr("coordinates")
 
                     created_vars[var] = v
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -870,9 +870,7 @@ class TestCMIP6CMORiserWrite:
             assert "coordinates" not in bnds_attrs
 
     @pytest.mark.unit
-    def test_write_drops_stale_coordinates_token(
-        self, cmoriser_with_dataset, temp_dir
-    ):
+    def test_write_drops_stale_coordinates_token(self, cmoriser_with_dataset, temp_dir):
         """
         Regression test: the main data variable's 'coordinates' attribute must
         not propagate tokens inherited from the raw input that no longer refer

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -869,6 +869,91 @@ class TestCMIP6CMORiserWrite:
             assert "bounds" not in bnds_attrs
             assert "coordinates" not in bnds_attrs
 
+    @pytest.mark.unit
+    def test_write_drops_stale_coordinates_token(
+        self, cmoriser_with_dataset, temp_dir
+    ):
+        """
+        Regression test: the main data variable's 'coordinates' attribute must
+        not propagate tokens inherited from the raw input that no longer refer
+        to a variable in the dataset.
+
+        Mirrors the real ACCESS-MOPPy bug where UM input carried
+        coordinates='height_0' on tas/hurs/huss while only a real 'height'
+        scalar coordinate was written.
+        """
+        cmoriser_with_dataset.ds = cmoriser_with_dataset.ds.assign_coords(
+            height=xr.DataArray(2.0, attrs={"units": "m", "axis": "Z"})
+        )
+        cmoriser_with_dataset.ds["tas"].attrs["coordinates"] = "height_0"
+
+        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
+            mock_mem.return_value = MagicMock(
+                total=32 * 1024**3,
+                available=16 * 1024**3,
+            )
+            cmoriser_with_dataset.write()
+
+        output_files = list(Path(temp_dir).glob("*.nc"))
+        assert len(output_files) == 1
+
+        with nc.Dataset(output_files[0], "r") as ds_nc:
+            coords_attr = ds_nc.variables["tas"].getncattr("coordinates")
+            assert "height_0" not in coords_attr.split()
+            assert "height" in coords_attr.split()
+
+    @pytest.mark.unit
+    def test_write_removes_coordinates_when_only_stale_tokens(
+        self, cmoriser_with_dataset, temp_dir
+    ):
+        """
+        If every token inherited from the input refers to a non-existent
+        variable and there are no auxiliary coordinates to add, the
+        'coordinates' attribute must be removed rather than left dangling.
+        """
+        cmoriser_with_dataset.ds["tas"].attrs["coordinates"] = "phantom_coord"
+
+        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
+            mock_mem.return_value = MagicMock(
+                total=32 * 1024**3,
+                available=16 * 1024**3,
+            )
+            cmoriser_with_dataset.write()
+
+        output_files = list(Path(temp_dir).glob("*.nc"))
+        assert len(output_files) == 1
+
+        with nc.Dataset(output_files[0], "r") as ds_nc:
+            assert "coordinates" not in ds_nc.variables["tas"].ncattrs()
+
+    @pytest.mark.unit
+    def test_write_merges_valid_existing_with_aux_coords(
+        self, cmoriser_with_dataset, temp_dir
+    ):
+        """
+        Valid tokens already present in the input's 'coordinates' attribute
+        must be preserved and merged with the auxiliary coordinates collected
+        from the dataset, with order preserved and duplicates removed.
+        """
+        cmoriser_with_dataset.ds = cmoriser_with_dataset.ds.assign_coords(
+            height=xr.DataArray(2.0, attrs={"units": "m", "axis": "Z"})
+        )
+        cmoriser_with_dataset.ds["tas"].attrs["coordinates"] = "lat"
+
+        with patch("access_moppy.base.psutil.virtual_memory") as mock_mem:
+            mock_mem.return_value = MagicMock(
+                total=32 * 1024**3,
+                available=16 * 1024**3,
+            )
+            cmoriser_with_dataset.write()
+
+        output_files = list(Path(temp_dir).glob("*.nc"))
+        assert len(output_files) == 1
+
+        with nc.Dataset(output_files[0], "r") as ds_nc:
+            coords_tokens = ds_nc.variables["tas"].getncattr("coordinates").split()
+            assert coords_tokens == ["lat", "height"]
+
     # ==================== Chunked Write Tests ====================
 
     @pytest.mark.unit


### PR DESCRIPTION
## Issue to be fixed 

The CMORised output for `tas`, `hurs`, `huss` (Amon) has

```text
tas:coordinates = "height_0 height" ;
```

but only `height` is actually written to the file. `height_0` is a dangling
reference, flagged by WCRP compliance-checker:

```text
[ATTR004] Variable 'tas' attribute 'coordinates' as-variable check
  Referenced variables not found: ['height_0']
```

## Fix

Replace the merge with a token-aware, dataset-validated one in
`src/access_moppy/base.py`:

```python
if var == self.cmor_name:
    existing_tokens = vdat.attrs.get("coordinates", "").split()
    valid_existing = [t for t in existing_tokens if t in self.ds.variables]
    merged = list(dict.fromkeys(valid_existing + list(aux_coords)))
    if merged:
        v.setncattr("coordinates", " ".join(merged))
    elif "coordinates" in v.ncattrs():
        v.delncattr("coordinates")
```

- Drops tokens not present in `self.ds.variables` (kills the dangling
  `height_0`).
- Deduplicates with `dict.fromkeys` (preserves order).
- Removes the attribute entirely when nothing valid remains, instead of
  leaving a dangling reference inherited from line 1047's attribute copy.


## Scope of the Change

Single block in `src/access_moppy/base.py`. Behaviour identical to the
previous code in every scenario where the previous output was already correct;
strictly improves the cases that previously produced dangling or duplicate
tokens. No existing tests assert on the output `coordinates` attribute, so no
test changes are required (a regression test is recommended but not blocking).