### PR TITLE
Capture structured PBS metadata in batch reports

### DIFF
--- a/docs/source/batch_processing.rst
+++ b/docs/source/batch_processing.rst
@@ -338,6 +338,13 @@ report is a schema-versioned export for after-the-fact completion checks,
 provenance capture, and later loading into dashboards or databases.  It
 contains summary counts, final success/terminal-state flags, monitor metadata,
 per-task status/timing/PBS job IDs, log paths, and bounded failure details.
+When PBS history is still available, each task also includes a filtered
+``pbs`` object with Payu-style scheduler provenance such as final job state,
+exit status, queue/project, timestamps, requested resources, and resources
+used.  ACCESS-MOPPy deliberately does not dump unbounded PBS fields such as
+submit arguments or stdout/stderr content; reports can still contain NCI
+project names, hostnames, job IDs, and filesystem paths, so treat them as
+operational provenance rather than public artefacts.
 
 Existing tracker databases can be exported manually:
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -404,6 +404,9 @@ The batch system includes several monitoring tools:
    At monitor finalisation it also writes
    `{output_folder}/moppy_batch_report.json`, a schema-versioned JSON export
    of the tracker state for after-the-fact completion checks and provenance.
+   When available, the report includes filtered structured PBS metadata for
+   each sub-job, including exit status, queue/project, requested resources,
+   and resources used.
    You can regenerate this report later with:
 
    .. code-block:: bash

--- a/src/access_moppy/batch_cmoriser.py
+++ b/src/access_moppy/batch_cmoriser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import signal
@@ -23,7 +24,7 @@ SIDECAR_FILENAME = ".moppy_main.jobid"
 # How often the monitor polls PBS for sub-job state. 30s keeps qstat load low
 # while still detecting OOM kills within a poll cycle.
 MONITOR_POLL_INTERVAL_SECONDS = 30
-QstatInfo = dict[str, str]
+QstatInfo = dict[str, Any]
 BatchConfig = Mapping[str, Any]
 
 
@@ -72,8 +73,120 @@ def compute_monitor_walltime(config: BatchConfig) -> str:
     return format_walltime(longest + 30 * 60)
 
 
-def qstat_full(job_id: str) -> QstatInfo | None:
-    """Run `qstat -fx <job_id>` and parse the result into a dict.
+PBS_JOB_FIELDS = (
+    "job_state",
+    "Exit_status",
+    "queue",
+    "project",
+    "Account_Name",
+    "exec_host",
+    "exec_vnode",
+    "comment",
+    "ctime",
+    "etime",
+    "qtime",
+    "stime",
+    "mtime",
+)
+PBS_RESOURCES_USED_FIELDS = (
+    "cpupercent",
+    "cput",
+    "mem",
+    "ncpus",
+    "vmem",
+    "walltime",
+)
+PBS_RESOURCE_LIST_FIELDS = (
+    "jobfs",
+    "mem",
+    "mpiprocs",
+    "ncpus",
+    "storage",
+    "walltime",
+)
+PBS_FLAT_FIELDS = (
+    *PBS_JOB_FIELDS,
+    *(f"resources_used.{field}" for field in PBS_RESOURCES_USED_FIELDS),
+    *(f"Resource_List.{field}" for field in PBS_RESOURCE_LIST_FIELDS),
+)
+
+
+def _parse_qstat_json(stdout: str, job_id: str) -> QstatInfo | None:
+    """Parse filtered PBS JSON qstat output for one job.
+
+    PBS JSON contains many fields, including paths, submit arguments, and user
+    information. MOPPy keeps a deliberately small Payu-style subset that is
+    useful for resource/provenance reporting without dumping the entire record.
+    """
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    jobs = payload.get("Jobs")
+    if not isinstance(jobs, dict) or not jobs:
+        return None
+
+    selected_job_id = str(job_id)
+    job_info = jobs.get(selected_job_id)
+    if not isinstance(job_info, dict):
+        # PBS can key the job as either "123" or "123.gadi-pbs" depending on
+        # command/server context; fall back to the only record when present.
+        selected_job_id, job_info = next(iter(jobs.items()))
+        if not isinstance(job_info, dict):
+            return None
+
+    info: QstatInfo = {
+        "scheduler": "pbs",
+        "qstat_format": "json",
+        "job_id": selected_job_id,
+    }
+    for key in ("pbs_version", "pbs_server"):
+        value = payload.get(key)
+        if value is not None:
+            info[key] = value
+    for key in PBS_JOB_FIELDS:
+        value = job_info.get(key)
+        if value is not None:
+            info[key] = value
+
+    resources_used = job_info.get("resources_used")
+    if isinstance(resources_used, dict):
+        for key in PBS_RESOURCES_USED_FIELDS:
+            value = resources_used.get(key)
+            if value is not None:
+                info[f"resources_used.{key}"] = value
+
+    resource_list = job_info.get("Resource_List")
+    if isinstance(resource_list, dict):
+        for key in PBS_RESOURCE_LIST_FIELDS:
+            value = resource_list.get(key)
+            if value is not None:
+                info[f"Resource_List.{key}"] = value
+
+    return info
+
+
+def _qstat_full_json(job_id: str) -> QstatInfo | None:
+    """Run `qstat -xf -F json <job_id>` and parse filtered PBS metadata."""
+    try:
+        result = subprocess.run(  # noqa: S603  # nosec B603
+            ["qstat", "-xf", "-F", "json", str(job_id)],
+            capture_output=True,
+            text=True,
+            check=False,
+            shell=False,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return _parse_qstat_json(result.stdout, job_id)
+
+
+def _qstat_full_text(job_id: str) -> QstatInfo | None:
+    """Run `qstat -fx <job_id>` and parse legacy text output.
 
     Returns None on timeout, missing binary, or empty output (the latter
     happens once a job has been purged from PBS history). PBS Pro wraps long
