### PR TITLE
Improve core batch tracking docstrings and types

### DIFF
--- a/src/access_moppy/batch_cmoriser.py
+++ b/src/access_moppy/batch_cmoriser.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import os
 import shlex
 import signal
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
 from importlib.resources import files
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -18,10 +22,22 @@ SIDECAR_FILENAME = ".moppy_main.jobid"
 # How often the monitor polls PBS for sub-job state. 30s keeps qstat load low
 # while still detecting OOM kills within a poll cycle.
 MONITOR_POLL_INTERVAL_SECONDS = 30
+QstatInfo = dict[str, str]
+BatchConfig = Mapping[str, Any]
 
 
-def parse_walltime(s):
-    """Parse an 'HH:MM:SS' or 'MM:SS' walltime string into seconds."""
+def parse_walltime(s: str) -> int:
+    """Parse an ``HH:MM:SS`` or ``MM:SS`` walltime string into seconds.
+
+    Args:
+        s: PBS-style walltime string.
+
+    Returns:
+        Walltime duration in seconds.
+
+    Raises:
+        ValueError: If the string is not in ``HH:MM:SS`` or ``MM:SS`` form.
+    """
     parts = str(s).strip().split(":")
     if len(parts) == 3:
         h, m, sec = parts
@@ -32,14 +48,14 @@ def parse_walltime(s):
     return int(h) * 3600 + int(m) * 60 + int(sec)
 
 
-def format_walltime(seconds):
-    """Render an integer second count as a zero-padded 'HH:MM:SS' string."""
+def format_walltime(seconds: int) -> str:
+    """Render an integer second count as a zero-padded ``HH:MM:SS`` string."""
     h, rem = divmod(int(seconds), 3600)
     m, s = divmod(rem, 60)
     return f"{h:02d}:{m:02d}:{s:02d}"
 
 
