### PR TITLE
Add durable batch JSON coordination report

### DIFF
--- a/docs/source/batch_processing.rst
+++ b/docs/source/batch_processing.rst
@@ -309,14 +309,42 @@ changes to make the DB total explicit, e.g.
    # one-shot snapshot for cron / email / logs
    moppy-tui --once --page 2 --page-size 20
 
-   # machine-readable JSON for jq / scripts
+   # machine-readable JSON snapshot for jq / scripts
    moppy-tui --json | jq '.summary'
+
+   # durable batch coordination report from an existing tracker DB
+   moppy-batch-report --db <output_folder>/cmor_tasks.db
+
+   # write the report somewhere explicit
+   moppy-batch-report --db <output_folder>/cmor_tasks.db --output batch_report.json
 
    # disable colour for log capture
    moppy-tui --once --no-color | tee progress.log
 
 The ``--once`` and ``--json`` modes never block on stdin, so they are safe
 in pipelines and cron jobs.
+
+**Durable JSON coordination report**
+
+When the batch monitor finalises, ACCESS-MOPPy writes a durable coordination
+report next to the tracker database:
+
+.. code-block:: text
+
+   <output_folder>/moppy_batch_report.json
+
+The SQLite database remains the source of truth for coordination; the JSON
+report is a schema-versioned export for after-the-fact completion checks,
+provenance capture, and later loading into dashboards or databases.  It
+contains summary counts, final success/terminal-state flags, monitor metadata,
+per-task status/timing/PBS job IDs, log paths, and bounded failure details.
+
+Existing tracker databases can be exported manually:
+
+.. code-block:: bash
+
+   moppy-batch-report --db <output_folder>/cmor_tasks.db
+
 
 **When to use which dashboard:**
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -399,7 +399,16 @@ The batch system includes several monitoring tools:
    - Task status for each variable
    - Start and completion times
    - Error messages for failed tasks
-   - Experiment metadata
+   - PBS job IDs and experiment metadata
+
+   At monitor finalisation it also writes
+   `{output_folder}/moppy_batch_report.json`, a schema-versioned JSON export
+   of the tracker state for after-the-fact completion checks and provenance.
+   You can regenerate this report later with:
+
+   .. code-block:: bash
+
+      moppy-batch-report --db <output_folder>/cmor_tasks.db
 
 File Organization
 -----------------
@@ -418,6 +427,7 @@ The batch system organizes files as follows:
    │   └── ...
    └── output_folder/                      # Your specified output directory
        ├── cmor_tasks.db                   # Progress tracking database