@@ -95,10 +208,19 @@ def qstat_full(job_id: str) -> QstatInfo | None:
     if result.returncode != 0 or not result.stdout.strip():
         return None
 
-    info: QstatInfo = {}
+    parsed: QstatInfo = {}
+    info: QstatInfo = {
+        "scheduler": "pbs",
+        "qstat_format": "text",
+        "job_id": str(job_id),
+    }
     current_key = None
     for raw in result.stdout.splitlines():
         if not raw or raw.startswith("Job Id:"):
+            if raw.startswith("Job Id:"):
+                _, _, parsed_job_id = raw.partition(":")
+                if parsed_job_id.strip():
+                    info["job_id"] = parsed_job_id.strip()
             current_key = None
             continue
         if (
@@ -106,13 +228,27 @@ def qstat_full(job_id: str) -> QstatInfo | None:
             and "=" not in raw
             and current_key
         ):
-            info[current_key] += raw.strip()
+            parsed[current_key] += raw.strip()
             continue
         if "=" in raw:
             key, _, val = raw.partition("=")
             current_key = key.strip()
-            info[current_key] = val.strip()
+            parsed[current_key] = val.strip()
+    for key in PBS_FLAT_FIELDS:
+        value = parsed.get(key)
+        if value is not None:
+            info[key] = value
     return info
+
+
+def qstat_full(job_id: str) -> QstatInfo | None:
+    """Return filtered final PBS metadata for a job.
+
+    Prefer PBS' JSON output, matching Payu's telemetry implementation. Fall
+    back to the older text parser on systems where `qstat -F json` is missing
+    or returns unparsable output.
+    """
+    return _qstat_full_json(job_id) or _qstat_full_text(job_id)
 
 
 def qstat_state(info: QstatInfo | None) -> str:
@@ -124,7 +260,8 @@ def qstat_state(info: QstatInfo | None) -> str:
     """
     if not info:
         return "gone"
-    return info.get("job_state", "gone")
+    state = info.get("job_state", "gone")
+    return str(state)
 
 
 def format_pbs_error(
@@ -197,6 +334,7 @@ def reconcile_one(
       a message built from qstat plus the worker's stderr tail.
     - DB already in a terminal state: leave it alone — the worker beat us.
     """
+    tracker.set_pbs_info(variable, experiment_id, info)
     current = tracker.get_status(variable, experiment_id)
     exit_raw = info.get("Exit_status") if info else None
     try:

--- a/src/access_moppy/batch_report.py
+++ b/src/access_moppy/batch_report.py
@@ -111,16 +111,106 @@ def _load_task_rows(db_path: Path) -> list[sqlite3.Row]:
     conn = sqlite3.connect(uri, uri=True, timeout=5)
     conn.row_factory = sqlite3.Row
     try:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(cmor_tasks)").fetchall()
+        }
+        pbs_job_id_expr = (
+            "pbs_job_id" if "pbs_job_id" in columns else "NULL AS pbs_job_id"
+        )
+        pbs_info_expr = (
+            "pbs_info_json" if "pbs_info_json" in columns else "NULL AS pbs_info_json"
+        )
         return conn.execute(
-            """
+            f"""
             SELECT id, variable, experiment_id, status, start_time, end_time,
-                   error_message, pbs_job_id
+                   error_message, {pbs_job_id_expr}, {pbs_info_expr}
             FROM cmor_tasks
             ORDER BY id
-            """
+            """  # noqa: S608  # PBS expressions are chosen from constants above
         ).fetchall()
     finally:
         conn.close()
