### PR TITLE
Fix CMIP6 experiment global attribute to match the WCRP/esgvoc CV label

### DIFF
--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -883,6 +883,47 @@ class CMIP6Vocabulary:
 
         return rendered_filename
 
+    # Canonical CMIP6-CV ``experiment`` labels resolved via esgvoc, keyed by
+    # experiment_id. esgvoc lookups touch a database, so resolve each
+    # experiment at most once per process.
+    _EXPERIMENT_LABEL_CACHE: Dict[str, Optional[str]] = {}
+
+    def _resolve_experiment_label(self) -> str:
+        """Return the canonical ``experiment`` global-attribute value.
+
+        The WCRP compliance checker (cc-plugin-wcrp + esgvoc) compares the
+        global ``experiment`` attribute against esgvoc's CMIP6 controlled
+        vocabulary, whose label (e.g. ``"Historical simulation"``) differs from
+        the descriptive phrase carried in the legacy CMIP6_CVs JSON bundled with
+        this package (e.g. ``"all-forcing simulation of the recent past"``).
+
+        Resolve the label from esgvoc so the written attribute matches what the
+        checker validates. Fall back to the bundled CV value when esgvoc is
+        unavailable or carries no label for this experiment -- in the latter
+        case the checker skips the comparison, so the legacy value is accepted.
+        """
+        legacy_label = self.experiment.get("experiment", "")
+
+        eid = self.experiment_id
+        if eid not in CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE:
+            label: Optional[str] = None
+            try:
+                import esgvoc.api as voc
+
+                term = voc.get_term_in_collection(
+                    project_id="cmip6",
+                    collection_id="experiment_id",
+                    term_id=eid,
+                )
+                if term is not None:
+                    label = getattr(term, "experiment", None)
+            except Exception:
+                label = None
+            CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE[eid] = label
+
+        resolved = CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE[eid]
+        return resolved if resolved else legacy_label
+
     def get_required_global_attributes(self) -> Dict[str, Any]:
         now = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         variant = self.get_variant_components()
@@ -892,7 +933,7 @@ class CMIP6Vocabulary:
             "activity_id": self._resolve_activity_id(),
             "creation_date": now,
             "data_specs_version": self.cmip_table["Header"].get("data_specs_version"),
