### PR TITLE
Improve public docstrings and type annotations

### DIFF
--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import warnings
 from contextlib import ExitStack
 from importlib.resources import as_file
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from types import TracebackType
+from typing import Any
 
 import xarray as xr
 
@@ -29,7 +32,7 @@ _DEFAULT_MODEL_ID = "ACCESS-ESM1.6"
 
 
 def _warn_if_mapping_missing(
-    raw_mapping: Dict, compound_name: str, model_id: Optional[str]
+    raw_mapping: dict[str, Any], compound_name: str, model_id: str | None
 ) -> None:
     """
     Emit a :class:`MappingNotFoundWarning` when no model mapping is found.
@@ -80,14 +83,24 @@ def _warn_if_mapping_missing(
 
 
 class ACCESS_ESM_CMORiser:
-    """
-    Coordinates the CMORisation process using CMIP6 or CMIP7 Vocabulary and CMORiser.
-    Handles DRS, versioning, and orchestrates the workflow.
+    """High-level public interface for ACCESS-ESM CMORisation.
+
+    ``ACCESS_ESM_CMORiser`` selects the appropriate vocabulary and component
+    CMORiser implementation for a requested CMIP variable, then delegates the
+    scientific processing to that implementation.  It accepts either paths to
+    raw NetCDF files or an already-open xarray object, manages DRS output
+    metadata, and can be used as a context manager when bundled resource files
+    are involved.
     """
 
     def __init__(
         self,
-        input_data: Optional[Union[str, list, xr.Dataset, xr.DataArray]] = None,
+        input_data: str
+        | Path
+        | list[str | Path]
+        | xr.Dataset
+        | xr.DataArray
+        | None = None,
         *,
         compound_name: str,
         experiment_id: str,
@@ -95,36 +108,65 @@ class ACCESS_ESM_CMORiser:
         variant_label: str,
         grid_label: str,
         cmip_version: str = "CMIP6",
-        activity_id: str = None,
-        output_path: Optional[Union[str, Path]] = ".",
-        drs_root: Optional[Union[str, Path]] = None,
-        parent_info: Optional[Dict[str, Dict[str, Any]]] = None,
-        model_id: Optional[str] = None,
+        activity_id: str | None = None,
+        output_path: str | Path | None = ".",
+        drs_root: str | Path | None = None,
+        parent_info: dict[str, dict[str, Any]] | None = None,
+        model_id: str | None = None,
         validate_frequency: bool = True,
         enable_resampling: bool = False,
         enable_chunking: bool = False,
         resampling_method: str = "auto",
         # Backward compatibility
-        input_paths: Optional[Union[str, list]] = None,
-    ):
-        """
-        Initializes the CMORiser with necessary parameters.
-        :param input_data: Path(s) to input NetCDF files, xarray Dataset, or xarray DataArray.
-        :param compound_name: CMOR variable name (e.g., 'Amon.tas').
-        :param experiment_id: CMIP experiment ID (e.g., 'historical').
-        :param source_id: CMIP source ID (e.g., 'ACCESS-ESM1-5').
-        :param variant_label: CMIP variant label (e.g., 'r1i1p1f1').
-        :param grid_label: CMIP grid label (e.g., 'gn').
-        :param cmip_version: CMIP version to use - one of 'CMIP6', 'CMIP6Plus', or 'CMIP7' (default: 'CMIP6').
-        :param activity_id: CMIP activity ID (e.g., 'CMIP').
-        :param output_path: Path to write the CMORised output.
-        :param drs_root: Optional root path for DRS structure.
-        :param parent_info: Optional dictionary with parent experiment metadata.
-        :param model_id: Optional model identifier for model-specific mappings (e.g., 'ACCESS-ESM1.6').
-        :param validate_frequency: Whether to validate temporal frequency consistency across input files (default: True).
-        :param enable_resampling: Whether to enable automatic temporal resampling when frequency mismatches occur (default: False).
-        :param resampling_method: Method for temporal resampling ('auto', 'mean', 'sum', 'min', 'max', 'first', 'last') (default: 'auto').
-        :param input_paths: [DEPRECATED] Use input_data instead. Kept for backward compatibility.
+        input_paths: str | Path | list[str | Path] | None = None,
+    ) -> None:
+        """Initialise a CMORiser for one CMIP compound variable.
+
+        Args:
+            input_data: Path, paths, xarray dataset, or xarray data array to
+                CMORise.  May be omitted for internally generated variables or
+                variables backed by bundled resource files.
+            compound_name: CMIP table and short name, e.g. ``"Amon.tas"``.
+            experiment_id: CMIP experiment ID, e.g. ``"historical"``.
+            source_id: CMIP source ID, e.g. ``"ACCESS-ESM1-5"``.
+            variant_label: CMIP variant label, e.g. ``"r1i1p1f1"``.
+            grid_label: CMIP grid label, e.g. ``"gn"``.
+            cmip_version: Vocabulary family to use: ``"CMIP6"``,
+                ``"CMIP6Plus"``, or ``"CMIP7"``.
+            activity_id: Optional CMIP activity ID, e.g. ``"CMIP"``.
+            output_path: Directory used by the component CMORiser when writing
+                output.
+            drs_root: Optional DRS root directory.  When supplied, output is
+                written under this CMIP DRS tree.
+            parent_info: Optional parent-experiment metadata keyed by CMIP
+                attribute name.  Missing values fall back to ACCESS-MOPPy
+                defaults for piControl parent metadata.
+            model_id: Model mapping identifier, e.g. ``"ACCESS-ESM1.6"``.
+            validate_frequency: Validate temporal frequency consistency across
+                file inputs.  This is disabled automatically for xarray inputs.
+            enable_resampling: Enable automatic temporal resampling when
+                frequency mismatches are detected.
+            enable_chunking: Enable dask chunking in supported component
+                CMORisers.
+            resampling_method: Temporal resampling method: ``"auto"``,
+                ``"mean"``, ``"sum"``, ``"min"``, ``"max"``, ``"first"``, or
+                ``"last"``.
+            input_paths: Deprecated alias for ``input_data`` retained for
+                backward compatibility.
+
+        Raises:
+            ValueError: If ``cmip_version`` is unsupported, both ``input_data``
+                and ``input_paths`` are supplied, required input data is
+                missing, or the CMIP table is not supported.
+
+        Warns:
+            MappingNotFoundWarning: Warned when a model mapping file or mapping
+                entry is unavailable for the requested variable.
+
+        Notes:
+            Use :meth:`close` or a ``with`` statement to release temporary
+            bundled-resource contexts when ``input_data`` is omitted and a
+            resource-backed variable is used.
         """
 
         # Validate CMIP version
@@ -397,10 +439,31 @@ class ACCESS_ESM_CMORiser:
                 f"sea-ice: {_seaice_tables}."
             )
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> xr.DataArray:
+        """Return a variable from the wrapped CMORised dataset.
+
+        Args:
+            key: Dataset variable name to retrieve.
+
+        Returns:
+            The requested xarray data array.
+        """
         return self.cmoriser.ds[key]
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Any:
+        """Delegate unknown attributes to the wrapped xarray dataset.
+
+        Args:
+            attr: Attribute name requested by the caller.
+
+        Returns:
+            The corresponding attribute from the underlying
+            :class:`xarray.Dataset`.
+
+        Raises:
+            AttributeError: If no component CMORiser has been initialised or
+                the wrapped dataset does not expose ``attr``.
+        """
         # Guard against infinite recursion when cmoriser itself is not yet set
         if attr == "cmoriser":
             raise AttributeError(
@@ -409,20 +472,34 @@ class ACCESS_ESM_CMORiser:
         # This is only called if the attr is not found on CMORiser itself
         return getattr(self.cmoriser.ds, attr)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Set a variable on the wrapped CMORised dataset.
+
+        Args:
+            key: Dataset variable name to update.
+            value: Value accepted by :class:`xarray.Dataset` assignment.
+        """
         self.cmoriser.ds[key] = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """Return the representation of the wrapped xarray dataset."""
         return repr(self.cmoriser.ds)
 