+
+
+def _parse_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_pbs_info(value: str | None) -> dict[str, Any] | None:
+    if not value:
+        return None
+    try:
+        loaded = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _compact_dict(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a dict with null/empty nested values removed."""
+    compact: dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, Mapping):
+            nested = _compact_dict(value)
+            if nested:
+                compact[key] = nested
+        elif value is not None:
+            compact[key] = value
+    return compact
+
+
+def _prefixed_values(info: Mapping[str, Any], prefix: str) -> dict[str, Any]:
+    prefix_dot = f"{prefix}."
+    return {
+        key.removeprefix(prefix_dot): value
+        for key, value in info.items()
+        if key.startswith(prefix_dot)
+    }
+
+
+def _pbs_report(
+    info: Mapping[str, Any] | None, job_id: str | None
+) -> dict[str, Any] | None:
+    """Build the filtered PBS object written into the batch report.
+
+    The report intentionally avoids unbounded PBS fields such as submit
+    arguments. ``raw_qstat`` is a filtered subset persisted by the monitor, not
+    the full scheduler response.
+    """
+    if info is None:
+        return None
+
+    pbs = {
+        "scheduler": info.get("scheduler", "pbs"),
+        "job_id": info.get("job_id", job_id),
+        "job_state": info.get("job_state"),
+        "exit_status": _parse_int(info.get("Exit_status")),
+        "queue": info.get("queue"),
+        "account": info.get("Account_Name") or info.get("account"),
+        "project": info.get("project"),
+        "pbs_server": info.get("pbs_server"),
+        "pbs_version": info.get("pbs_version"),
+        "timestamps": {
+            "created_at": info.get("ctime"),
+            "eligible_at": info.get("etime"),
+            "queued_at": info.get("qtime"),
+            "started_at": info.get("stime"),
+            "modified_at": info.get("mtime"),
+        },
+        "resources_requested": _prefixed_values(info, "Resource_List"),
+        "resources_used": _prefixed_values(info, "resources_used"),
+        "exec_host": info.get("exec_host"),
+        "exec_vnode": info.get("exec_vnode"),
+        "comment": info.get("comment"),
+        "qstat_format": info.get("qstat_format"),
+        "raw_qstat": dict(info),
+    }
+    return _compact_dict(pbs)
 
 
 def build_batch_report(
@@ -161,6 +251,7 @@ def build_batch_report(
     failures: list[dict[str, Any]] = []
     for row in rows:
         logs = _task_log_paths(script_path, row["variable"])
+        pbs = _pbs_report(_load_pbs_info(row["pbs_info_json"]), row["pbs_job_id"])
         task = {
             "id": row["id"],
             "variable": row["variable"],
@@ -170,6 +261,7 @@ def build_batch_report(
             "end_time": row["end_time"],
             "duration_seconds": _duration_seconds(row["start_time"], row["end_time"]),
             "pbs_job_id": row["pbs_job_id"],
+            "pbs": pbs,
             "stdout": logs["stdout"],
             "stderr": logs["stderr"],
             "error_message": row["error_message"],

--- a/src/access_moppy/tracking.py
+++ b/src/access_moppy/tracking.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 import random
 import sqlite3
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import TracebackType
 from typing import Any, Literal, cast
@@ -70,7 +71,8 @@ class TaskTracker:
                             start_time TEXT,
                             end_time TEXT,
                             error_message TEXT,
-                            pbs_job_id TEXT
+                            pbs_job_id TEXT,
+                            pbs_info_json TEXT
                         )
                         """
                     )
@@ -88,6 +90,10 @@ class TaskTracker:
                     if "pbs_job_id" not in existing:
                         self.conn.execute(
                             "ALTER TABLE cmor_tasks ADD COLUMN pbs_job_id TEXT"
+                        )
+                    if "pbs_info_json" not in existing:
+                        self.conn.execute(
+                            "ALTER TABLE cmor_tasks ADD COLUMN pbs_info_json TEXT"
                         )
                 return
             except sqlite3.OperationalError as e:
@@ -187,6 +193,45 @@ class TaskTracker:
         )
         row = cur.fetchone()
         return row[0] if row is not None else None