-def compute_monitor_walltime(config):
+def compute_monitor_walltime(config: BatchConfig) -> str:
     """Pick a walltime for the monitor job from the batch config.
 
     The monitor only needs to outlive the slowest sub-job, so we take the
@@ -55,7 +71,7 @@ def compute_monitor_walltime(config):
     return format_walltime(longest + 30 * 60)
 
 
-def qstat_full(job_id):
+def qstat_full(job_id: str) -> QstatInfo | None:
     """Run `qstat -fx <job_id>` and parse the result into a dict.
 
     Returns None on timeout, missing binary, or empty output (the latter
@@ -78,7 +94,7 @@ def qstat_full(job_id):
     if result.returncode != 0 or not result.stdout.strip():
         return None
 
-    info = {}
+    info: QstatInfo = {}
     current_key = None
     for raw in result.stdout.splitlines():
         if not raw or raw.startswith("Job Id:"):
@@ -98,7 +114,7 @@ def qstat_full(job_id):
     return info
 
 
-def qstat_state(info):
+def qstat_state(info: QstatInfo | None) -> str:
     """Return the PBS job_state letter from a qstat_full() dict.
 
     Returns 'gone' when info is None (job no longer visible to PBS) or when
@@ -110,7 +126,12 @@ def qstat_state(info):
     return info.get("job_state", "gone")
 
 
-def format_pbs_error(variable, job_id, info, script_dir):
+def format_pbs_error(
+    variable: str,
+    job_id: str,
+    info: QstatInfo | None,
+    script_dir: str | Path,
+) -> str:
     """Assemble a single-line failure message for a dead sub-job.
 
     Pulls exit_status, the PBS comment (often the reason a job was killed),
@@ -157,7 +178,14 @@ def format_pbs_error(variable, job_id, info, script_dir):
     return " | ".join(parts)
 
 
-def reconcile_one(tracker, variable, experiment_id, job_id, info, script_dir):
+def reconcile_one(
+    tracker: TaskTracker,
+    variable: str,
+    experiment_id: str,
+    job_id: str,
+    info: QstatInfo | None,
+    script_dir: str | Path,
+) -> None:
     """Decide what to write to the DB for one finished sub-job.
 
     The worker normally writes its own terminal status. The monitor only
@@ -188,7 +216,17 @@ def reconcile_one(tracker, variable, experiment_id, job_id, info, script_dir):
     tracker.mark_failed(variable, experiment_id, msg)
 
 
-def start_dashboard(dashboard_path: str, db_path: str):
+def start_dashboard(dashboard_path: str, db_path: str) -> None:
+    """Launch the Streamlit dashboard for a task-tracker database.
+
+    Args:
+        dashboard_path: Filesystem path to the dashboard Python script.
+        db_path: SQLite task-tracker database path to expose via the
+            ``CMOR_TRACKER_DB`` environment variable.
+
+    The function returns without raising for missing/invalid dashboard paths
+    so batch submission can continue when the optional dashboard is unavailable.
+    """
     env = os.environ.copy()
     env["CMOR_TRACKER_DB"] = db_path
 
@@ -232,8 +270,20 @@ def start_dashboard(dashboard_path: str, db_path: str):
     )
 
 
-def create_job_script(variable, config, db_path, script_dir):
-    """Create PBS job script and Python script for a variable."""
+def create_job_script(
+    variable: str, config: BatchConfig, db_path: str | Path, script_dir: Path
+) -> Path:
+    """Create PBS and Python worker scripts for one variable.
+
+    Args:
+        variable: Variable name from the batch config.
+        config: Batch CMORisation configuration dictionary.
+        db_path: Path to the task-tracker SQLite database.
+        script_dir: Directory where generated scripts should be written.
+
+    Returns:
+        Path to the generated PBS job script.
+    """
     from importlib.resources import files
 
     from jinja2 import Template
@@ -300,8 +350,11 @@ def create_job_script(variable, config, db_path, script_dir):
     return pbs_script_path
 
 
-def submit_job(script_path):
-    """Submit a PBS job and return the job ID."""
+def submit_job(script_path: str | Path) -> str | None:
+    """Submit a PBS job script and return the PBS job id.
+
+    Returns ``None`` when the script path is invalid or ``qsub`` fails.
+    """
     try:
         # Security: validate and escape script_path to prevent injection
         script_path_str = str(script_path)
@@ -345,7 +398,7 @@ def submit_job(script_path):
         return None
 
 
-def wait_for_jobs(job_ids, poll_interval=30):
+def wait_for_jobs(job_ids: list[str], poll_interval: int = 30) -> None:
     """Wait for all jobs to complete and report status."""
     print(f"Waiting for {len(job_ids)} jobs to complete...")
 
@@ -412,7 +465,12 @@ def wait_for_jobs(job_ids, poll_interval=30):
     print("All jobs completed!")
 
 
-def create_monitor_script(config, config_path, db_path, script_dir):
+def create_monitor_script(
+    config: BatchConfig,
+    config_path: str | Path,
+    db_path: str | Path,
+    script_dir: str | Path,
+) -> Path:
     """Render the PBS script for the monitor job and write it to script_dir.
 
     The script is tiny (1 CPU, 4 GB) — it just submits sub-jobs and polls
@@ -442,7 +500,7 @@ def create_monitor_script(config, config_path, db_path, script_dir):
     return monitor_path
 
 
-def monitor_main():
+def monitor_main() -> None:
     """Entry point for the monitor PBS job, invoked via `--monitor`.
 
     Runs on a compute node. Reads the batch config from $MOPPY_CONFIG_PATH,
@@ -484,7 +542,7 @@ def monitor_main():
     try:
         # job_map maps the PBS jobid we got back from qsub to the variable it
         # processes. monitor_loop iterates this map to poll qstat per sub-job.
-        job_map = {}
+        job_map: dict[str, str] = {}
         for variable in config["variables"]:
             if tracker.is_done(variable, experiment_id):
                 print(f"Skipped (already completed): {variable}")
@@ -518,7 +576,7 @@ def monitor_main():
             finalize_monitor(tracker, config, experiment_id, db_path)
             return
 
-        def shutdown_handler(sig, _frame):
+        def shutdown_handler(sig: int, _frame: object) -> None:
             # PBS sends SIGTERM before SIGKILL on walltime exceedance or qdel.
             # Best-effort: any sub still in a non-terminal state had its outcome
             # cut short from our perspective, so mark it failed. SIGKILL would
@@ -548,7 +606,12 @@ def monitor_main():
         tracker.close()
 
 
-def monitor_loop(tracker, job_map, experiment_id, script_dir):
+def monitor_loop(
+    tracker: TaskTracker,
+    job_map: Mapping[str, str],
+    experiment_id: str,
+    script_dir: str | Path,
+) -> None:
     """Poll qstat for each pending sub-job and reconcile when it finishes.
 
     Exits once every sub-job has left the queue (state no longer in
@@ -573,7 +636,12 @@ def monitor_loop(tracker, job_map, experiment_id, script_dir):
             print(f"Sub-job done: {variable} (job {job_id}, state={state})")
 
 
-def finalize_monitor(tracker, config, experiment_id, db_path):
+def finalize_monitor(
+    tracker: TaskTracker,
+    config: BatchConfig,
+    experiment_id: str,
+    db_path: str | Path,
+) -> None:
     """Run a last-pass consistency check, print a summary, remove the sidecar.
 
     Catches the rare case where monitor_loop saw a sub finish but the DB
@@ -616,7 +684,7 @@ def finalize_monitor(tracker, config, experiment_id, db_path):
         pass
 
 
-def main():
+def main() -> None:
     """CLI entry point for `moppy-cmorise`.
 
     Two invocation modes:

--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -1,20 +1,39 @@
+from __future__ import annotations
+
 import random
 import sqlite3
 import time
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional
+from types import TracebackType
+from typing import Any, Literal, cast
+
+TaskStatus = Literal["pending", "running", "completed", "failed"]
 
 
 class TaskTracker:
-    def __init__(self, db_path: Optional[Path] = None):
+    """Track CMORisation task state in a small SQLite database.
+
+    The tracker is used by the batch CMORiser, PBS monitor job, dashboard,
+    and worker scripts to coordinate per-variable task state. It stores one
+    row per ``(variable, experiment_id)`` pair and retries transient SQLite
+    failures seen on Lustre-backed filesystems.
+
+    Args:
+        db_path: Optional path to the SQLite database. When omitted, the
+            default database under ``~/.moppy/db/cmor_tasks.db`` is used.
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
         if db_path is None:
             db_path = Path.home() / ".moppy" / "db" / "cmor_tasks.db"
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path, timeout=30)
+        self.conn: sqlite3.Connection | None = sqlite3.connect(self.db_path, timeout=30)
         self._init_db()
 
-    def _init_db(self):
+    def _init_db(self) -> None:
+        """Initialise the task table and Lustre-friendly SQLite settings."""
         # On Lustre (Gadi /scratch, /g/data), fsync() intermittently returns
         # EIO under concurrent PBS job access (SQLITE_IOERR: disk I/O error).
         # WAL mode also causes SIGBUS via its mmap'd .db-shm.
@@ -77,7 +96,13 @@ class TaskTracker:
                 else:
                     raise
 
-    def add_task(self, variable: str, experiment_id: str):
+    def add_task(self, variable: str, experiment_id: str) -> None:
+        """Insert a task row if it does not already exist.
+
+        Args:
+            variable: CMOR variable name or compound variable identifier.
+            experiment_id: Experiment identifier associated with the task.
+        """
         self._execute_with_retry(
             """
             INSERT OR IGNORE INTO cmor_tasks (variable, experiment_id)
@@ -86,7 +111,8 @@ class TaskTracker:
             (variable, experiment_id),
         )
 
-    def mark_running(self, variable: str, experiment_id: str):
+    def mark_running(self, variable: str, experiment_id: str) -> None:
+        """Mark a task as running and set its start timestamp."""
         self._execute_with_retry(
             """
             UPDATE cmor_tasks
@@ -96,7 +122,8 @@ class TaskTracker:
             (variable, experiment_id),
         )
 
-    def mark_completed(self, variable: str, experiment_id: str):
+    def mark_completed(self, variable: str, experiment_id: str) -> None:
+        """Mark a task as completed and clear any previous error message."""
         self._execute_with_retry(
             """
             UPDATE cmor_tasks
@@ -106,11 +133,14 @@ class TaskTracker:
             (variable, experiment_id),
         )
 
-    def mark_done(self, variable: str, experiment_id: str):
+    def mark_done(self, variable: str, experiment_id: str) -> None:
         """Alias for mark_completed for backward compatibility."""
         self.mark_completed(variable, experiment_id)
 
-    def mark_failed(self, variable: str, experiment_id: str, error_message: str):
+    def mark_failed(
+        self, variable: str, experiment_id: str, error_message: str
+    ) -> None:
+        """Mark a task as failed and store the supplied error message."""
         self._execute_with_retry(
             """
             UPDATE cmor_tasks
@@ -120,8 +150,13 @@ class TaskTracker:
             (error_message, variable, experiment_id),
         )
 
-    def get_status(self, variable: str, experiment_id: str) -> Optional[str]:
-        """Get the status of a task."""
+    def get_status(self, variable: str, experiment_id: str) -> TaskStatus | None:
+        """Get the current task status.
+
+        Returns:
+            One of ``"pending"``, ``"running"``, ``"completed"``, or
+            ``"failed"`` if the task exists; otherwise ``None``.
+        """
         cur = self._execute_with_retry(
             "SELECT status FROM cmor_tasks WHERE variable=? AND experiment_id=?",
             (variable, experiment_id),
@@ -130,9 +165,10 @@ class TaskTracker:
         return row[0] if row is not None else None
 
     def is_done(self, variable: str, experiment_id: str) -> bool:
+        """Return whether the task has reached the completed state."""
         return self.get_status(variable, experiment_id) == "completed"
 
-    def set_pbs_job_id(self, variable: str, experiment_id: str, job_id: str):
+    def set_pbs_job_id(self, variable: str, experiment_id: str, job_id: str) -> None:
         """Record the PBS job id that the monitor submitted for this variable.
 
         Stored so the monitor (or a successor) can later query PBS for the
@@ -143,7 +179,7 @@ class TaskTracker:
             (job_id, variable, experiment_id),
         )
 
-    def get_pbs_job_id(self, variable: str, experiment_id: str) -> Optional[str]:
+    def get_pbs_job_id(self, variable: str, experiment_id: str) -> str | None:
         """Return the PBS job id recorded for this variable, or None if unset."""
         cur = self._execute_with_retry(
             "SELECT pbs_job_id FROM cmor_tasks WHERE variable=? AND experiment_id=?",
@@ -152,7 +188,9 @@ class TaskTracker:
         row = cur.fetchone()
         return row[0] if row is not None else None
 
-    def list_unfinished(self, experiment_id: str):
+    def list_unfinished(
+        self, experiment_id: str
+    ) -> list[tuple[str, TaskStatus, str | None]]:
         """Return rows for tasks that have not reached a terminal state.
 
         Used when a monitor restarts and needs to rebuild its watch set from
@@ -165,7 +203,7 @@ class TaskTracker:
         )
         return cur.fetchall()
 
-    def close(self):
+    def close(self) -> None:
         """Close the underlying sqlite connection. Idempotent.
 
         Use this (or the context-manager form `with TaskTracker(...) as t:`)
@@ -181,17 +219,28 @@ class TaskTracker:
                 pass
             self.conn = None
 
-    def __enter__(self):
+    def __enter__(self) -> TaskTracker:
+        """Return this tracker for context-manager use."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool:
+        """Close the SQLite connection when leaving a context-manager block."""
         self.close()
         return False
 
-    def _db_execute(self, query, params=()):
-        return self.conn.execute(query, params)
+    def _db_execute(self, query: str, params: Sequence[Any] = ()) -> sqlite3.Cursor:
+        """Execute a SQL statement using the active connection."""
+        return cast(sqlite3.Connection, self.conn).execute(query, params)
 
-    def _execute_with_retry(self, query, params=(), max_retries=5):
+    def _execute_with_retry(
+        self, query: str, params: Sequence[Any] = (), max_retries: int = 5
+    ) -> sqlite3.Cursor:
+        """Execute a statement, retrying transient SQLite/Lustre failures."""
         # Retries on two transient Lustre errors:
         # - "database is locked": another process holds the write lock
         # - "disk I/O error": Lustre metadata server EIO under high concurrency
@@ -199,7 +248,7 @@ class TaskTracker:
         _TRANSIENT = ("database is locked", "disk I/O error")
         for attempt in range(max_retries):
             try:
-                with self.conn:
+                with cast(sqlite3.Connection, self.conn):
                     return self._db_execute(query, params)
             except sqlite3.OperationalError as e:
                 if (

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 import importlib.metadata as importlib_metadata
 import json
 import logging
 import re
 import warnings
+from collections.abc import ItemsView, Iterator, KeysView, Mapping, ValuesView
 from datetime import timedelta
 from importlib.resources import files
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import cftime
 import numpy as np
@@ -312,12 +315,26 @@ def get_monthly_ocean_files(
 
 
 class VariableMapping:
-    """
-    A wrapper class for variable mappings that provides enhanced display functionality
-    for Jupyter notebooks and better user experience.
+    """Dictionary-like wrapper for a CMOR variable mapping.
+
+    ``VariableMapping`` preserves normal mapping access while adding concise
+    text and rich HTML representations for notebooks. It is returned by the
+    public ``ACCESS_ESM_CMORiser.variable_mapping`` helper so users can inspect
+    how a CMIP variable maps to ACCESS model output fields.
+
+    Args:
+        mapping_dict: Raw mapping dictionary keyed by CMOR variable name.
+        compound_name: CMIP compound name, usually ``"<table>.<variable>"``.
+        model_id: ACCESS model identifier. Defaults to ``"ACCESS-ESM1.6"``
+            when omitted.
     """
 
-    def __init__(self, mapping_dict: Dict, compound_name: str, model_id: str = None):
+    def __init__(
+        self,
+        mapping_dict: Mapping[str, Any],
+        compound_name: str,
+        model_id: str | None = None,
+    ) -> None:
         self._mapping = mapping_dict
         self.compound_name = compound_name
         self.model_id = model_id or "ACCESS-ESM1.6"
@@ -325,38 +342,45 @@ class VariableMapping:
             compound_name.split(".")[1] if "." in compound_name else compound_name
         )
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
+        """Return a raw mapping entry by key."""
         return self._mapping[key]
 
-    def __contains__(self, key):
+    def __contains__(self, key: object) -> bool:
+        """Return whether the raw mapping contains ``key``."""
         return key in self._mapping
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over raw mapping keys."""
         return iter(self._mapping)
 
-    def keys(self):
+    def keys(self) -> KeysView[str]:
+        """Return a view of raw mapping keys."""
         return self._mapping.keys()
 
-    def values(self):
+    def values(self) -> ValuesView[Any]:
+        """Return a view of raw mapping values."""
         return self._mapping.values()
 
-    def items(self):
+    def items(self) -> ItemsView[str, Any]:
+        """Return a view of raw mapping items."""
         return self._mapping.items()
 
-    def get(self, key, default=None):
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return a raw mapping entry, or ``default`` if the key is absent."""
         return self._mapping.get(key, default)
 
     @property
-    def mapping(self):
+    def mapping(self) -> Mapping[str, Any]:
         """Access the raw mapping dictionary."""
         return self._mapping
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if not self._mapping:
             return f"VariableMapping(empty - no mapping found for {self.compound_name})"
         return f"VariableMapping({self.compound_name}, model={self.model_id})"
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Rich HTML display for Jupyter notebooks (xarray-inspired theme)."""
         if not self._mapping:
             return f"""


### PR DESCRIPTION
## Summary
- add runtime-neutral type annotations and docstrings to batch/PBS CMORiser helpers
- document and type TaskTracker lifecycle/status APIs
- annotate VariableMapping dictionary-like access and notebook display helpers
- apply the repo pre-commit formatting workflow

## Validation
- `/home/node/.openclaw/agents/main/agent/codex-home/home/.local/bin/pre-commit run --all-files` — passed
- `HOME=/tmp/moppy-test-home ./.pixi/envs/test/bin/pytest tests/unit/test_tracking.py tests/unit/test_batch_cmoriser.py -q` — 104 passed
- `HOME=/tmp/moppy-test-home ./.pixi/envs/test/bin/pytest tests/unit -q` — 1064 passed, 19 warnings
- `find src/access_moppy tests -path 'src/access_moppy/vocabularies' -prune -o -name '*.py' -print | xargs ./.pixi/envs/test/bin/ruff check` — All checks passed
- `git diff --check` — passed

No vendored/submodule vocabulary material under `src/access_moppy/vocabularies/` was modified.