-    def to_dataset(self):
-        """
-        Returns the underlying xarray Dataset from the CMORiser.
+    def to_dataset(self) -> xr.Dataset:
+        """Return the underlying CMORised xarray dataset.
+
+        Returns:
+            The dataset owned by the selected component CMORiser.
+
+        Notes:
+            The returned object is the live dataset, not a copy.  Mutating it
+            mutates the data that :meth:`write` will serialise.
         """
         return self.cmoriser.ds
 
-    def to_iris(self):
-        """
+    def to_iris(self) -> Any:
+        """Convert the underlying xarray dataset to a single Iris cube.
+
         Converts the underlying xarray Dataset to a single Iris Cube with proper
         auxiliary coordinates, masking, and bounds for curvilinear ocean grids.
 
@@ -434,8 +511,13 @@ class ACCESS_ESM_CMORiser:
         Requires ncdata and iris to be installed.
 
         Returns:
-            iris.cube.Cube: A single Cube for the CMORised variable with proper
+            A single ``iris.cube.Cube`` for the CMORised variable with proper
             auxiliary coordinates, bounds, and masking applied.
+
+        Raises:
+            ImportError: If ``ncdata`` or ``iris`` is unavailable.
+            ValueError: If the converted cube list does not contain the
+                CMORised variable.
         """
         try:
             import numpy as np