-            "experiment": self.experiment["experiment"],
+            "experiment": self._resolve_experiment_label(),
             "experiment_id": self.experiment_id,
             "forcing_index": variant["forcing_index"],
             "frequency": self.variable["frequency"],

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -890,3 +890,88 @@ def test_load_table_error_includes_filename_and_directory(
     msg = str(exc_info.value)
     assert "looked for" in msg
     assert str(vocab.table_dir) in msg
+
+
+# ---------------------------------------------------------------------------
+# _resolve_experiment_label: canonical CMIP6 `experiment` global attribute
+# (see issue-experiment-attribute-cv-mismatch). The WCRP checker compares the
+# file's `experiment` against esgvoc's label, which differs from the legacy
+# CMIP6_CVs phrase bundled with this package.
+# ---------------------------------------------------------------------------
+import sys
+from types import SimpleNamespace
+
+
+def _fake_esgvoc_module(term):
+    """Build a stand-in ``esgvoc.api`` module returning ``term`` from any lookup."""
+    api = SimpleNamespace(get_term_in_collection=lambda **kwargs: term)
+    return {"esgvoc": SimpleNamespace(api=api), "esgvoc.api": api}
+
+
+@pytest.mark.unit
+def test_resolve_experiment_label_uses_esgvoc(vocabulary_instance):
+    """esgvoc's canonical label overrides the legacy CV description."""
+    CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE.clear()
+    vocabulary_instance.experiment_id = "historical"
+    vocabulary_instance.experiment = {
+        "experiment": "all-forcing simulation of the recent past"
+    }
+    term = SimpleNamespace(experiment="Historical simulation")
+    with patch.dict(sys.modules, _fake_esgvoc_module(term)):
+        assert (
+            vocabulary_instance._resolve_experiment_label() == "Historical simulation"
+        )
+
+
+@pytest.mark.unit
+def test_resolve_experiment_label_falls_back_when_esgvoc_label_empty(
+    vocabulary_instance,
+):
+    """When esgvoc has no label for the experiment, keep the legacy CV value."""
+    CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE.clear()
+    vocabulary_instance.experiment_id = "piControl"
+    vocabulary_instance.experiment = {"experiment": "pre-industrial control"}
+    term = SimpleNamespace(experiment=None)
+    with patch.dict(sys.modules, _fake_esgvoc_module(term)):
+        assert (
+            vocabulary_instance._resolve_experiment_label()
+            == "pre-industrial control"
+        )
+
+
+@pytest.mark.unit
+def test_resolve_experiment_label_falls_back_when_esgvoc_missing(vocabulary_instance):
+    """Without esgvoc installed, fall back to the legacy CV value."""
+    CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE.clear()
+    vocabulary_instance.experiment_id = "historical"
+    vocabulary_instance.experiment = {
+        "experiment": "all-forcing simulation of the recent past"
+    }
+    # Make `import esgvoc.api` raise ImportError.
+    with patch.dict(sys.modules, {"esgvoc": None, "esgvoc.api": None}):
+        assert (
+            vocabulary_instance._resolve_experiment_label()
+            == "all-forcing simulation of the recent past"
+        )
+
+
+@pytest.mark.unit
+def test_resolve_experiment_label_is_cached(vocabulary_instance):
+    """The esgvoc lookup is performed at most once per experiment_id."""
+    CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE.clear()
+    vocabulary_instance.experiment_id = "historical"
+    vocabulary_instance.experiment = {"experiment": "legacy"}
+    calls = {"n": 0}
+
+    def _counting_lookup(**kwargs):
+        calls["n"] += 1
+        return SimpleNamespace(experiment="Historical simulation")
+
+    api = SimpleNamespace(get_term_in_collection=_counting_lookup)
+    fake = {"esgvoc": SimpleNamespace(api=api), "esgvoc.api": api}
+    with patch.dict(sys.modules, fake):
+        first = vocabulary_instance._resolve_experiment_label()
+        second = vocabulary_instance._resolve_experiment_label()
+
+    assert first == second == "Historical simulation"
+    assert calls["n"] == 1

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -1,5 +1,7 @@
 """Unit tests for vocabulary processor helper methods."""
 
+import sys
+from types import SimpleNamespace
 from unittest.mock import mock_open, patch
 
 import numpy as np
@@ -898,10 +900,6 @@ def test_load_table_error_includes_filename_and_directory(
 # file's `experiment` against esgvoc's label, which differs from the legacy
 # CMIP6_CVs phrase bundled with this package.
 # ---------------------------------------------------------------------------
-import sys
-from types import SimpleNamespace
-
-
 def _fake_esgvoc_module(term):
     """Build a stand-in ``esgvoc.api`` module returning ``term`` from any lookup."""
     api = SimpleNamespace(get_term_in_collection=lambda **kwargs: term)
@@ -934,8 +932,7 @@ def test_resolve_experiment_label_falls_back_when_esgvoc_label_empty(
     term = SimpleNamespace(experiment=None)
     with patch.dict(sys.modules, _fake_esgvoc_module(term)):
         assert (
-            vocabulary_instance._resolve_experiment_label()
-            == "pre-industrial control"
+            vocabulary_instance._resolve_experiment_label() == "pre-industrial control"
         )
 
 


### PR DESCRIPTION
## Summary

Every CMORised CMIP6 file written the global `experiment` attribute from the
**legacy** bundled `CMIP6_CVs` JSON, whose `experiment` field is a long
descriptive phrase (e.g. `"all-forcing simulation of the recent past"`). The
WCRP compliance checker (`wcrp_cmip6:1.0`, cc-plugin-wcrp + esgvoc) validates
that attribute against **esgvoc's** CMIP6 controlled vocabulary, whose label is
the short canonical name (e.g. `"Historical simulation"`). The two vocabularies
disagree, so the checker raised a MED-priority `[ATTR007]` cross-attribute
consistency failure on every affected file.

This PR resolves the `experiment` label from esgvoc — the *same* source the
checker uses — so the written value matches by construction, with a safe
fallback to the legacy value.

## Problem

The bundled legacy CV and esgvoc's CMIP6 universe carry different values in the
`experiment` field:

| Source | `experiment` for `historical` |
| --- | --- |
| Bundled `CMIP6_CVs/CMIP6_experiment_id.json` (what we wrote) | `all-forcing simulation of the recent past` |
| esgvoc `cmip6` CV (what the checker validates against) | `Historical simulation` |

The checker, `checks/consistency_checks/check_experiment_consistency.py`
(`[ATTR007]`), does roughly:

```python
reference_term = voc.get_term_in_collection("cmip6", "experiment_id", experiment_id)
expected_experiment = getattr(reference_term, "experiment", None)
if expected_experiment and actual_experiment is not None:
    if actual_experiment != str(expected_experiment).strip():
        failures.append(f"Inconsistency for 'experiment': CV expects "
                        f"'{expected_experiment}', file has '{actual_experiment}'.")
```

Two consequences matter:

1. The authoritative value is **esgvoc's** `term.experiment`, not the bundled
   CV's.
2. The comparison only runs when `expected_experiment` is non-empty. esgvoc
   returns `None` for most experiments (e.g. `piControl`, `amip`), so the check
   is *skipped* for those and the legacy value is accepted. Only experiments
   where esgvoc has a non-empty label (e.g. `historical`, `esm-hist`) failed.

The attribute is written once, in `CMIP6Vocabulary.get_required_global_attributes`:

```python
"experiment": self.experiment["experiment"],   # legacy CV description -> mismatch
```

## Fix

Resolve the label from esgvoc and fall back to the bundled CV value. The write
site now calls a small helper:

```python
"experiment": self._resolve_experiment_label(),
```

### The esgvoc.api integration

The new helper `CMIP6Vocabulary._resolve_experiment_label()` is the core of this
change. Design points:

- **Same source as the checker.** It calls
  `esgvoc.api.get_term_in_collection(project_id="cmip6",
  collection_id="experiment_id", term_id=experiment_id)` and reads
  `term.experiment` — the exact call and field `[ATTR007]` compares against. By
  construction the written value equals what the checker expects, for *any*
  experiment esgvoc has a label for (not special-cased for `historical`).

- **Lazy, optional import.** `import esgvoc.api as voc` happens *inside* the
  method, not at module top. esgvoc is a checker/pixi dependency, not a hard
  runtime dependency of the core CMORiser, so importing lazily keeps it optional.

- **Safe fallback.** Any failure — esgvoc not installed (`ImportError`), term not
  found, or an empty label — falls back to the bundled CV value
  (`self.experiment["experiment"]`). When esgvoc has no label the checker skips
  the comparison anyway, so the legacy value remains valid.

- **Cached per experiment.** Results are memoised in a class-level
  `_EXPERIMENT_LABEL_CACHE` keyed by `experiment_id`, because esgvoc lookups
  touch a local database; each experiment is resolved at most once per process.

```python
# Canonical CMIP6-CV ``experiment`` labels resolved via esgvoc, keyed by
# experiment_id. esgvoc lookups touch a database, so resolve each
# experiment at most once per process.
_EXPERIMENT_LABEL_CACHE: Dict[str, Optional[str]] = {}

def _resolve_experiment_label(self) -> str:
    """Return the canonical ``experiment`` global-attribute value.

    The WCRP compliance checker (cc-plugin-wcrp + esgvoc) compares the
    global ``experiment`` attribute against esgvoc's CMIP6 controlled
    vocabulary, whose label (e.g. ``"Historical simulation"``) differs from
    the descriptive phrase carried in the legacy CMIP6_CVs JSON bundled with
    this package (e.g. ``"all-forcing simulation of the recent past"``).

    Resolve the label from esgvoc so the written attribute matches what the
    checker validates. Fall back to the bundled CV value when esgvoc is
    unavailable or carries no label for this experiment -- in the latter
    case the checker skips the comparison, so the legacy value is accepted.
    """
    legacy_label = self.experiment.get("experiment", "")

    eid = self.experiment_id
    if eid not in CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE:
        label: Optional[str] = None
        try:
            import esgvoc.api as voc

            term = voc.get_term_in_collection(
                project_id="cmip6",
                collection_id="experiment_id",
                term_id=eid,
            )
            if term is not None:
                label = getattr(term, "experiment", None)
        except Exception:
            label = None
        CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE[eid] = label

    resolved = CMIP6Vocabulary._EXPERIMENT_LABEL_CACHE[eid]
    return resolved if resolved else legacy_label
```

### Why esgvoc instead of editing the bundled JSON

- The bundled `CMIP6_CVs` directory is a git **submodule** tracking upstream
  `WCRP-CMIP/CMIP6_CVs`. Editing `CMIP6_experiment_id.json` in place diverges
  from upstream and can be wiped by `git submodule update`.
- esgvoc is the checker's own vocabulary, so it stays correct as the CV evolves,
  with zero maintenance of a hand-copied label table.

## Scope

- CMIP6 only. `CMIP7Vocabulary` does not emit an `experiment` global attribute,
  so it is untouched.
- Single attribute write path; general across all experiments, not special-cased
  for `historical`.

## Tests

Four unit tests in `tests/unit/test_vocabulary_processors.py` mock `esgvoc.api`
via `sys.modules`, so they pass with or without esgvoc installed:

- `test_resolve_experiment_label_uses_esgvoc` — esgvoc label overrides the legacy
  description.
- `test_resolve_experiment_label_falls_back_when_esgvoc_label_empty` — empty
  esgvoc label keeps the legacy value.
- `test_resolve_experiment_label_falls_back_when_esgvoc_missing` — missing esgvoc
  (`ImportError`) keeps the legacy value.
- `test_resolve_experiment_label_is_cached` — the lookup runs at most once per
  `experiment_id`.

## Verification

- esgvoc resolves `historical -> "Historical simulation"` and
  `esm-hist -> "ESM historical simulation"`; `piControl -> None` (checker skips).
- Live end-to-end in `conda/analysis3-26.06`:
  `CMIP6Vocabulary("Amon.tas", "historical", ...)._resolve_experiment_label()`
  returns `"Historical simulation"`.
- A re-CMORised `tas_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn` file now carries
  `:experiment = "Historical simulation"`, and `compliance-checker
  --test wcrp_cmip6:1.0` reports no `[ATTR007]` `experiment` inconsistency.