+
+    def set_pbs_info(
+        self,
+        variable: str,
+        experiment_id: str,
+        info: Mapping[str, Any] | None,
+    ) -> None:
+        """Store structured PBS metadata for a task.
+
+        Args:
+            variable: CMOR variable name or compound variable identifier.
+            experiment_id: Experiment identifier associated with the task.
+            info: Filtered PBS metadata from ``qstat``. ``None`` clears the
+                stored metadata.
+        """
+        payload = (
+            None
+            if info is None
+            else json.dumps(dict(info), sort_keys=True, separators=(",", ":"))
+        )
+        self._execute_with_retry(
+            "UPDATE cmor_tasks SET pbs_info_json=? WHERE variable=? AND experiment_id=?",
+            (payload, variable, experiment_id),
+        )
+
+    def get_pbs_info(self, variable: str, experiment_id: str) -> dict[str, Any] | None:
+        """Return structured PBS metadata for a task, if present."""
+        cur = self._execute_with_retry(
+            "SELECT pbs_info_json FROM cmor_tasks WHERE variable=? AND experiment_id=?",
+            (variable, experiment_id),
+        )
+        row = cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        try:
+            loaded = json.loads(row[0])
+        except json.JSONDecodeError:
+            return None
+        return loaded if isinstance(loaded, dict) else None
 
     def list_unfinished(
         self, experiment_id: str

--- a/tests/unit/test_batch_cmoriser.py
+++ b/tests/unit/test_batch_cmoriser.py
@@ -521,9 +521,73 @@ class TestQstatHelpers:
         "    resources_used.mem = 186465316kb\n"
         "    resources_used.walltime = 00:34:18\n"
     )
+    SAMPLE_QSTAT_JSON = """
+    {
+      "pbs_version": "2022.1.3",
+      "pbs_server": "gadi-pbs",
+      "Jobs": {
+        "12345.gadi-pbs": {
+          "job_state": "F",
+          "Exit_status": 0,
+          "queue": "normal",
+          "project": "tm70",
+          "Account_Name": "tm70",
+          "exec_host": "gadi-cpu-clx-0001/0*4",
+          "comment": "Job run",
+          "ctime": "Thu Jun 04 01:00:00 2026",
+          "etime": "Thu Jun 04 01:00:01 2026",
+          "qtime": "Thu Jun 04 01:00:02 2026",
+          "stime": "Thu Jun 04 01:01:00 2026",
+          "mtime": "Thu Jun 04 01:30:00 2026",
+          "resources_used": {
+            "cpupercent": 95,
+            "cput": "00:25:12",
+            "mem": "6gb",
+            "ncpus": 4,
+            "vmem": "7gb",
+            "walltime": "00:27:03"
+          },
+          "Resource_List": {
+            "jobfs": "100mb",
+            "mem": "8gb",
+            "mpiprocs": 4,
+            "ncpus": 4,
+            "storage": "gdata/tm70+scratch/tm70",
+            "walltime": "00:30:00"
+          },
+          "Submit_arguments": "-P tm70 /path/that/should/not/be/stored"
+        }
+      }
+    }
+    """
 
     @pytest.mark.unit
-    def test_qstat_full_parses_well_formed(self):
+    def test_qstat_full_prefers_json_output(self):
+        result = Mock(returncode=0, stdout=self.SAMPLE_QSTAT_JSON)
+        with patch("subprocess.run", return_value=result):
+            info = qstat_full("12345.gadi-pbs")
+
+        assert info["qstat_format"] == "json"
+        assert info["pbs_server"] == "gadi-pbs"
+        assert info["job_state"] == "F"
+        assert info["Exit_status"] == 0
+        assert info["resources_used.walltime"] == "00:27:03"
+        assert info["Resource_List.mem"] == "8gb"
+        assert "Submit_arguments" not in info
+
+    @pytest.mark.unit
+    def test_qstat_full_falls_back_to_text_parser(self):
+        json_result = Mock(returncode=0, stdout="not json")
+        text_result = Mock(returncode=0, stdout=self.SAMPLE_QSTAT)
+        with patch("subprocess.run", side_effect=[json_result, text_result]):
+            info = qstat_full("12345.gadi-pbs")
+
+        assert info["qstat_format"] == "text"
+        assert info["job_state"] == "F"
+        assert info["Exit_status"] == "271"
+
+    @pytest.mark.unit
+    def test_qstat_full_parses_well_formed_text(self):
         result = Mock(returncode=0, stdout=self.SAMPLE_QSTAT)
         with patch("subprocess.run", return_value=result):
             info = qstat_full("12345.gadi-pbs")
@@ -683,6 +747,7 @@ class TestReconcileOne:
             reconcile_one(tracker, "Amon.tas", "historical", "12345", info, temp_dir)
 
             assert tracker.get_status("Amon.tas", "historical") == "completed"
+            assert tracker.get_pbs_info("Amon.tas", "historical") == info
 
     @pytest.mark.unit
     def test_exit_zero_with_stale_running_backfills_completed(self, temp_dir):
@@ -711,6 +776,7 @@ class TestReconcileOne:
             )
 
             assert tracker.get_status("Omon.zostoga", "historical") == "failed"