@@ -493,30 +575,36 @@ class ACCESS_ESM_CMORiser:
 
         return main_cube
 
-    def run(self, write_output: bool = False):
+    def run(self, write_output: bool = False) -> None:
+        """Run CMORisation for the configured variable.
+
+        Args:
+            write_output: When ``True``, write the CMORised dataset after
+                processing.
         """
-        Runs the CMORisation process, including variable selection, processing,
-        attribute updates, and optional output writing."""
 
         self.cmoriser.run()
         if write_output:
             self.cmoriser.write()
 
-    def write(self):
-        """
-        Writes the CMORised dataset to the specified output path.
-        """
+    def write(self) -> None:
+        """Write the CMORised dataset to the configured output path."""
         self.cmoriser.write()
 
-    def close(self):
-        """Release any held resource-file contexts."""
+    def close(self) -> None:
+        """Release any temporary contexts opened for bundled resource files."""
         self._resource_stack.close()
 
-    def __enter__(self):
-        """Return self for context-manager usage."""
+    def __enter__(self) -> ACCESS_ESM_CMORiser:
+        """Return ``self`` for context-manager usage."""
         return self
 
-    def __exit__(self, exc_type, exc, tb):
-        """Ensure resource contexts are cleaned up on context exit."""
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        """Clean up resource contexts when leaving a ``with`` block."""
         self.close()
         return False

--- a/src/access_moppy/esmval/__init__.py
+++ b/src/access_moppy/esmval/__init__.py
@@ -32,6 +32,12 @@ Public API
 - :func:`~access_moppy.esmval.config_gen.write_esmval_config`
 """
 
+from access_moppy.esmval.config_gen import (
+    merge_into_existing_config,
+    write_esmval_config,
+    write_esmval_config_alongside,
+)
+from access_moppy.esmval.file_finder import RawFileFinder
 from access_moppy.esmval.orchestrator import CMORiseOrchestrator
 from access_moppy.esmval.recipe_reader import CMORTask, RecipeReader
 from access_moppy.esmval.variable_mapper import VariableIndex
@@ -39,6 +45,10 @@ from access_moppy.esmval.variable_mapper import VariableIndex
 __all__ = [
     "CMORiseOrchestrator",
     "CMORTask",
+    "RawFileFinder",
     "RecipeReader",
     "VariableIndex",
+    "merge_into_existing_config",
+    "write_esmval_config",
+    "write_esmval_config_alongside",
 ]