+       ├── moppy_batch_report.json         # Final JSON coordination report
        └── CMIP6/                          # CMORised output files (if drs_root specified)
            └── CMIP/
                └── ACCESS-NRI/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ docs = [
 moppy-cmorise = "access_moppy.batch_cmoriser:main"
 moppy-dashboard = "access_moppy.dashboard.cmor_dashboard:main"
 moppy-tui = "access_moppy.dashboard.cli_dashboard:main"
+moppy-batch-report = "access_moppy.batch_report:main"
 moppy-example-config = "access_moppy.examples.show_config:main"
 moppy-calc-ab-coeffts = "access_moppy.legacy_utilities.calc_hybrid_height_coeffs:main"
 moppy-esmval-prepare = "access_moppy.esmval.cli_commands:main_prepare"

--- a/src/access_moppy/batch_cmoriser.py
+++ b/src/access_moppy/batch_cmoriser.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import yaml
 
+from access_moppy.batch_report import write_batch_report
 from access_moppy.tracking import TaskTracker
 
 # Sidecar file dropped in output_folder so the dashboard / a successor monitor
@@ -573,7 +574,14 @@ def monitor_main() -> None:
 
         if not job_map:
             print("No sub-jobs to monitor.")
-            finalize_monitor(tracker, config, experiment_id, db_path)
+            finalize_monitor(
+                tracker,
+                config,
+                experiment_id,
+                db_path,
+                config_path=config_path,
+                script_dir=script_dir,
+            )
             return
 
         def shutdown_handler(sig: int, _frame: object) -> None:
@@ -601,7 +609,14 @@ def monitor_main() -> None:
         signal.signal(signal.SIGTERM, shutdown_handler)
 
         monitor_loop(tracker, job_map, experiment_id, script_dir)
-        finalize_monitor(tracker, config, experiment_id, db_path)
+        finalize_monitor(
+            tracker,
+            config,
+            experiment_id,
+            db_path,
+            config_path=config_path,
+            script_dir=script_dir,
+        )
     finally:
         tracker.close()
 
@@ -641,6 +656,9 @@ def finalize_monitor(
     config: BatchConfig,
     experiment_id: str,
     db_path: str | Path,
+    *,
+    config_path: str | Path | None = None,
+    script_dir: str | Path | None = None,
 ) -> None:
     """Run a last-pass consistency check, print a summary, remove the sidecar.
 
@@ -676,6 +694,19 @@ def finalize_monitor(
         f"Batch monitor done. completed={summary['completed']}, "
         f"failed={summary['failed']}, fixed_stuck={summary['fixed_stuck']}"
     )
+
+    try:
+        report_path = write_batch_report(
+            db_path,
+            config=config,
+            config_path=config_path,
+            script_dir=script_dir,
+        )
+        print(f"Wrote batch coordination report: {report_path}")
+    except Exception as e:
+        print(
+            f"Warning: failed to write batch coordination report: {e}", file=sys.stderr
+        )
 
     sidecar = Path(db_path).parent / SIDECAR_FILENAME
     try:

--- a/src/access_moppy/batch_report.py
+++ b/src/access_moppy/batch_report.py
@@ -1,0 +1,276 @@
+"""Durable JSON reports for ACCESS-MOPPy batch coordination."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "access-moppy.batch-report.v1"
+REPORT_FILENAME = "moppy_batch_report.json"
+SIDECAR_FILENAME = ".moppy_main.jobid"
+TERMINAL_STATUSES = {"completed", "failed"}
+KNOWN_STATUSES = ("completed", "failed", "running", "pending", "retrying")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _duration_seconds(start: str | None, end: str | None) -> float | None:
+    start_dt = _parse_datetime(start)
+    end_dt = _parse_datetime(end)
+    if start_dt is None or end_dt is None:
+        return None
+    return (end_dt - start_dt).total_seconds()
+
+
+def _read_monitor_sidecar(output_folder: Path) -> dict[str, str | None]:
+    sidecar = output_folder / SIDECAR_FILENAME
+    if not sidecar.exists():
+        return {"pbs_job_id": None, "submitted_at": None}
+    lines = sidecar.read_text(encoding="utf-8").splitlines()
+    return {
+        "pbs_job_id": lines[0].strip() if lines and lines[0].strip() else None,
+        "submitted_at": lines[1].strip()
+        if len(lines) > 1 and lines[1].strip()
+        else None,
+    }
+
+
+def _log_path(path: Path) -> str | None:
+    return str(path) if path.exists() else str(path)
+
+
+def _task_log_paths(script_dir: Path | None, variable: str) -> dict[str, str | None]:
+    if script_dir is None:
+        return {"stdout": None, "stderr": None}
+    safe_variable = variable.replace(".", "_")
+    var_dir = script_dir / safe_variable
+    return {
+        "stdout": _log_path(var_dir / f"cmor_{safe_variable}.out"),
+        "stderr": _log_path(var_dir / f"cmor_{safe_variable}.err"),
+    }
+
+
+def _monitor_log_paths(script_dir: Path | None) -> dict[str, str | None]:
+    if script_dir is None:
+        return {"stdout": None, "stderr": None}
+    return {
+        "stdout": _log_path(script_dir / "moppy_monitor.out"),
+        "stderr": _log_path(script_dir / "moppy_monitor.err"),
+    }
+
+
+def _stderr_tail(stderr_path: str | None, max_lines: int) -> str | None:
+    if not stderr_path or max_lines <= 0:
+        return None
+    path = Path(stderr_path)
+    if not path.exists():
+        return None
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    return "\n".join(lines[-max_lines:]) if lines else None
+
+
+def _classify_status(summary: Mapping[str, int]) -> tuple[str, bool, bool]:
+    total = summary.get(
+        "total", sum(count for status, count in summary.items() if status != "total")
+    )
+    nonterminal = sum(
+        count
+        for status, count in summary.items()
+        if status != "total" and status not in TERMINAL_STATUSES
+    )
+    failed = summary.get("failed", 0)
+    all_terminal = total == 0 or nonterminal == 0
+    if not all_terminal:
+        return "incomplete", False, False
+    if failed:
+        return "failed", False, True
+    return "completed", True, True
+
+
+def _load_task_rows(db_path: Path) -> list[sqlite3.Row]:
+    uri = f"file:{db_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=5)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            """
+            SELECT id, variable, experiment_id, status, start_time, end_time,
+                   error_message, pbs_job_id
+            FROM cmor_tasks
+            ORDER BY id
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def build_batch_report(
+    db_path: str | Path,
+    *,
+    config: Mapping[str, Any] | None = None,
+    config_path: str | Path | None = None,
+    output_folder: str | Path | None = None,
+    script_dir: str | Path | None = None,
+    created_at: str | None = None,
+    completed_at: str | None = None,
+    stderr_tail_lines: int = 20,
+) -> dict[str, Any]:
+    """Build a JSON-serialisable batch coordination report.
+
+    SQLite remains the source of truth; this report is a derived snapshot for
+    after-the-fact completion checks, provenance capture, and dashboard/database
+    ingestion.
+    """
+    db_path = Path(db_path)
+    output_path = Path(output_folder) if output_folder is not None else db_path.parent
+    script_path = Path(script_dir) if script_dir is not None else None
+    config_path_str = str(config_path) if config_path is not None else None
+    now = created_at or _utc_now_iso()
+
+    rows = _load_task_rows(db_path)
+    summary = {status: 0 for status in KNOWN_STATUSES}
+    for row in rows:
+        summary[row["status"]] = summary.get(row["status"], 0) + 1
+    summary["total"] = len(rows)
+
+    status, success, all_terminal = _classify_status(summary)
+    final_completed_at = completed_at if all_terminal else None
+    if all_terminal and final_completed_at is None:
+        final_completed_at = now
+
+    tasks: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for row in rows:
+        logs = _task_log_paths(script_path, row["variable"])
+        task = {
+            "id": row["id"],
+            "variable": row["variable"],
+            "experiment_id": row["experiment_id"],
+            "status": row["status"],
+            "start_time": row["start_time"],
+            "end_time": row["end_time"],
+            "duration_seconds": _duration_seconds(row["start_time"], row["end_time"]),
+            "pbs_job_id": row["pbs_job_id"],
+            "stdout": logs["stdout"],
+            "stderr": logs["stderr"],
+            "error_message": row["error_message"],
+        }
+        tasks.append(task)
+        if row["status"] == "failed":
+            failure = {
+                "variable": row["variable"],
+                "experiment_id": row["experiment_id"],
+                "pbs_job_id": row["pbs_job_id"],
+                "error_message": row["error_message"],
+                "stderr": logs["stderr"],
+                "stderr_tail": _stderr_tail(logs["stderr"], stderr_tail_lines),
+            }
+            failures.append(failure)
+
+    monitor = _read_monitor_sidecar(output_path)
+    monitor.update(_monitor_log_paths(script_path))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": now,
+        "completed_at": final_completed_at,
+        "status": status,
+        "success": success,
+        "all_tasks_terminal": all_terminal,
+        "db_path": str(db_path),
+        "config_path": config_path_str,
+        "output_folder": str(output_path),
+        "script_dir": str(script_path) if script_path is not None else None,
+        "experiment_id": config.get("experiment_id") if config else None,
+        "summary": summary,
+        "monitor": monitor,
+        "tasks": tasks,
+        "failures": failures,
+    }
+
+
+def write_batch_report(
+    db_path: str | Path,
+    output_path: str | Path | None = None,
+    **kwargs: Any,
+) -> Path:
+    """Write a durable batch report and return the report path."""
+    db_path = Path(db_path)
+    report_path = (
+        Path(output_path)
+        if output_path is not None
+        else db_path.parent / REPORT_FILENAME
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report = build_batch_report(db_path, **kwargs)
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return report_path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="moppy-batch-report",
+        description="Export an ACCESS-MOPPy batch tracker database to JSON.",
+    )
+    parser.add_argument("--db", required=True, help="Path to cmor_tasks.db.")
+    parser.add_argument(
+        "--output",
+        help="Report path. Defaults to <db parent>/moppy_batch_report.json.",
+    )
+    parser.add_argument("--config", help="Original batch configuration path.")
+    parser.add_argument(
+        "--script-dir", help="Directory containing generated PBS scripts/logs."
+    )
+    parser.add_argument(
+        "--stderr-tail-lines",
+        type=int,
+        default=20,
+        help="Number of stderr tail lines to include for failed tasks (default: 20).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for exporting a batch report."""
+    args = _build_parser().parse_args(argv)
+    config = None
+    if args.config:
+        import yaml
+
+        with Path(args.config).open() as f:
+            config = yaml.safe_load(f)
+    report_path = write_batch_report(
+        args.db,
+        args.output,
+        config=config,
+        config_path=args.config,
+        script_dir=args.script_dir,
+        stderr_tail_lines=args.stderr_tail_lines,
+    )
+    print(report_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_batch_report.py
+++ b/tests/unit/test_batch_report.py
@@ -1,0 +1,174 @@
+"""Unit tests for durable batch JSON report generation."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from access_moppy import batch_report
+from access_moppy.batch_cmoriser import SIDECAR_FILENAME, finalize_monitor
+from access_moppy.tracking import TaskTracker
+
+
+def _seed_mixed_db(db_path: Path, script_dir: Path) -> None:
+    with TaskTracker(db_path) as tracker:
+        for variable in ("Amon.tas", "Amon.pr", "Omon.tos"):
+            tracker.add_task(variable, "historical")
+        tracker.set_pbs_job_id("Amon.tas", "historical", "123.gadi-pbs")
+        tracker.set_pbs_job_id("Amon.pr", "historical", "124.gadi-pbs")
+        tracker.set_pbs_job_id("Omon.tos", "historical", "125.gadi-pbs")
+
+    start = datetime(2026, 6, 4, 1, 0, 0)
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(
+            "UPDATE cmor_tasks SET status='completed', start_time=?, end_time=? "
+            "WHERE variable='Amon.tas'",
+            (
+                start.isoformat(timespec="seconds"),
+                (start + timedelta(seconds=90)).isoformat(timespec="seconds"),
+            ),
+        )
+        conn.execute(
+            "UPDATE cmor_tasks SET status='failed', start_time=?, end_time=?, "
+            "error_message=? WHERE variable='Amon.pr'",
+            (
+                start.isoformat(timespec="seconds"),
+                (start + timedelta(seconds=30)).isoformat(timespec="seconds"),
+                "input missing",
+            ),
+        )
+        conn.execute(
+            "UPDATE cmor_tasks SET status='running', start_time=? "
+            "WHERE variable='Omon.tos'",
+            ((start + timedelta(seconds=10)).isoformat(timespec="seconds"),),
+        )
+    conn.close()
+
+    err_dir = script_dir / "Amon_pr"
+    err_dir.mkdir(parents=True)
+    (err_dir / "cmor_Amon_pr.err").write_text("line1\nline2\nline3\n")
+
+
+def test_build_batch_report_mixed_statuses(tmp_path: Path) -> None:
+    db_path = tmp_path / "cmor_tasks.db"
+    script_dir = tmp_path / "cmor_job_scripts"
+    _seed_mixed_db(db_path, script_dir)
+    (tmp_path / SIDECAR_FILENAME).write_text("999.gadi-pbs\n2026-06-04T00:00:00\n")
+
+    report = batch_report.build_batch_report(
+        db_path,
+        config={"experiment_id": "historical"},
+        config_path=tmp_path / "batch_config.yml",
+        script_dir=script_dir,
+        created_at="2026-06-04T02:00:00+00:00",
+        stderr_tail_lines=2,
+    )
+
+    assert report["schema_version"] == "access-moppy.batch-report.v1"
+    assert report["status"] == "incomplete"
+    assert report["success"] is False
+    assert report["all_tasks_terminal"] is False
+    assert report["completed_at"] is None
+    assert report["summary"] == {
+        "completed": 1,
+        "failed": 1,
+        "running": 1,
+        "pending": 0,
+        "retrying": 0,
+        "total": 3,
+    }
+    assert report["monitor"]["pbs_job_id"] == "999.gadi-pbs"
+    assert report["monitor"]["submitted_at"] == "2026-06-04T00:00:00"
+    completed = next(t for t in report["tasks"] if t["variable"] == "Amon.tas")
+    assert completed["duration_seconds"] == 90.0
+    assert completed["pbs_job_id"] == "123.gadi-pbs"
+    failure = report["failures"][0]
+    assert failure["variable"] == "Amon.pr"
+    assert failure["stderr_tail"] == "line2\nline3"
+
+
+@pytest.mark.parametrize(
+    ("statuses", "expected_status", "success", "all_terminal"),
+    [
+        (["completed", "completed"], "completed", True, True),
+        (["completed", "failed"], "failed", False, True),
+        (["completed", "pending"], "incomplete", False, False),
+    ],
+)
+def test_report_status_classification(
+    tmp_path: Path,
+    statuses: list[str],
+    expected_status: str,
+    success: bool,
+    all_terminal: bool,
+) -> None:
+    db_path = tmp_path / "cmor_tasks.db"
+    with TaskTracker(db_path) as tracker:
+        for idx, status in enumerate(statuses):
+            variable = f"Amon.var{idx}"
+            tracker.add_task(variable, "historical")
+            if status == "completed":
+                tracker.mark_completed(variable, "historical")
+            elif status == "failed":
+                tracker.mark_failed(variable, "historical", "boom")
+
+    report = batch_report.build_batch_report(
+        db_path, created_at="2026-06-04T02:00:00+00:00"
+    )
+
+    assert report["status"] == expected_status
+    assert report["success"] is success
+    assert report["all_tasks_terminal"] is all_terminal
+    assert (report["completed_at"] is not None) is all_terminal
+
+
+def test_write_batch_report_and_cli(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path = tmp_path / "cmor_tasks.db"
+    with TaskTracker(db_path) as tracker:
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_completed("Amon.tas", "historical")
+
+    report_path = tmp_path / "report.json"
+    written = batch_report.write_batch_report(db_path, report_path)
+    assert written == report_path
+    payload = json.loads(report_path.read_text())
+    assert payload["summary"]["completed"] == 1
+
+    cli_path = tmp_path / "cli-report.json"
+    rc = batch_report.main(["--db", str(db_path), "--output", str(cli_path)])
+    assert rc == 0
+    assert str(cli_path) in capsys.readouterr().out
+    assert json.loads(cli_path.read_text())["tasks"][0]["variable"] == "Amon.tas"
+
+
+def test_finalize_monitor_writes_report_before_removing_sidecar(tmp_path: Path) -> None:
+    db_path = tmp_path / "cmor_tasks.db"
+    script_dir = tmp_path / "cmor_job_scripts"
+    script_dir.mkdir()
+    (tmp_path / SIDECAR_FILENAME).write_text("monitor.123\n2026-06-04T00:00:00\n")
+
+    with TaskTracker(db_path) as tracker:
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_completed("Amon.tas", "historical")
+        finalize_monitor(
+            tracker,
+            {"variables": ["Amon.tas"], "experiment_id": "historical"},
+            "historical",
+            db_path,
+            config_path=tmp_path / "batch_config.yml",
+            script_dir=script_dir,
+        )
+
+    assert not (tmp_path / SIDECAR_FILENAME).exists()
+    report = json.loads((tmp_path / "moppy_batch_report.json").read_text())
+    assert report["status"] == "completed"
+    assert report["success"] is True
+    assert report["monitor"]["pbs_job_id"] == "monitor.123"
+    assert report["script_dir"] == str(script_dir)


### PR DESCRIPTION
## Summary
- add `access_moppy.batch_report` for schema-versioned durable batch coordination reports
- write `{output_folder}/moppy_batch_report.json` from monitor finalisation while keeping SQLite as source of truth
- add `moppy-batch-report` CLI for regenerating/exporting reports from existing `cmor_tasks.db` files
- document the report artifact and add unit coverage for report generation, classification, writing, CLI export, and finalisation integration

Closes #418.

## Validation
- `/home/node/.openclaw/agents/main/agent/codex-home/home/.local/bin/pre-commit run --all-files` — passed
- `HOME=/tmp/moppy-test-home ./.pixi/envs/test/bin/pytest tests/unit/test_batch_report.py tests/unit/test_batch_cmoriser.py tests/unit/test_cli_dashboard.py -q` — 107 passed
- `HOME=/tmp/moppy-test-home ./.pixi/envs/test/bin/pytest tests/unit -q` — 1070 passed, 19 warnings
- `find src/access_moppy tests -path 'src/access_moppy/vocabularies' -prune -o -name '*.py' -print | xargs ./.pixi/envs/test/bin/ruff check` — All checks passed
- `git diff --check` — passed

Note: the repo-supported pre-commit command is `pixi run -e dev pre-commit run --all-files`, but `pixi` is not available in this shell, so I used the installed pre-commit executable directly against `.pre-commit-config.yaml`.