+            assert tracker.get_pbs_info("Omon.zostoga", "historical") == info
             # Error message captures the PBS detail
             row = tracker.conn.execute(
                 "SELECT error_message FROM cmor_tasks WHERE variable=?",
@@ -856,6 +922,7 @@ class TestMonitorLoop:
             monitor_loop(tracker, job_map, "historical", temp_dir)
 
             assert tracker.get_status("Amon.tas", "historical") == "completed"
+            assert tracker.get_pbs_info("Amon.tas", "historical") == finished_info
 
     @pytest.mark.unit
     def test_loop_keeps_polling_while_state_is_running(self, temp_dir, monkeypatch):

--- a/tests/unit/test_batch_cmoriser.py
+++ b/tests/unit/test_batch_cmoriser.py
@@ -587,6 +587,61 @@ class TestQstatHelpers:
         assert info["Exit_status"] == "271"
 
     @pytest.mark.unit
+    def test_qstat_full_falls_back_when_json_has_no_jobs(self):
+        json_result = Mock(returncode=0, stdout='{"Jobs": {}}')
+        text_result = Mock(returncode=0, stdout=self.SAMPLE_QSTAT)
+        with patch("subprocess.run", side_effect=[json_result, text_result]):
+            info = qstat_full("12345.gadi-pbs")
+
+        assert info["qstat_format"] == "text"
+        assert info["job_state"] == "F"
+
+    @pytest.mark.unit
+    def test_qstat_full_falls_back_when_json_job_payload_is_invalid(self):
+        json_result = Mock(returncode=0, stdout='{"Jobs": {"12345.gadi-pbs": "bad"}}')
+        text_result = Mock(returncode=0, stdout=self.SAMPLE_QSTAT)
+        with patch("subprocess.run", side_effect=[json_result, text_result]):
+            info = qstat_full("12345.gadi-pbs")
+
+        assert info["qstat_format"] == "text"
+        assert info["Exit_status"] == "271"
+
+    @pytest.mark.unit
+    def test_qstat_full_json_uses_only_job_when_key_differs(self):
+        output = self.SAMPLE_QSTAT_JSON.replace("12345.gadi-pbs", "12345")
+        result = Mock(returncode=0, stdout=output)
+        with patch("subprocess.run", return_value=result):
+            info = qstat_full("12345.gadi-pbs")
+
+        assert info["qstat_format"] == "json"
+        assert info["job_id"] == "12345"
+        assert info["Resource_List.storage"] == "gdata/tm70+scratch/tm70"
+
+    @pytest.mark.unit
+    def test_qstat_full_json_ignores_non_mapping_resource_sections(self):
+        output = """
+        {
+          "Jobs": {
+            "12345.gadi-pbs": {
+              "job_state": "F",
+              "resources_used": "not-a-dict",
+              "Resource_List": "not-a-dict"
+            }
+          }
+        }
+        """
+        result = Mock(returncode=0, stdout=output)
+        with patch("subprocess.run", return_value=result):
+            info = qstat_full("12345.gadi-pbs")
+
+        assert info == {
+            "scheduler": "pbs",
+            "qstat_format": "json",
+            "job_id": "12345.gadi-pbs",
+            "job_state": "F",
+        }
+
+    @pytest.mark.unit
     def test_qstat_full_parses_well_formed_text(self):
         result = Mock(returncode=0, stdout=self.SAMPLE_QSTAT)
         with patch("subprocess.run", return_value=result):

--- a/tests/unit/test_batch_report.py
+++ b/tests/unit/test_batch_report.py
@@ -134,6 +134,99 @@ def test_build_batch_report_mixed_statuses(tmp_path: Path) -> None:
     assert failure["stderr_tail"] == "line2\nline3"
 
 
+def test_build_batch_report_handles_invalid_dates_and_stderr_read_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invalid timestamps and unreadable stderr tails are omitted safely."""
+    db_path = tmp_path / "cmor_tasks.db"
+    script_dir = tmp_path / "cmor_job_scripts"
+    with TaskTracker(db_path) as tracker:
+        tracker.add_task("Amon.tas", "historical")
+        tracker.mark_failed("Amon.tas", "historical", "boom")
+
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(
+            "UPDATE cmor_tasks SET start_time='not-a-date', end_time='also-bad' "
+            "WHERE variable='Amon.tas'"
+        )
+    conn.close()
+
+    err_dir = script_dir / "Amon_tas"
+    err_dir.mkdir(parents=True)
+    err_path = err_dir / "cmor_Amon_tas.err"
+    err_path.write_text("line1\n")
+
+    original_read_text = Path.read_text
+
+    def flaky_read_text(self: Path, *args, **kwargs) -> str:
+        if self == err_path:
+            raise OSError("cannot read")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+    report = batch_report.build_batch_report(db_path, script_dir=script_dir)
+
+    task = report["tasks"][0]
+    assert task["duration_seconds"] is None
+    assert report["failures"][0]["stderr_tail"] is None
+
+
+def test_build_batch_report_ignores_invalid_pbs_json(tmp_path: Path) -> None:
+    """Malformed or non-object PBS JSON is treated as absent metadata."""
+    db_path = tmp_path / "cmor_tasks.db"
+    with TaskTracker(db_path) as tracker:
+        tracker.add_task("Amon.badjson", "historical")
+        tracker.add_task("Amon.listjson", "historical")
+
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(
+            "UPDATE cmor_tasks SET pbs_info_json='not json' "
+            "WHERE variable='Amon.badjson'"
+        )
+        conn.execute(
+            "UPDATE cmor_tasks SET pbs_info_json='[]' " "WHERE variable='Amon.listjson'"
+        )
+    conn.close()
+
+    report = batch_report.build_batch_report(db_path)
+
+    assert [task["pbs"] for task in report["tasks"]] == [None, None]
+
+
+def test_batch_report_pbs_object_omits_invalid_exit_status(tmp_path: Path) -> None:
+    """Non-integer PBS exit statuses do not break report generation."""
+    db_path = tmp_path / "cmor_tasks.db"
+    with TaskTracker(db_path) as tracker:
+        tracker.add_task("Amon.tas", "historical")
+        tracker.set_pbs_job_id("Amon.tas", "historical", "123.gadi-pbs")
+        tracker.set_pbs_info(
+            "Amon.tas",
+            "historical",
+            {"job_id": "123.gadi-pbs", "Exit_status": "not-an-int"},
+        )
+
+    task = batch_report.build_batch_report(db_path)["tasks"][0]
+
+    assert task["pbs"]["job_id"] == "123.gadi-pbs"
+    assert "exit_status" not in task["pbs"]
+
+
+def test_batch_report_pbs_object_handles_missing_exit_status(tmp_path: Path) -> None:
+    """Missing PBS exit status is omitted, not represented as null."""
+    db_path = tmp_path / "cmor_tasks.db"
+    with TaskTracker(db_path) as tracker:
+        tracker.add_task("Amon.tas", "historical")
+        tracker.set_pbs_info("Amon.tas", "historical", {"job_state": "F"})
+
+    task = batch_report.build_batch_report(db_path)["tasks"][0]
+
+    assert task["pbs"]["job_state"] == "F"
+    assert "exit_status" not in task["pbs"]
+
+
 @pytest.mark.parametrize(
     ("statuses", "expected_status", "success", "all_terminal"),
     [
@@ -188,6 +281,23 @@ def test_write_batch_report_and_cli(
     assert rc == 0
     assert str(cli_path) in capsys.readouterr().out
     assert json.loads(cli_path.read_text())["tasks"][0]["variable"] == "Amon.tas"
+
+
+def test_cli_loads_config_file(tmp_path: Path) -> None:
+    """The report CLI can include experiment metadata from a config file."""
+    db_path = tmp_path / "cmor_tasks.db"
+    config_path = tmp_path / "batch_config.yml"
+    config_path.write_text("experiment_id: historical\n")
+    with TaskTracker(db_path) as tracker:
+        tracker.add_task("Amon.tas", "historical")
+
+    output = tmp_path / "report.json"
+    rc = batch_report.main(
+        ["--db", str(db_path), "--output", str(output), "--config", str(config_path)]
+    )
+
+    assert rc == 0
+    assert json.loads(output.read_text())["experiment_id"] == "historical"
 
 
 def test_build_batch_report_handles_old_tracker_schema(tmp_path: Path) -> None:

--- a/tests/unit/test_batch_report.py
+++ b/tests/unit/test_batch_report.py
@@ -21,6 +21,38 @@ def _seed_mixed_db(db_path: Path, script_dir: Path) -> None:
         tracker.set_pbs_job_id("Amon.tas", "historical", "123.gadi-pbs")
         tracker.set_pbs_job_id("Amon.pr", "historical", "124.gadi-pbs")
         tracker.set_pbs_job_id("Omon.tos", "historical", "125.gadi-pbs")
+        tracker.set_pbs_info(
+            "Amon.tas",
+            "historical",
+            {
+                "scheduler": "pbs",
+                "qstat_format": "json",
+                "job_id": "123.gadi-pbs",
+                "job_state": "F",
+                "Exit_status": 0,
+                "queue": "normal",
+                "project": "tm70",
+                "Account_Name": "tm70",
+                "pbs_server": "gadi-pbs",
+                "pbs_version": "2022.1.3",
+                "ctime": "Thu Jun 04 01:00:00 2026",
+                "etime": "Thu Jun 04 01:00:01 2026",
+                "qtime": "Thu Jun 04 01:00:02 2026",
+                "stime": "Thu Jun 04 01:01:00 2026",
+                "mtime": "Thu Jun 04 01:30:00 2026",
+                "resources_used.cpupercent": 95,
+                "resources_used.cput": "00:25:12",
+                "resources_used.mem": "6gb",
+                "resources_used.vmem": "7gb",
+                "resources_used.walltime": "00:27:03",
+                "Resource_List.ncpus": 4,
+                "Resource_List.mem": "8gb",
+                "Resource_List.walltime": "00:30:00",
+                "Resource_List.storage": "gdata/tm70+scratch/tm70",
+                "exec_host": "gadi-cpu-clx-0001/0*4",
+                "comment": "Job run",
+            },
+        )
 
     start = datetime(2026, 6, 4, 1, 0, 0)
     conn = sqlite3.connect(db_path)
@@ -87,6 +119,16 @@ def test_build_batch_report_mixed_statuses(tmp_path: Path) -> None:
     completed = next(t for t in report["tasks"] if t["variable"] == "Amon.tas")
     assert completed["duration_seconds"] == 90.0
     assert completed["pbs_job_id"] == "123.gadi-pbs"
+    assert completed["pbs"]["scheduler"] == "pbs"
+    assert completed["pbs"]["job_id"] == "123.gadi-pbs"
+    assert completed["pbs"]["exit_status"] == 0
+    assert completed["pbs"]["queue"] == "normal"
+    assert completed["pbs"]["resources_used"]["mem"] == "6gb"
+    assert completed["pbs"]["resources_requested"]["walltime"] == "00:30:00"
+    assert completed["pbs"]["timestamps"]["started_at"] == "Thu Jun 04 01:01:00 2026"
+    assert completed["pbs"]["raw_qstat"]["qstat_format"] == "json"
+    running = next(t for t in report["tasks"] if t["variable"] == "Omon.tos")
+    assert running["pbs"] is None
     failure = report["failures"][0]
     assert failure["variable"] == "Amon.pr"
     assert failure["stderr_tail"] == "line2\nline3"
@@ -146,6 +188,36 @@ def test_write_batch_report_and_cli(
     assert rc == 0
     assert str(cli_path) in capsys.readouterr().out
     assert json.loads(cli_path.read_text())["tasks"][0]["variable"] == "Amon.tas"
+
+
+def test_build_batch_report_handles_old_tracker_schema(tmp_path: Path) -> None:
+    """Reports can still be generated from pre-PBS-metadata tracker DBs."""
+    db_path = tmp_path / "old.db"
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(
+            """
+            CREATE TABLE cmor_tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                variable TEXT NOT NULL,
+                experiment_id TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                start_time TEXT,
+                end_time TEXT,
+                error_message TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO cmor_tasks (variable, experiment_id, status) "
+            "VALUES ('Amon.tas', 'historical', 'completed')"
+        )
+    conn.close()
+
+    report = batch_report.build_batch_report(db_path)
+
+    assert report["tasks"][0]["pbs_job_id"] is None
+    assert report["tasks"][0]["pbs"] is None
 
 
 def test_finalize_monitor_writes_report_before_removing_sidecar(tmp_path: Path) -> None:

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -435,6 +435,19 @@ class TestTaskTracker:
             assert tracker.get_pbs_info("Amon.tas", "historical") is None
 
     @pytest.mark.unit