--- a/src/access_moppy/esmval/cli_commands.py
+++ b/src/access_moppy/esmval/cli_commands.py
@@ -388,7 +388,20 @@ def _prepare(
 
 
 def main_prepare(argv: Sequence[str] | None = None) -> int:
-    """Entry point for ``moppy-esmval-prepare``."""
+    """Entry point for ``moppy-esmval-prepare``.
+
+    Parameters
+    ----------
+    argv:
+        Optional argument list.  When omitted, arguments are read from
+        ``sys.argv`` by :mod:`argparse`.
+
+    Returns
+    -------
+    int
+        Process-style exit code: ``0`` on success, ``1`` on parse or
+        preparation failure.
+    """
     parser = _build_parser(prog="moppy-esmval-prepare")
     args = parser.parse_args(list(argv) if argv is not None else None)
     _configure_logging(args.verbose)
@@ -427,7 +440,19 @@ def main_run(argv: Sequence[str] | None = None) -> int:
     """Entry point for ``moppy-esmval-run``.
 
     Runs CMORisation, writes config overlay, then calls
-    ``esmvaltool run <recipe> --config <overlay>``.
+    ``esmvaltool run <recipe>`` with ``ESMVALTOOL_CONFIG_DIR`` set when the
+    generated config was written outside the default user config directory.
+
+    Parameters
+    ----------
+    argv:
+        Optional argument list.  When omitted, arguments are read from
+        ``sys.argv`` by :mod:`argparse`.
+
+    Returns
+    -------
+    int
+        Exit code from ESMValTool, or ``1`` when the preparation step fails.
     """
     parser = _build_parser(prog="moppy-esmval-run")
     parser.add_argument(

--- a/src/access_moppy/esmval/config_gen.py
+++ b/src/access_moppy/esmval/config_gen.py
@@ -169,7 +169,16 @@ def write_esmval_config(
 def load_existing_config(config_path: str | Path) -> dict[str, Any]:
     """Read an existing ESMValCore config file and return it as a dict.
 
-    Returns an empty dict when the file does not exist.
+    Parameters
+    ----------
+    config_path:
+        Path to the YAML config file to read.
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed mapping from the file, or an empty dict when the file does not
+        exist, is empty, or does not contain a YAML mapping.
     """
     p = Path(config_path)
     if not p.exists():
@@ -221,3 +230,38 @@ def write_esmval_config_alongside(
         else Path(base_config_path).parent / DEFAULT_CONFIG_FILENAME
     )
     return write_esmval_config(cache_dir=cache_dir, output_path=dest)
+
+
+def merge_into_existing_config(
+    cache_dir: str | Path,
+    base_config_path: str | Path,
+    output_path: str | Path | None = None,
+) -> Path:
+    """Write MOPPy's ESMValCore data-source config next to an existing file.
+
+    This is a compatibility alias for :func:`write_esmval_config_alongside`.
+    The historical name is kept because it is part of the documented ESMVal
+    API.  Despite the name, the existing config file is **not** edited in
+    place; ESMValCore 2.14+ merges YAML files from the user config directory
+    at load time.
+
+    Parameters
+    ----------
+    cache_dir:
+        MOPPy cache directory (the CMIP DRS root).
+    base_config_path:
+        Path to any existing file in the target ESMValCore config directory.
+    output_path:
+        Optional output file path.  Defaults to
+        ``<parent of base_config_path>/moppy-esmval-data.yml``.
+
+    Returns
+    -------
+    Path
+        Path to the written MOPPy data-source config file.
+    """
+    return write_esmval_config_alongside(
+        cache_dir=cache_dir,
+        base_config_path=base_config_path,
+        output_path=output_path,
+    )

--- a/src/access_moppy/esmval/file_finder.py
+++ b/src/access_moppy/esmval/file_finder.py
@@ -111,6 +111,20 @@ class RawFileFinder:
         variable_index: VariableIndex | None = None,
         pattern_overrides: dict[str, str] | None = None,
     ) -> None:
+        """Initialise a finder for one raw ACCESS archive root.
+
+        Parameters
+        ----------
+        input_root:
+            Root directory under which ``outputNNN`` cycle directories are
+            searched.
+        variable_index:
+            Optional pre-built variable index.  Supplying one avoids rebuilding
+            or reusing the default ``ACCESS-ESM1.6`` index implicitly.
+        pattern_overrides:
+            Optional mapping of compound names to glob patterns relative to
+            ``input_root``.
+        """
         self._root = Path(input_root)
         self._index = variable_index or VariableIndex()
         self._overrides: dict[str, str] = pattern_overrides or {}
@@ -121,6 +135,7 @@ class RawFileFinder:
 
     @property
     def input_root(self) -> Path:
+        """Return the raw ACCESS archive root searched by this finder."""
         return self._root
 
     def find(

--- a/src/access_moppy/esmval/orchestrator.py
+++ b/src/access_moppy/esmval/orchestrator.py
@@ -66,6 +66,7 @@ class TaskResult:
 
     @property
     def succeeded(self) -> bool:
+        """Return whether the task produced or reused usable output."""
         return self.status in ("done", "cached")
 
 
@@ -116,6 +117,26 @@ class CMORiseOrchestrator:
         max_workers: int = 1,
         dry_run: bool = False,
     ) -> None:
+        """Initialise the recipe preparation orchestrator.
+
+        Parameters
+        ----------
+        input_root:
+            Root directory containing raw ACCESS-ESM output.
+        cache_dir:
+            Directory where CMORised files will be written and later exposed
+            to ESMValCore as a CMIP DRS root.
+        model_id:
+            ACCESS-MOPPy model mapping identifier.
+        pattern_overrides:
+            Optional per-compound-name glob overrides forwarded to
+            :class:`RawFileFinder`.
+        max_workers:
+            Number of worker processes to use for independent tasks.  Values
+            less than one are treated as one.
+        dry_run:
+            When ``True``, report the planned work without writing outputs.
+        """
         self._input_root = Path(input_root)
         self._cache_dir = Path(cache_dir).expanduser().resolve()
         self._model_id = model_id
@@ -135,6 +156,7 @@ class CMORiseOrchestrator:
 
     @property
     def cache_dir(self) -> Path:
+        """Return the resolved CMORised-output cache directory."""
         return self._cache_dir
 
     def prepare_recipe(

--- a/src/access_moppy/esmval/recipe_reader.py
+++ b/src/access_moppy/esmval/recipe_reader.py
@@ -104,6 +104,21 @@ class RecipeReader:
         recipe_path: str | Path,
         allowed_datasets: frozenset[str] | None = None,
     ) -> None:
+        """Load a recipe and configure supported dataset filtering.
+
+        Parameters
+        ----------
+        recipe_path:
+            Path to the ESMValTool YAML recipe.
+        allowed_datasets:
+            Dataset facet values that should be treated as ACCESS-ESM output.
+            When omitted, the built-in ACCESS-ESM dataset aliases are used.
+
+        Raises
+        ------
+        ValueError
+            If the recipe YAML top level is not a mapping.
+        """
         self._path = Path(recipe_path)
         self._allowed_datasets = allowed_datasets or _ACCESS_ESM_DATASET_NAMES
         self._recipe: dict[str, Any] = self._load()

--- a/src/access_moppy/esmval/variable_mapper.py
+++ b/src/access_moppy/esmval/variable_mapper.py
@@ -86,6 +86,14 @@ class VariableIndex:
     _cache: dict[str, dict[tuple[str, str], MappingEntry]] = {}
 
     def __init__(self, model_id: str = "ACCESS-ESM1.6") -> None:
+        """Initialise or reuse the cached mapping index for ``model_id``.
+
+        Parameters
+        ----------
+        model_id:
+            ACCESS-MOPPy model identifier whose bundled mapping JSON should be
+            indexed.
+        """
         self._model_id = model_id
         if model_id not in VariableIndex._cache:
             VariableIndex._cache[model_id] = self._build_index(model_id)
@@ -99,6 +107,7 @@ class VariableIndex:
 
     @property
     def model_id(self) -> str:
+        """Return the ACCESS-MOPPy model identifier backing this index."""
         return self._model_id
 
     def get(self, mip: str, short_name: str) -> MappingEntry | None:


### PR DESCRIPTION
## Summary

PR1 of the docstrings/types audit.

- Expands public docstrings and type annotations for `ACCESS_ESM_CMORiser` and the ESMVal integration modules.
- Documents accepted inputs, metadata arguments, warnings/errors, live dataset semantics, Iris conversion, writing, cleanup, and context-manager behaviour.
- Exports documented ESMVal API objects from `access_moppy.esmval`.
- Adds `merge_into_existing_config()` as a compatibility alias for the documented config-generation API.

## Behaviour / compatibility

- No intended behavioural changes to CMORisation, file discovery, recipe parsing, or orchestration.
- Additive public API exports only.
- Runtime-visible changes are limited to annotations/docstrings and the additive compatibility helper.
- No vendored vocabulary material modified.

## Validation

Using a temporary non-interactive MOPPy config:

- `HOME=/tmp/moppy-test-home ./.pixi/envs/test/bin/pytest tests/unit -q` → `1064 passed, 19 warnings`
- ESMVal unit subset → `172 passed`
- Scoped Ruff excluding `src/access_moppy/vocabularies/` → `All checks passed!`
- `git diff --check` → passed

Report: `/workspace/coding/reports/20260604-0214-access-moppy-docstrings-types-pr1.md`