+    def test_get_pbs_info_returns_none_for_malformed_json(self, temp_dir):
+        """Malformed legacy/corrupt PBS JSON is treated as missing metadata."""
+        db_path = temp_dir / "test_tracker.db"
+        with TaskTracker(db_path) as tracker:
+            tracker.add_task("Amon.tas", "historical")
+            tracker.conn.execute(
+                "UPDATE cmor_tasks SET pbs_info_json='not json' WHERE variable=?",
+                ("Amon.tas",),
+            )
+
+            assert tracker.get_pbs_info("Amon.tas", "historical") is None
+
+    @pytest.mark.unit
     def test_list_unfinished_excludes_terminal_states(self, temp_dir):
         """list_unfinished returns only pending/running rows, not completed/failed."""
         db_path = temp_dir / "test_tracker.db"

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -408,6 +408,33 @@ class TestTaskTracker:
             assert tracker.get_pbs_job_id("nonexistent.var", "historical") is None
 
     @pytest.mark.unit
+    def test_pbs_info_round_trip(self, temp_dir):
+        """set_pbs_info stores structured PBS metadata as JSON."""
+        db_path = temp_dir / "test_tracker.db"
+        pbs_info = {
+            "scheduler": "pbs",
+            "job_id": "12345.gadi-pbs",
+            "Exit_status": "0",
+            "resources_used.walltime": "00:10:00",
+        }
+        with TaskTracker(db_path) as tracker:
+            tracker.add_task("Amon.tas", "historical")
+            assert tracker.get_pbs_info("Amon.tas", "historical") is None
+
+            tracker.set_pbs_info("Amon.tas", "historical", pbs_info)
+            assert tracker.get_pbs_info("Amon.tas", "historical") == pbs_info
+
+            tracker.set_pbs_info("Amon.tas", "historical", None)
+            assert tracker.get_pbs_info("Amon.tas", "historical") is None
+
+    @pytest.mark.unit
+    def test_get_pbs_info_returns_none_for_unknown_task(self, temp_dir):
+        """get_pbs_info returns None when the task row is absent."""
+        db_path = temp_dir / "test_tracker.db"
+        with TaskTracker(db_path) as tracker:
+            assert tracker.get_pbs_info("Amon.tas", "historical") is None
+
+    @pytest.mark.unit
     def test_list_unfinished_excludes_terminal_states(self, temp_dir):
         """list_unfinished returns only pending/running rows, not completed/failed."""
         db_path = temp_dir / "test_tracker.db"
@@ -453,8 +480,8 @@ class TestTaskTracker:
             assert tracker.list_unfinished("piControl") == []
 
     @pytest.mark.unit
-    def test_schema_migration_adds_pbs_job_id_column(self, temp_dir):
-        """Opening an old-schema DB auto-adds pbs_job_id via ALTER TABLE."""
+    def test_schema_migration_adds_pbs_columns(self, temp_dir):
+        """Opening an old-schema DB auto-adds PBS columns via ALTER TABLE."""
         db_path = temp_dir / "old.db"
 
         # Hand-build a pre-migration DB lacking the pbs_job_id column
@@ -485,6 +512,7 @@ class TestTaskTracker:
                 ).fetchall()
             }
             assert "pbs_job_id" in columns
+            assert "pbs_info_json" in columns
 
             # Existing rows are preserved by the migration
             assert tracker.get_status("Omon.zostoga", "historical") == "running"
@@ -495,10 +523,13 @@ class TestTaskTracker:
                 tracker.get_pbs_job_id("Omon.zostoga", "historical")
                 == "168282805.gadi-pbs"
             )
+            pbs_info = {"job_id": "168282805.gadi-pbs", "Exit_status": "0"}
+            tracker.set_pbs_info("Omon.zostoga", "historical", pbs_info)
+            assert tracker.get_pbs_info("Omon.zostoga", "historical") == pbs_info
 
     @pytest.mark.unit
     def test_schema_migration_idempotent(self, temp_dir):
-        """Re-opening a DB that already has pbs_job_id does not duplicate the column."""
+        """Re-opening a DB that already has PBS columns does not duplicate them."""
         db_path = temp_dir / "test_tracker.db"
 
         # First open: creates schema with pbs_job_id
@@ -513,5 +544,6 @@ class TestTaskTracker:
                 for row in t2.conn.execute("PRAGMA table_info(cmor_tasks)").fetchall()
             ]
             assert columns.count("pbs_job_id") == 1
+            assert columns.count("pbs_info_json") == 1
             # Data preserved across reopens
             assert t2.get_pbs_job_id("Amon.tas", "historical") == "12345.gadi-pbs"


### PR DESCRIPTION
## Summary
- prefer Payu-style `qstat -xf -F json` PBS metadata, with existing text parsing as fallback
- persist filtered structured PBS metadata in `cmor_tasks.pbs_info_json`
- add per-task `pbs` objects to `moppy_batch_report.json` with job state, exit status, queue/project, timestamps, requested/used resources, and filtered raw metadata
- document privacy/provenance implications and add migration/report/tests coverage

Closes #420.

## Validation
- `/home/node/.openclaw/agents/main/agent/codex-home/home/.local/bin/pre-commit run --all-files` — passed
- `HOME=/tmp/moppy-test-home ./.pixi/envs/test/bin/pytest tests/unit/test_tracking.py tests/unit/test_batch_cmoriser.py tests/unit/test_batch_report.py -q` — 115 passed
- `HOME=/tmp/moppy-test-home ./.pixi/envs/test/bin/pytest tests/unit -q` — 1075 passed, 19 warnings
- `find src/access_moppy tests -path 'src/access_moppy/vocabularies' -prune -o -name '*.py' -print | xargs ./.pixi/envs/test/bin/ruff check` — passed
- `git diff --check` — passed