### PR TITLE
Add automatic file discovery for CMORisation

### DIFF
--- a/docs/source/batch_processing.rst
+++ b/docs/source/batch_processing.rst
@@ -71,11 +71,19 @@ Complete configuration file specification:
    input_folder: "/g/data/project/model_output"
    output_folder: "/scratch/project/cmor_output"
 
-   # Required: File pattern mapping
-   file_patterns:
-     Amon.pr: "output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
-     Omon.tos: "output[0-4][0-9][0-9]/ocean/*temp*.nc"
-     Amon.tas: "output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
+   # Optional: model_id selects the mapping file used for auto file-discovery.
+   # Defaults to "ACCESS-ESM1.6" when omitted.
+   # model_id: ACCESS-ESM1.6
+
+   # Optional: Explicit file patterns per variable.
+   # When omitted, MOPPy discovers files automatically from the
+   # file_discovery configuration embedded in the model mapping JSON.
+   # Provide explicit patterns only to override the defaults — for example
+   # to restrict to a subset of output folders or to handle non-standard layouts.
+   #
+   # file_patterns:
+   #   Amon.pr:  "output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
+   #   Omon.tos: "output[0-4][0-9][0-9]/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc"
 
    # PBS Resource Configuration
    queue: "normal"                    # PBS queue name
@@ -150,17 +158,24 @@ Performance Optimization
 
       jobfs: "200GB"  # Provides fast local SSD storage
 
-2. **Optimize file patterns** to minimize file scanning:
+2. **Prefer auto-discovery over manual patterns** when possible:
+
+   Auto-discovery builds focused glob patterns from the variable's
+   ``model_variables`` list and the component-level config in the mapping
+   JSON, so it is already tuned to the expected file layout.  Only add an
+   explicit ``file_patterns`` entry when you need to narrow the set of
+   output folders (e.g. for a time-range subset) or when dealing with
+   a non-standard folder layout.
 
    .. code-block:: yaml
 
-      # Good: Specific pattern
+      # Restrict to a specific decade — manual override
       file_patterns:
-        Amon.pr: "output[0-4][0-9][0-9]/atmosphere/netCDF/*pr*_mon.nc"
+        Amon.pr: "output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
 
-      # Avoid: Overly broad patterns
+      # Avoid: Overly broad patterns scan the entire tree
       file_patterns:
-        Amon.pr: "**/*.nc"  # Scans entire directory tree
+        Amon.pr: "**/*.nc"
 
 **Memory Management**
 

--- a/docs/source/batch_processing.rst
+++ b/docs/source/batch_processing.rst
@@ -169,7 +169,7 @@ Performance Optimization
 
    .. code-block:: yaml
 
-      # Restrict to a specific decade — manual override
+      # Restrict to specific folders — manual override
       file_patterns:
         Amon.pr: "output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -35,9 +35,29 @@ ACCESS-MOPPy supports Dask for parallel processing, which can significantly spee
 Data selection
 --------------
 
-The `ACCESS_ESM_CMORiser` class (described in detail below) takes as input a list of paths to NetCDF files containing the raw model output variables to be CMORised. The CMORiser does **not** assume any specific folder structure, DRS (Data Reference Syntax), or file naming convention. It is intentionally left to the user to ensure that the provided files contain the original variables required for CMORisation.
+``ACCESS_ESM_CMORiser`` offers two ways to supply input data:
 
-This design is intentional: ACCESS-NRI plans to integrate ACCESS-MOPPy into extended workflows that leverage the [ACCESS-NRI Intake Catalog](https://github.com/ACCESS-NRI/access-nri-intake-catalog) or evaluation frameworks such as [ESMValTool](https://www.esmvaltool.org/) and [ILAMB](https://www.ilamb.org/). By decoupling file selection from the CMORiser, ACCESS-MOPPy can be flexibly used in a variety of data processing and evaluation pipelines.
+**Option 1 — Auto-discovery (recommended):** pass the root directory of your
+payu archive via ``input_folder``.  ACCESS-MOPPy reads the variable's mapping
+entry and the model's ``file_discovery`` configuration to locate the relevant
+files automatically — no manual ``glob`` required.
+
+.. code-block:: python
+
+   # Point to the archive root; ACCESS-MOPPy finds the files for you.
+   archive_root = "/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/historical/MyRun"
+
+Optionally, restrict the search to a specific time window:
+
+.. code-block:: python
+
+   # Only files within 1900–1950 will be included.
+   archive_root = "/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/historical/MyRun"
+   start_year, end_year = 1900, 1950
+
+**Option 2 — Explicit file list:** collect the files yourself and pass them
+via ``input_data``.  This is useful when the auto-discovery pattern does not
+match your archive layout, or when you want fine-grained control.
 
 .. code-block:: python
 
@@ -45,7 +65,7 @@ This design is intentional: ACCESS-NRI plans to integrate ACCESS-MOPPy into exte
    files = glob.glob("../../Test_data/esm1-6/atmosphere/aiihca.pa-0961*_mon.nc")
 
 Parent experiment information
-----------------------------
+-----------------------------
 
 In CMIP workflows, providing parent experiment information is required for proper data provenance and traceability. This metadata describes the relationship between your experiment and its parent (for example, a historical run branching from a piControl simulation), and is essential for CMIP data publication and compliance.
 
@@ -68,68 +88,90 @@ If you choose to skip this step, ACCESS-MOPPy will issue a warning to let you kn
    }
 
 Set up the CMORiser for CMORisation
------------------------------------
+------------------------------------
 
-To begin the CMORisation process, you need to create an instance of the `ACCESS_ESM_CMORiser` class. This class requires several key parameters, including the list of input NetCDF files and metadata describing your experiment.
+To begin the CMORisation process, you need to create an instance of the `ACCESS_ESM_CMORiser` class. This class requires several key parameters, including the input data and metadata describing your experiment.
 
 A crucial parameter is the `compound_name`, which should be specified using the full CMIP convention: `table.variable` (for example, `Amon.rsds`). This format uniquely identifies the variable, its frequency (e.g., monthly, daily), and the associated CMIP table, ensuring that all requirements for grids and metadata are correctly handled. Using the full compound name helps avoid ambiguity and guarantees that the CMORiser applies the correct standards for each variable.
 
 You can also provide additional metadata such as `experiment_id`, `source_id`, `variant_label`, and `grid_label` to ensure your output is CMIP-compliant. Optionally, you may include parent experiment information for full provenance tracking.
+
+Using ``input_folder`` (auto-discovery):
 
 .. code-block:: python
 
    from access_moppy import ACCESS_ESM_CMORiser
 
    cmoriser = ACCESS_ESM_CMORiser(
-       input_paths=files,
+       input_folder=archive_root,   # archive root — files discovered automatically
+       start_year=1900,             # optional: restrict to 1900–1950
+       end_year=1950,
        compound_name="Amon.rsds",
        experiment_id="historical",
        source_id="ACCESS-ESM1-5",
        variant_label="r1i1p1f1",
        grid_label="gn",
        activity_id="CMIP",
-         cmip_version="CMIP6",  # Optional, default is CMIP6
-       parent_info=parent_experiment_config # <-- This is optional, can be skipped if not needed
+       cmip_version="CMIP6",        # Optional, default is CMIP6
+       parent_info=parent_experiment_config,  # Optional
    )
 
-   Choosing CMIP6 vs CMIP6Plus vs CMIP7
-   ------------------------------------
+Or, using an explicit file list (``input_data``):
 
-   From a user point of view, vocabulary selection is controlled by the ``cmip_version`` argument in ``ACCESS_ESM_CMORiser``:
+.. code-block:: python
 
-   - ``cmip_version="CMIP6"`` (default) uses CMIP6 controlled vocabularies
-   - ``cmip_version="CMIP6Plus"`` uses CMIP6Plus controlled vocabularies
-   - ``cmip_version="CMIP7"`` uses CMIP7 controlled vocabularies
+   from access_moppy import ACCESS_ESM_CMORiser
 
-   .. code-block:: python
+   cmoriser = ACCESS_ESM_CMORiser(
+       input_data=files,
+       compound_name="Amon.rsds",
+       experiment_id="historical",
+       source_id="ACCESS-ESM1-5",
+       variant_label="r1i1p1f1",
+       grid_label="gn",
+       activity_id="CMIP",
+       cmip_version="CMIP6",        # Optional, default is CMIP6
+       parent_info=parent_experiment_config,  # Optional
+   )
 
-      from access_moppy import ACCESS_ESM_CMORiser
+Choosing CMIP6 vs CMIP6Plus vs CMIP7
+-------------------------------------
 
-      # CMIP6 (default)
-      cmip6_cmoriser = ACCESS_ESM_CMORiser(
-         input_data=files,
-         compound_name="Amon.rsds",
-         experiment_id="historical",
-         source_id="ACCESS-ESM1-5",
-         variant_label="r1i1p1f1",
-         grid_label="gn",
-         activity_id="CMIP",
-         cmip_version="CMIP6",
-      )
+From a user point of view, vocabulary selection is controlled by the ``cmip_version`` argument in ``ACCESS_ESM_CMORiser``:
 
-      # CMIP6Plus
-      cmip6plus_cmoriser = ACCESS_ESM_CMORiser(
-         input_data=files,
-         compound_name="Amon.rsds",
-         experiment_id="historical",
-         source_id="ACCESS-CM2",
-         variant_label="r1i1p1f1",
-         grid_label="gn",
-         activity_id="CMIP",
-         cmip_version="CMIP6Plus",
-      )
+- ``cmip_version="CMIP6"`` (default) uses CMIP6 controlled vocabularies
+- ``cmip_version="CMIP6Plus"`` uses CMIP6Plus controlled vocabularies
+- ``cmip_version="CMIP7"`` uses CMIP7 controlled vocabularies
 
-   Use ``source_id``, ``experiment_id``, and other metadata values that exist in the selected controlled vocabulary set. CMIP6 and CMIP6Plus entries are not always identical.
+.. code-block:: python
+
+   from access_moppy import ACCESS_ESM_CMORiser
+
+   # CMIP6 (default)
+   cmip6_cmoriser = ACCESS_ESM_CMORiser(
+       input_data=files,
+       compound_name="Amon.rsds",
+       experiment_id="historical",
+       source_id="ACCESS-ESM1-5",
+       variant_label="r1i1p1f1",
+       grid_label="gn",
+       activity_id="CMIP",
+       cmip_version="CMIP6",
+   )
+
+   # CMIP6Plus
+   cmip6plus_cmoriser = ACCESS_ESM_CMORiser(
+       input_data=files,
+       compound_name="Amon.rsds",
+       experiment_id="historical",
+       source_id="ACCESS-CM2",
+       variant_label="r1i1p1f1",
+       grid_label="gn",
+       activity_id="CMIP",
+       cmip_version="CMIP6Plus",
+   )
+
+Use ``source_id``, ``experiment_id``, and other metadata values that exist in the selected controlled vocabulary set. CMIP6 and CMIP6Plus entries are not always identical.
 
 Exploring Variable Mappings
 ---------------------------

--- a/docs/source/mapping_reference.rst
+++ b/docs/source/mapping_reference.rst
@@ -81,15 +81,20 @@ Each mapping file is a JSON object with the following top-level keys:
    }
 
 ``model_info``
-   A metadata block describing the model and which components have mappings.
+   A metadata block describing the model, its components, and — most
+   importantly — how to discover raw output files automatically.
 
    .. code-block:: json
 
       {
         "model_id": "ACCESS-ESM1.6",
         "components": ["aerosol", "atmosphere", "land", "landIce", "ocean", "sea_ice"],
-        "description": "Variable mappings for ACCESS-ESM1.6 Earth System Model"
+        "description": "Variable mappings for ACCESS-ESM1.6 Earth System Model",
+        "file_discovery": { ... }
       }
+
+   The ``file_discovery`` sub-block drives automatic file discovery (see
+   :ref:`file-discovery` below).
 
 Each **component** key (``aerosol``, ``atmosphere``, etc.) maps CMIP variable names to
 their entry dictionaries.  When :func:`~access_moppy.utilities.load_model_mappings` is
@@ -139,6 +144,16 @@ required fields:
      - Present for variables on vertical levels.  Describes the vertical coordinate type
        and the variables needed to reconstruct it.
        See :ref:`zaxis-field` below.
+   * - ``file_pattern``
+     - No
+     - A glob pattern (or list of patterns), **relative to** ``input_folder``, that
+       overrides the component-level auto-discovery for this specific variable.
+       Use this for edge-cases: unusual filenames, legacy layouts, or variables
+       spread across multiple file types.  Example::
+
+           "file_pattern": "output[0-9][0-9][0-9]/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc"
+
+       When absent, discovery falls back to the ``file_discovery`` block in ``model_info``.
    * - ``ressource_file``
      - No
      - Name of a bundled NetCDF resource file (stored under ``src/access_moppy/resources/``)
@@ -624,8 +639,154 @@ Adding a new model
 
 1. Create ``src/access_moppy/mappings/<MODEL_ID>_mappings.json`` following the
    same top-level structure (``model_info`` + component keys).
-2. Pass ``model_id="<MODEL_ID>"`` to ``ACCESS_ESM_CMORiser`` to activate the new
+2. Add a ``file_discovery`` block to ``model_info`` (see :ref:`file-discovery`)
+   so that MOPPy can auto-discover raw files for the new model.
+3. Pass ``model_id="<MODEL_ID>"`` to ``ACCESS_ESM_CMORiser`` to activate the new
    mapping file.
-3. If the model uses a different CMORiser class (e.g. a new ocean component), implement
+4. If the model uses a different CMORiser class (e.g. a new ocean component), implement
    a :class:`~access_moppy.base.CMORiser` subclass and wire it up in
    :mod:`access_moppy.driver`.
+
+.. _file-discovery:
+
+File Discovery
+--------------
+
+Overview
+^^^^^^^^
+
+:func:`~access_moppy.file_discovery.discover_files` automatically locates raw
+model output files for a CMIP variable given only an archive root directory.
+It is used as a fallback by the batch system when no explicit ``file_patterns``
+entry is present in the batch config.
+
+Resolution order
+^^^^^^^^^^^^^^^^
+
+1. **Per-variable** ``file_pattern`` in the mapping entry — explicit override
+   for edge-cases (unusual filenames, legacy layouts, or derived variables
+   drawing from multiple file types).
+2. **Component-level** ``frequency_patterns`` from ``model_info.file_discovery``
+   — the normal path, resolved by substituting ``{model_var}`` from
+   ``model_variables`` and globbing under ``input_folder``.
+3. :class:`~access_moppy.file_discovery.FileDiscoveryError` — raised when
+   neither source provides a pattern; the batch job fails with an actionable
+   message.
+
+``file_discovery`` block in ``model_info``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: json
+
+   "file_discovery": {
+     "output_dir_pattern": "output[0-9][0-9][0-9]",
+     "components": {
+       "atmosphere": {
+         "subdir": "atmosphere/netCDF",
+         "frequency_patterns": {
+           "mon":   "*.pa-*_mon.nc",
+           "day":   "*.pe-*_dai.nc",
+           "3hr":   "*.pi-*_3hr.nc",
+           "6hr":   "*.pj-*_6hr.nc",
+           "subhr": "*.pc-*.nc"
+         }
+       },
+       "sea_ice": {
+         "subdir": "ice",
+         "frequency_patterns": {
+           "mon": "iceh-1monthly-mean_*.nc",
+           "day": "iceh-1daily-mean_*.nc"
+         }
+       },
+       "ocean": {
+         "subdir": "ocean",
+         "frequency_patterns": {
+           "mon": "ocean-*-{model_var}-1mon-mean-y_*.nc",
+           "day": "ocean-*-{model_var}-1day-mean-y_*.nc",
+           "yr":  "ocean-*-{model_var}-1yr-mean-y_*.nc",
+           "fx":  "ocean-*-{model_var}-fx.nc"
+         }
+       }
+     }
+   }
+
+``output_dir_pattern``
+   Glob fragment matched against the top-level output sub-directories
+   (e.g. ``output000``, ``output001``, …).
+
+``subdir``
+   Path relative to the output directory where the component's files live.
+
+``frequency_patterns``
+   Dictionary keyed by **frequency token** (``"mon"``, ``"day"``, ``"3hr"``,
+   ``"6hr"``, ``"yr"``, ``"fx"``) mapping to a filename glob.
+
+   When the pattern contains ``{model_var}``, it is substituted with each
+   entry in the variable's ``model_variables`` list and all results are
+   merged — this is how multi-variable derivations (e.g. ocean overturning
+   computed from two transport fields) collect all required files.
+
+   When the pattern has **no** ``{model_var}`` placeholder (atmosphere, sea
+   ice), a single glob is issued that returns all files for that frequency,
+   regardless of which variable is requested.  All variables at that
+   frequency are packed into the same file in those components.
+
+``frequency_patterns`` keys
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The key is derived from the CMIP table name of the requested variable:
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Key
+     - CMIP tables that map to it
+   * - ``mon``
+     - ``Amon``, ``Lmon``, ``Omon``, ``SImon``, ``AERmon``, ``CFmon``, ``Emon``, …
+   * - ``day``
+     - ``day``, ``Oday``, ``SIday``
+   * - ``3hr``
+     - ``3hr``, ``E3hr``, ``CF3hr``
+   * - ``6hr``
+     - ``6hrLev``, ``6hrPlev``, ``6hrPlevPt``
+   * - ``subhr``
+     - ``1hr``, ``Esubhr``
+   * - ``yr``
+     - ``Oyr``, ``yr``, ``Eyr``
+   * - ``fx``
+     - ``fx``, ``Ofx``
+
+Year-based filtering
+^^^^^^^^^^^^^^^^^^^^
+
+:func:`~access_moppy.file_discovery.discover_files` accepts optional
+``start_year`` and ``end_year`` arguments.  After globbing, files outside the
+requested range are removed by parsing the year directly from the filename
+— no files are opened, so filtering adds negligible overhead even for large
+archives.
+
+The following filename conventions are recognised:
+
+* ``ocean-2d-tos-1mon-mean-y_1850.nc`` → year ``1850``
+* ``iceh-1monthly-mean_1850-01.nc`` → year ``1850``
+* ``aiihca.pa-185001_mon.nc`` → year ``1850``
+* ``tos_mean_ocean_1mon_185001-185012.nc`` → start year ``1850``
+  (proposed unified naming scheme)
+
+Adapting to a different file layout
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each model version can have its own mapping file with a different
+``file_discovery`` block.  To add support for a new file organisation:
+
+1. Create (or copy) a mapping JSON — e.g.
+   ``ACCESS-ESM1.6-unified_mappings.json``.
+2. Update ``model_info.file_discovery`` with the new ``subdir`` values and
+   ``frequency_patterns`` globs.
+3. For per-variable overrides (renamed files, unusual paths), add a
+   ``file_pattern`` field directly to the variable entry.
+4. Point the batch config at the new mapping: ``model_id: ACCESS-ESM1.6-unified``.
+
+Old and new runs can be processed side-by-side; the ``model_id`` in each
+batch config selects the correct layout independently.

--- a/notebooks/Getting_started.ipynb
+++ b/notebooks/Getting_started.ipynb
@@ -981,7 +981,7 @@
     "siconc_files = discover_files(ARCHIVE_ROOT, \"SImon.siconc\")\n",
     "print(f\"\\nSImon.siconc → {len(siconc_files)} file(s)\")\n",
     "for f in siconc_files[:3]:\n",
-    "    print(f\"  {f}\")\n"
+    "    print(f\"  {f}\")"
    ]
   },
   {
@@ -994,7 +994,7 @@
     "# Optional: restrict to a specific time range by year.\n",
     "# Filtering is done by parsing the year from the filename — no files are opened.\n",
     "files_1990s = discover_files(ARCHIVE_ROOT, \"Amon.rsds\", start_year=1990, end_year=1999)\n",
-    "print(f\"Amon.rsds (1990–1999) → {len(files_1990s)} file(s)\")\n"
+    "print(f\"Amon.rsds (1990–1999) → {len(files_1990s)} file(s)\")"
    ]
   },
   {
@@ -1058,15 +1058,15 @@
    "source": [
     "# Use the auto-discovered files (or substitute `files` for the manually-built list above)\n",
     "cmoriser = ACCESS_ESM_CMORiser(\n",
-    "    input_data=atmos_files,           # <-- swap in ocean_files, siconc_files, etc. as needed\n",
+    "    input_data=atmos_files,  # <-- swap in ocean_files, siconc_files, etc. as needed\n",
     "    compound_name=\"Amon.rsds\",\n",
     "    experiment_id=\"piControl-spinup\",\n",
-    "    source_id=\"ACCESS-ESM1-5\",        # <-- ACCESS-ESM1-6 is not yet registered in the CMIP6 catalog\n",
+    "    source_id=\"ACCESS-ESM1-5\",  # <-- ACCESS-ESM1-6 is not yet registered in the CMIP6 catalog\n",
     "    variant_label=\"r1i1p1f1\",\n",
     "    grid_label=\"gn\",\n",
     "    activity_id=\"CMIP\",\n",
     "    parent_info=parent_experiment_config,\n",
-    ")\n"
+    ")"
    ]
   },
   {

--- a/notebooks/Getting_started.ipynb
+++ b/notebooks/Getting_started.ipynb
@@ -933,6 +933,72 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0fb3dd60",
+   "metadata": {},
+   "source": [
+    "### Automatic file discovery (recommended)\n",
+    "\n",
+    "Instead of constructing glob patterns by hand, `discover_files` can find all the input files for a given CMIP variable automatically.  \n",
+    "It reads the `file_discovery` configuration embedded in the model mapping JSON — the same JSON that drives the CMORisation — so the correct subdirectory, file-naming scheme, and per-variable resolution are always applied without any manual effort.\n",
+    "\n",
+    "Key features:\n",
+    "- Works across all components (atmosphere, ocean, sea ice, land, aerosol)\n",
+    "- For **ocean** variables: resolves files per model variable (one file per diagnostic)\n",
+    "- For **atmosphere / sea ice**: resolves the single packed file for the relevant output frequency\n",
+    "- Optional `start_year` / `end_year` filtering without opening any files\n",
+    "- Falls back gracefully to an explicit pattern if a per-variable `file_pattern` is set in the mapping\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e29720f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from access_moppy.file_discovery import discover_files\n",
+    "\n",
+    "# Root of the payu archive (contains output000/, output001/, …)\n",
+    "ARCHIVE_ROOT = \"/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/spinup/Dec25-PI-control\"\n",
+    "\n",
+    "# --- Atmosphere: monthly surface downwelling shortwave ---\n",
+    "# All monthly atmosphere variables are packed in the same UM output file.\n",
+    "# discover_files returns all matching files across every output sub-directory.\n",
+    "atmos_files = discover_files(ARCHIVE_ROOT, \"Amon.rsds\")\n",
+    "print(f\"Amon.rsds  → {len(atmos_files)} file(s)\")\n",
+    "for f in atmos_files[:3]:\n",
+    "    print(f\"  {f}\")\n",
+    "\n",
+    "# --- Ocean: monthly sea-surface temperature ---\n",
+    "# Ocean diagnostics are one-variable-per-file; discover_files uses the\n",
+    "# model_variables from the mapping to build the correct per-variable glob.\n",
+    "ocean_files = discover_files(ARCHIVE_ROOT, \"Omon.tos\")\n",
+    "print(f\"\\nOmon.tos   → {len(ocean_files)} file(s)\")\n",
+    "for f in ocean_files[:3]:\n",
+    "    print(f\"  {f}\")\n",
+    "\n",
+    "# --- Sea ice: monthly sea-ice concentration ---\n",
+    "siconc_files = discover_files(ARCHIVE_ROOT, \"SImon.siconc\")\n",
+    "print(f\"\\nSImon.siconc → {len(siconc_files)} file(s)\")\n",
+    "for f in siconc_files[:3]:\n",
+    "    print(f\"  {f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "444693b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional: restrict to a specific time range by year.\n",
+    "# Filtering is done by parsing the year from the filename — no files are opened.\n",
+    "files_1990s = discover_files(ARCHIVE_ROOT, \"Amon.rsds\", start_year=1990, end_year=1999)\n",
+    "print(f\"Amon.rsds (1990–1999) → {len(files_1990s)} file(s)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d458b955",
    "metadata": {},
    "source": [
@@ -985,21 +1051,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "0e54cf4e-b707-4128-aa93-23bb9cf684d3",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Use the auto-discovered files (or substitute `files` for the manually-built list above)\n",
     "cmoriser = ACCESS_ESM_CMORiser(\n",
-    "    input_data=files,\n",
+    "    input_data=atmos_files,           # <-- swap in ocean_files, siconc_files, etc. as needed\n",
     "    compound_name=\"Amon.rsds\",\n",
     "    experiment_id=\"piControl-spinup\",\n",
-    "    source_id=\"ACCESS-ESM1-5\",  # <-- ACCESS-ESM1-6 is not yet registered in the CMIP6 catalog, so we use ACCESS-ESM1-5 as a placeholder\n",
+    "    source_id=\"ACCESS-ESM1-5\",        # <-- ACCESS-ESM1-6 is not yet registered in the CMIP6 catalog\n",
     "    variant_label=\"r1i1p1f1\",\n",
     "    grid_label=\"gn\",\n",
     "    activity_id=\"CMIP\",\n",
-    "    parent_info=parent_experiment_config,  # <-- This is optional, can be skipped if not needed\n",
-    ")"
+    "    parent_info=parent_experiment_config,\n",
+    ")\n"
    ]
   },
   {

--- a/notebooks/Getting_started.ipynb
+++ b/notebooks/Getting_started.ipynb
@@ -915,6 +915,7 @@
     "# Optional — build an explicit file list if you need fine-grained control.\n",
     "# When using input_folder, ACCESS-MOPPy does this automatically.\n",
     "import glob\n",
+    "\n",
     "files = glob.glob(ARCHIVE_ROOT + \"/output40[0-1]/atmosphere/netCDF/aiihca.pa-*_mon.nc\")\n",
     "print(f\"Explicit file list: {len(files)} atmospheric file(s) found\")"
    ]
@@ -1045,7 +1046,7 @@
     "# input_folder triggers automatic file discovery — no glob required.\n",
     "# Optionally restrict the time range with start_year / end_year.\n",
     "cmoriser = ACCESS_ESM_CMORiser(\n",
-    "    input_folder=ARCHIVE_ROOT,       # archive root; files are auto-discovered\n",
+    "    input_folder=ARCHIVE_ROOT,  # archive root; files are auto-discovered\n",
     "    # start_year=1990, end_year=1999  # optional year filter\n",
     "    compound_name=\"Amon.rsds\",\n",
     "    experiment_id=\"piControl-spinup\",\n",

--- a/notebooks/Getting_started.ipynb
+++ b/notebooks/Getting_started.ipynb
@@ -863,16 +863,18 @@
    "source": [
     "## Data selection\n",
     "\n",
-    "The `ACCESS_ESM_CMORiser` class (described in detail below) takes as input a list of paths to NetCDF files containing the raw model output variables to be CMORised. The CMORiser does **not** assume any specific folder structure, DRS (Data Reference Syntax), or file naming convention. It is intentionally left to the user to ensure that the provided files contain the original variables required for CMORisation.\n",
+    "`ACCESS_ESM_CMORiser` supports two ways to supply input data:\n",
     "\n",
-    "For this example, we will be using data from the **December Spin-up run for ACCESS-ESM1.6 development**. This dataset is available on NCI at `/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/spinup/Dec25-PI-control` and represents an important milestone in the ACCESS-ESM1.6 model development process. Using this dataset allows us to demonstrate CMORisation with realistic ACCESS model output that's being prepared for CMIP7.\n",
+    "**Option 1 — `input_folder` (recommended):** pass the archive root directory and ACCESS-MOPPy discovers the right files automatically, using the variable's mapping entry and the model's `file_discovery` configuration.  No glob patterns required.\n",
     "\n",
-    "This design is intentional: ACCESS-NRI plans to integrate ACCESS-MOPPeR into extended workflows that leverage the [ACCESS-NRI Intake Catalog](https://github.com/ACCESS-NRI/access-nri-intake-catalog) or evaluation frameworks such as [ESMValTool](https://www.esmvaltool.org/) and [ILAMB](https://www.ilamb.org/). By decoupling file selection from the CMORiser, ACCESS-MOPPeR can be flexibly used in a variety of data processing and evaluation pipelines."
+    "**Option 2 — `input_data`:** pass an explicit list of file paths.  Useful when you need precise control or when the archive layout differs from the model defaults.\n",
+    "\n",
+    "For this notebook we use the **December Spin-up run for ACCESS-ESM1.6 development**, available on NCI at `/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/spinup/Dec25-PI-control`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "26d5bf0b",
    "metadata": {},
    "outputs": [
@@ -890,27 +892,14 @@
     }
    ],
    "source": [
-    "# Define the root folder path for the ACCESS-ESM1.6 December Spin-up dataset\n",
-    "# This path will be used consistently throughout the notebook for all model components\n",
-    "ROOT_FOLDER = \"/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/spinup/Dec25-PI-control/\"\n",
-    "\n",
-    "# Define target folder patterns for different model components\n",
-    "ATMOS_FOLDERS = \"output40[0-1]/atmosphere/netCDF/\"\n",
-    "OCEAN_FOLDERS = \"output40[0-9]/ocean/\"\n",
-    "LAND_FOLDERS = \"output40[0-1]/atmosphere/netCDF/\"\n",
-    "OCEAN_GRID_FOLDERS = \"output401/ocean/\"  # Specific folder for ocean grid files\n",
-    "\n",
-    "print(f\"Using dataset from: {ROOT_FOLDER}\")\n",
-    "print(\"Target folders:\")\n",
-    "print(f\"  Atmosphere: {ATMOS_FOLDERS}\")\n",
-    "print(f\"  Ocean: {OCEAN_FOLDERS}\")\n",
-    "print(f\"  Land: {LAND_FOLDERS}\")\n",
-    "print(f\"  Ocean Grid: {OCEAN_GRID_FOLDERS}\")"
+    "# Root of the payu archive — used throughout the notebook\n",
+    "ARCHIVE_ROOT = \"/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/spinup/Dec25-PI-control\"\n",
+    "print(f\"Archive root: {ARCHIVE_ROOT}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "f49fd1d4-dcb6-47a8-9d4a-731a7ca1ea0d",
    "metadata": {},
    "outputs": [
@@ -923,12 +912,11 @@
     }
    ],
    "source": [
-    "# Here we use NetCDF files from the ACCESS-ESM1.6 December Spin-up run\n",
-    "# This data is from the development of ACCESS-ESM1.6 for CMIP7\n",
+    "# Optional — build an explicit file list if you need fine-grained control.\n",
+    "# When using input_folder, ACCESS-MOPPy does this automatically.\n",
     "import glob\n",
-    "\n",
-    "files = glob.glob(ROOT_FOLDER + ATMOS_FOLDERS + \"aiihca.pa-*_mon.nc\")\n",
-    "print(f\"Found {len(files)} atmospheric files for CMORisation\")"
+    "files = glob.glob(ARCHIVE_ROOT + \"/output40[0-1]/atmosphere/netCDF/aiihca.pa-*_mon.nc\")\n",
+    "print(f\"Explicit file list: {len(files)} atmospheric file(s) found\")"
    ]
   },
   {
@@ -957,9 +945,6 @@
    "outputs": [],
    "source": [
     "from access_moppy.file_discovery import discover_files\n",
-    "\n",
-    "# Root of the payu archive (contains output000/, output001/, …)\n",
-    "ARCHIVE_ROOT = \"/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/spinup/Dec25-PI-control\"\n",
     "\n",
     "# --- Atmosphere: monthly surface downwelling shortwave ---\n",
     "# All monthly atmosphere variables are packed in the same UM output file.\n",
@@ -1042,11 +1027,12 @@
    "source": [
     "## Set up the CMORiser for CMORisation\n",
     "\n",
-    "To begin the CMORisation process, you need to create an instance of the `ACCESS_ESM_CMORiser` class. This class requires several key parameters, including the list of input NetCDF files and metadata describing your experiment.\n",
+    "To begin the CMORisation process, create an instance of `ACCESS_ESM_CMORiser`.  \n",
+    "The simplest approach is to pass `input_folder` — the archive root — and let ACCESS-MOPPy discover the input files automatically.  \n",
+    "You can optionally narrow the time range with `start_year` / `end_year`.\n",
     "\n",
-    "A crucial parameter is the `compound_name`, which should be specified using the full CMIP convention: `table.variable` (for example, `Amon.rsds`). This format uniquely identifies the variable, its frequency (e.g., monthly, daily), and the associated CMIP table, ensuring that all requirements for grids and metadata are correctly handled. Using the full compound name helps avoid ambiguity and guarantees that the CMORiser applies the correct standards for each variable.\n",
-    "\n",
-    "You can also provide additional metadata such as `experiment_id`, `source_id`, `variant_label`, and `grid_label` to ensure your output is CMIP-compliant. Optionally, you may include parent experiment information for full provenance tracking."
+    "A crucial parameter is `compound_name`, specified as `table.variable` (e.g. `Amon.rsds`).  \n",
+    "This uniquely identifies the variable, its output frequency, and the CMIP table, so the correct metadata standards are applied automatically."
    ]
   },
   {
@@ -1056,12 +1042,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use the auto-discovered files (or substitute `files` for the manually-built list above)\n",
+    "# input_folder triggers automatic file discovery — no glob required.\n",
+    "# Optionally restrict the time range with start_year / end_year.\n",
     "cmoriser = ACCESS_ESM_CMORiser(\n",
-    "    input_data=atmos_files,  # <-- swap in ocean_files, siconc_files, etc. as needed\n",
+    "    input_folder=ARCHIVE_ROOT,       # archive root; files are auto-discovered\n",
+    "    # start_year=1990, end_year=1999  # optional year filter\n",
     "    compound_name=\"Amon.rsds\",\n",
     "    experiment_id=\"piControl-spinup\",\n",
-    "    source_id=\"ACCESS-ESM1-5\",  # <-- ACCESS-ESM1-6 is not yet registered in the CMIP6 catalog\n",
+    "    source_id=\"ACCESS-ESM1-5\",  # ACCESS-ESM1-6 not yet in the CMIP6 catalog\n",
     "    variant_label=\"r1i1p1f1\",\n",
     "    grid_label=\"gn\",\n",
     "    activity_id=\"CMIP\",\n",
@@ -1254,7 +1242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "5834e61b",
    "metadata": {},
    "outputs": [
@@ -1336,7 +1324,7 @@
    "source": [
     "# Create a CMORiser for a different variable to see mapping differences\n",
     "tas_cmoriser = ACCESS_ESM_CMORiser(\n",
-    "    input_data=files,  # Can reuse the same files if they contain temperature data\n",
+    "    input_folder=ARCHIVE_ROOT,\n",
     "    compound_name=\"Amon.tas\",  # Near-surface air temperature\n",
     "    experiment_id=\"historical\",\n",
     "    source_id=\"ACCESS-ESM1-5\",\n",
@@ -1363,7 +1351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "ab088c31",
    "metadata": {},
    "outputs": [
@@ -1376,19 +1364,19 @@
     }
    ],
    "source": [
-    "# Import the ocean file discovery utility function from access_moppy\n",
-    "from access_moppy.utilities import get_monthly_ocean_files\n",
+    "# Preview which ocean salinity files will be used (optional — for inspection only).\n",
+    "# ACCESS_ESM_CMORiser does this internally when you pass input_folder.\n",
+    "from access_moppy.file_discovery import discover_files\n",
     "\n",
-    "# Find ocean salinity files using the utility function with explicit paths\n",
-    "ocean_files = get_monthly_ocean_files(\n",
-    "    \"Omon.so\", root_folder=ROOT_FOLDER, target_folders=OCEAN_FOLDERS\n",
-    ")\n",
-    "print(f\"Ocean files: {ocean_files[:2]}...\")  # Show first 2 files"
+    "ocean_files = discover_files(ARCHIVE_ROOT, \"Omon.so\")\n",
+    "print(f\"Omon.so → {len(ocean_files)} file(s)\")\n",
+    "for f in ocean_files[:3]:\n",
+    "    print(f\"  {f}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "3ec3b036",
    "metadata": {},
    "outputs": [
@@ -1460,9 +1448,9 @@
     }
    ],
    "source": [
-    "# Create a CMORiser for ocean salinity\n",
+    "# Create a CMORiser for ocean salinity — discovery handled automatically\n",
     "ocean_cmoriser = ACCESS_ESM_CMORiser(\n",
-    "    input_data=ocean_files,\n",
+    "    input_folder=ARCHIVE_ROOT,\n",
     "    compound_name=\"Omon.so\",  # Ocean salinity\n",
     "    experiment_id=\"piControl-spinup\",\n",
     "    source_id=\"ACCESS-ESM1-5\",\n",
@@ -1488,7 +1476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "1bbeb280",
    "metadata": {},
    "outputs": [
@@ -1567,11 +1555,12 @@
     }
    ],
    "source": [
-    "# Example: Ocean cell area (areacello)\n",
-    "# Use the predefined folder paths for consistency\n",
+    "# Example: Ocean cell area (areacello) — an Ofx (fixed/time-invariant) variable.\n",
+    "# These specific grid files are passed explicitly because they are well-known\n",
+    "# static files rather than time-varying output cycles.\n",
     "grid_files = [\n",
-    "    ROOT_FOLDER + OCEAN_GRID_FOLDERS + \"ocean-2d-area_t.nc\",\n",
-    "    ROOT_FOLDER + OCEAN_GRID_FOLDERS + \"ocean-2d-ht.nc\",  # Needed for depth info\n",
+    "    ARCHIVE_ROOT + \"/output401/ocean/ocean-2d-area_t.nc\",\n",
+    "    ARCHIVE_ROOT + \"/output401/ocean/ocean-2d-ht.nc\",  # needed for depth info\n",
     "]\n",
     "\n",
     "# Create CMORiser for ocean cell area\n",
@@ -1584,10 +1573,7 @@
     "    grid_label=\"gn\",\n",
     "    activity_id=\"CMIP\",\n",
     "    parent_info=parent_experiment_config,\n",
-    ")\n",
-    "\n",
-    "# Display the mapping for ocean cell area\n",
-    "areacello_cmoriser.variable_mapping"
+    ")"
    ]
   },
   {
@@ -1637,7 +1623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "ebdb82ba",
    "metadata": {},
    "outputs": [
@@ -1724,13 +1710,8 @@
    ],
    "source": [
     "# Example 1: Land Monthly Variable - Surface Runoff (mrro)\n",
-    "# Use the predefined folder paths for consistency\n",
-    "land_files = glob.glob(ROOT_FOLDER + LAND_FOLDERS + \"aiihca.pe-*_mon.nc\")\n",
-    "print(f\"Found {len(land_files)} land files\")\n",
-    "\n",
-    "# Create CMORiser for land surface runoff\n",
     "land_cmoriser = ACCESS_ESM_CMORiser(\n",
-    "    input_data=land_files,\n",
+    "    input_folder=ARCHIVE_ROOT,\n",
     "    compound_name=\"Lmon.mrro\",  # Surface runoff\n",
     "    experiment_id=\"piControl-spinup\",\n",
     "    source_id=\"ACCESS-ESM1-5\",\n",
@@ -1746,7 +1727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "46b6b00a",
    "metadata": {},
    "outputs": [
@@ -1825,11 +1806,10 @@
     }
    ],
    "source": [
-    "# Example 2: Earth System Monthly Variable\n",
-    "# Carbon cycle variables are also in land component files but use Emon table\n",
+    "# Example 2: Earth System Monthly Variable - Carbon stock on land (cLand)\n",
     "emon_cmoriser = ACCESS_ESM_CMORiser(\n",
-    "    input_data=land_files,  # Can reuse the same land files\n",
-    "    compound_name=\"Emon.cLand\",  # Gross Primary Productivity\n",
+    "    input_folder=ARCHIVE_ROOT,\n",
+    "    compound_name=\"Emon.cLand\",\n",
     "    experiment_id=\"piControl-spinup\",\n",
     "    source_id=\"ACCESS-ESM1-5\",\n",
     "    variant_label=\"r1i1p1f1\",\n",

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -11,6 +11,7 @@ import xarray as xr
 
 from access_moppy.atmosphere import Atmosphere_CMORiser
 from access_moppy.defaults import _default_parent_info
+from access_moppy.file_discovery import FileDiscoveryError, discover_files
 from access_moppy.ocean import Ocean_CMORiser_OM2, Ocean_CMORiser_OM3
 from access_moppy.sea_ice import SeaIce_CMORiser
 from access_moppy.utilities import (
@@ -22,7 +23,6 @@ from access_moppy.utilities import (
     load_cmip6_to_cmip7_mapping,
     load_model_mappings,
 )
-from access_moppy.file_discovery import FileDiscoveryError, discover_files
 from access_moppy.vocabulary_processors import (
     CMIP6PlusMIPVocabulary,
     CMIP6PlusVocabulary,

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -11,7 +11,11 @@ import xarray as xr
 
 from access_moppy.atmosphere import Atmosphere_CMORiser
 from access_moppy.defaults import _default_parent_info
-from access_moppy.file_discovery import FileDiscoveryError, discover_files
+from access_moppy.file_discovery import (
+    FileDiscoveryError,
+    _diagnose_no_files,
+    discover_files,
+)
 from access_moppy.ocean import Ocean_CMORiser_OM2, Ocean_CMORiser_OM3
 from access_moppy.sea_ice import SeaIce_CMORiser
 from access_moppy.utilities import (
@@ -121,8 +125,8 @@ class ACCESS_ESM_CMORiser:
         enable_chunking: bool = False,
         resampling_method: str = "auto",
         input_folder: str | Path | None = None,
-        start_year: int | None = None,
-        end_year: int | None = None,
+        start_year: int | str | None = None,
+        end_year: int | str | None = None,
         # Backward compatibility
         input_paths: str | Path | list[str | Path] | None = None,
     ) -> None:
@@ -164,9 +168,11 @@ class ACCESS_ESM_CMORiser:
                 ``input_data``.
             start_year: When ``input_folder`` is used, exclude files whose
                 year (parsed from the filename) is strictly before
-                *start_year*.
+                *start_year*.  Accepts an integer or a zero-padded string
+                (e.g. ``"0001"``), useful for pi-control experiments.
             end_year: When ``input_folder`` is used, exclude files whose
                 year (parsed from the filename) is strictly after *end_year*.
+                Accepts the same formats as *start_year*.
             input_paths: Deprecated alias for ``input_data`` retained for
                 backward compatibility.
 
@@ -279,9 +285,17 @@ class ACCESS_ESM_CMORiser:
                 ) from exc
 
             if not discovered:
+                diag = _diagnose_no_files(
+                    input_root=Path(input_folder),
+                    compound_name=self.cmip6_compound_name,
+                    model_id=model_id or _DEFAULT_MODEL_ID,
+                    start_year=start_year,
+                    end_year=end_year,
+                )
                 raise ValueError(
-                    f"No files found for '{self.cmip6_compound_name}' under '{input_folder}'. "
-                    "Check the path or pass explicit file paths via 'input_data'."
+                    f"No files found for '{self.cmip6_compound_name}' "
+                    f"under '{input_folder}'. {diag} "
+                    "Pass explicit file paths via 'input_data' to bypass discovery."
                 )
 
             input_data = [str(p) for p in discovered]

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -22,6 +22,7 @@ from access_moppy.utilities import (
     load_cmip6_to_cmip7_mapping,
     load_model_mappings,
 )
+from access_moppy.file_discovery import FileDiscoveryError, discover_files
 from access_moppy.vocabulary_processors import (
     CMIP6PlusMIPVocabulary,
     CMIP6PlusVocabulary,
@@ -119,6 +120,9 @@ class ACCESS_ESM_CMORiser:
         enable_resampling: bool = False,
         enable_chunking: bool = False,
         resampling_method: str = "auto",
+        input_folder: str | Path | None = None,
+        start_year: int | None = None,
+        end_year: int | None = None,
         # Backward compatibility
         input_paths: str | Path | list[str | Path] | None = None,
     ) -> None:
@@ -153,6 +157,16 @@ class ACCESS_ESM_CMORiser:
             resampling_method: Temporal resampling method: ``"auto"``,
                 ``"mean"``, ``"sum"``, ``"min"``, ``"max"``, ``"first"``, or
                 ``"last"``.
+            input_folder: Path to the raw model archive root (contains
+                ``output000/``, ``output001/``, …).  When provided, input
+                files are discovered automatically using the model mapping's
+                ``file_discovery`` configuration.  Mutually exclusive with
+                ``input_data``.
+            start_year: When ``input_folder`` is used, exclude files whose
+                year (parsed from the filename) is strictly before
+                *start_year*.
+            end_year: When ``input_folder`` is used, exclude files whose
+                year (parsed from the filename) is strictly after *end_year*.
             input_paths: Deprecated alias for ``input_data`` retained for
                 backward compatibility.
 
@@ -191,6 +205,12 @@ class ACCESS_ESM_CMORiser:
         elif input_paths is not None and input_data is not None:
             raise ValueError(
                 "Cannot specify both 'input_data' and 'input_paths'. Use 'input_data'."
+            )
+
+        if input_folder is not None and input_data is not None:
+            raise ValueError(
+                "Cannot specify both 'input_folder' and 'input_data'. "
+                "Use 'input_folder' for auto-discovery or 'input_data' for explicit paths."
             )
 
         # For CMIP7, map the compound name to CMIP6 equivalent if needed
@@ -241,6 +261,35 @@ class ACCESS_ESM_CMORiser:
             self.cmip6_compound_name = compound_name
             self.cmip7_compound_name = None
 
+        # Auto-discover input files when only a folder path is provided
+        if input_folder is not None:
+            try:
+                discovered = discover_files(
+                    input_folder,
+                    self.cmip6_compound_name,
+                    model_id=model_id or _DEFAULT_MODEL_ID,
+                    start_year=start_year,
+                    end_year=end_year,
+                )
+            except FileDiscoveryError as exc:
+                raise ValueError(
+                    f"Could not auto-discover files for '{self.cmip6_compound_name}': {exc}\n"
+                    "Add a 'file_pattern' field to the variable's mapping entry or "
+                    "pass explicit file paths via 'input_data'."
+                ) from exc
+
+            if not discovered:
+                raise ValueError(
+                    f"No files found for '{self.cmip6_compound_name}' under '{input_folder}'. "
+                    "Check the path or pass explicit file paths via 'input_data'."
+                )
+
+            input_data = [str(p) for p in discovered]
+            print(
+                f"✓ Auto-discovered {len(input_data)} file(s) for "
+                f"{self.cmip6_compound_name} under '{input_folder}'"
+            )
+
         # Check if this is an internal calculation that doesn't need input data
         is_internal_calc = False
         ressource_file = None
@@ -258,7 +307,7 @@ class ACCESS_ESM_CMORiser:
             isinstance(model_vars, list) and len(model_vars) == 0
         )
 
-        if input_paths is None and input_data is None:
+        if input_folder is None and input_paths is None and input_data is None:
             if is_self_contained:
                 pass  # no input data needed
             elif ressource_file is not None:

--- a/src/access_moppy/examples/batch_config.yml
+++ b/src/access_moppy/examples/batch_config.yml
@@ -25,20 +25,20 @@ activity_id: CMIP
 input_folder: "/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/spinup/JuneSpinUp-JuneSpinUp-bfaa9c5b"
 output_folder: "/scratch/tm70/rb5533/moppy_output"
 
+# Optional: model_id selects which mapping file drives auto file-discovery.
+# Defaults to "ACCESS-ESM1.6" when omitted.
+# model_id: ACCESS-ESM1.6
 
-# Optional: File patterns for each variable
-# If not specified, will use default patterns
-file_patterns:
-  Amon.pr: "/output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
-  Omon.tos: "/output[0-4][0-9][0-9]/ocean/ocean-2d-surface_temp-1monthly-mean*.nc"
-  Amon.tauu: "/output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
-  Amon.ts: "/output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
-  Omon.zos: "/output[0-4][0-9][0-9]/ocean/ocean-2d-sea_level-1monthly-mean*.nc"
-  Amon.hfss: "/output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
-  Amon.rlds: "/output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
-  Amon.rlus: "/output[0-4][0-9][0-9][0-9]/atmosphere/netCDF/*mon.nc"
-  Amon.rsds: "/output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
-  Amon.rsus: "/output[0-4][0-9][0-9][0-9]/atmosphere/netCDF/*mon.nc"
+# Optional: File patterns per variable.
+# When omitted, MOPPy auto-discovers files using the file_discovery config
+# embedded in the model mapping JSON (recommended).
+# Provide explicit patterns only when you need to override the defaults —
+# for example to restrict to a specific set of output folders, or when
+# processing data from a non-standard layout.
+#
+# file_patterns:
+#   Amon.pr:  "/output[0-4][0-9][0-9]/atmosphere/netCDF/*mon.nc"
+#   Omon.tos: "/output[0-4][0-9][0-9]/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc"
 
 
 # Optional: DRS root (if you want to organize output in CMIP6 DRS structure)

--- a/src/access_moppy/file_discovery.py
+++ b/src/access_moppy/file_discovery.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import glob as _glob
 import json
 import re
+from functools import cache
 from importlib.resources import files
 from pathlib import Path
 from typing import Optional

--- a/src/access_moppy/file_discovery.py
+++ b/src/access_moppy/file_discovery.py
@@ -115,9 +115,7 @@ def _load_full_mappings(model_id: str) -> dict:
     return json.loads(entry.read_text(encoding="utf-8"))
 
 
-def _find_variable_entry(
-    all_mappings: dict, cmor_name: str
-) -> tuple[str, dict] | None:
+def _find_variable_entry(all_mappings: dict, cmor_name: str) -> tuple[str, dict] | None:
     """Return ``(component, variable_entry)`` for *cmor_name*, or ``None``."""
     for component in _COMPONENT_SEARCH_ORDER:
         comp_data = all_mappings.get(component, {})

--- a/src/access_moppy/file_discovery.py
+++ b/src/access_moppy/file_discovery.py
@@ -102,9 +102,10 @@ class FileDiscoveryError(Exception):
 # ---------------------------------------------------------------------------
 
 
+@cache
 def _load_full_mappings(model_id: str) -> dict:
     """Load and return the complete mapping JSON for *model_id*."""
-    mapping_dir = files("access_moppy.mappings")
+    mapping_dir = files("access_moppy").joinpath("mappings")
     model_file = f"{model_id}_mappings.json"
     entry = mapping_dir / model_file
     if not entry.is_file():

--- a/src/access_moppy/file_discovery.py
+++ b/src/access_moppy/file_discovery.py
@@ -141,6 +141,10 @@ def _extract_year_from_path(path: Path) -> int | None:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     * ``tos_mean_ocean_1mon_185001-185012.nc`` → ``1850``  (start of range)
     * ``wt_mean_ocean_1yr_234501-234512.nc``   → ``2345``
+
+    Spinup / alternative legacy pattern
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    * ``ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc`` → ``1``  (spinup, ``_YYYY_MM``)
     """
     name = path.stem  # strip .nc extension
     # Unified pattern: _YYYYMM-YYYYMM at end of stem (start of time range)
@@ -151,12 +155,18 @@ def _extract_year_from_path(path: Path) -> int | None:
     m = re.search(r"_(\d{4})(?:-\d{2})?$", name)
     if m:
         return int(m.group(1))
+    # Spinup / alternative legacy: _YYYY_MM with underscore separator
+    m = re.search(r"_(\d{4})_\d{2}$", name)
+    if m:
+        return int(m.group(1))
     # Legacy: embedded YYYYMM inside stem (atmosphere: pa-185001_mon)
     m = re.search(r"-(\d{4})\d{2}(?:_|$)", name)
     if m:
         return int(m.group(1))
-    # Fallback: last 4-digit sequence that looks like a plausible year
-    candidates = [int(y) for y in re.findall(r"\d{4}", name) if 1000 <= int(y) <= 2999]
+    # Fallback: last 4-digit sequence that looks like a plausible year.
+    # Upper bound guards against matching unrelated integers; no lower bound
+    # so that spinup years below 1000 are not silently dropped.
+    candidates = [int(y) for y in re.findall(r"\d{4}", name) if int(y) <= 2999]
     return candidates[-1] if candidates else None
 
 

--- a/src/access_moppy/file_discovery.py
+++ b/src/access_moppy/file_discovery.py
@@ -186,7 +186,7 @@ def _build_patterns(
     if comp_cfg is None:
         raise FileDiscoveryError(
             f"No file_discovery config for component '{component}'. "
-            "Add a 'file_discovery.components.{component}' block to model_info "
+            f"Add a 'file_discovery.components.{component}' block to model_info "
             "or a per-variable 'file_pattern' to the mapping entry."
         )
 

--- a/src/access_moppy/file_discovery.py
+++ b/src/access_moppy/file_discovery.py
@@ -1,0 +1,336 @@
+"""
+Automatic file discovery for ACCESS model raw output.
+
+Given a CMIP compound name (e.g. ``"Omon.tos"``), this module finds the
+corresponding raw NetCDF files under a payu archive root without the user
+having to specify glob patterns manually.
+
+Discovery resolution order
+--------------------------
+1. Per-variable ``file_pattern`` in the mapping entry — explicit override,
+   useful for edge-cases or legacy folder layouts.
+2. Component-level ``frequency_patterns`` from the ``model_info.file_discovery``
+   block in the model mapping JSON, with ``{model_var}`` substituted by every
+   entry in ``model_variables`` (one file per model variable, as used by the
+   ocean component).  Atmosphere and sea-ice components pack all variables into
+   a single file per frequency, so no substitution is needed there.
+3. :class:`FileDiscoveryError` is raised when neither source provides a pattern.
+
+Year-based filtering
+--------------------
+Pass ``start_year`` and/or ``end_year`` to restrict the returned file list to
+a particular time range.  Filtering is performed by parsing the year directly
+from the filename (no file I/O), so it is cheap even for large archives.
+"""
+
+from __future__ import annotations
+
+import glob as _glob
+import json
+import re
+from importlib.resources import files
+from pathlib import Path
+from typing import Optional
+
+__all__ = ["discover_files", "FileDiscoveryError"]
+
+
+# ---------------------------------------------------------------------------
+# CMIP table → frequency key used inside file_discovery patterns
+# ---------------------------------------------------------------------------
+
+_TABLE_TO_FREQ: dict[str, str] = {
+    # Monthly
+    "Amon": "mon",
+    "Lmon": "mon",
+    "Omon": "mon",
+    "SImon": "mon",
+    "CFmon": "mon",
+    "AERmon": "mon",
+    "Emon": "mon",
+    "LImon": "mon",
+    "OImon": "mon",
+    # Daily
+    "day": "day",
+    "Oday": "day",
+    "SIday": "day",
+    "Aday": "day",
+    # 3-hourly
+    "3hr": "3hr",
+    "E3hr": "3hr",
+    "CF3hr": "3hr",
+    # 6-hourly
+    "6hrLev": "6hr",
+    "6hrPlev": "6hr",
+    "6hrPlevPt": "6hr",
+    "E6hrZ": "6hr",
+    # Sub-hourly
+    "1hr": "subhr",
+    "Esubhr": "subhr",
+    # Yearly
+    "Oyr": "yr",
+    "yr": "yr",
+    "Eyr": "yr",
+    # Fixed / time-invariant
+    "fx": "fx",
+    "Ofx": "fx",
+}
+
+# Search order for components inside a mapping JSON
+_COMPONENT_SEARCH_ORDER = (
+    "aerosol",
+    "atmosphere",
+    "land",
+    "landIce",
+    "ocean",
+    "oceanBgchem",
+    "sea_ice",
+)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class FileDiscoveryError(Exception):
+    """Raised when no file pattern can be determined for a variable."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_full_mappings(model_id: str) -> dict:
+    """Load and return the complete mapping JSON for *model_id*."""
+    mapping_dir = files("access_moppy.mappings")
+    model_file = f"{model_id}_mappings.json"
+    entry = mapping_dir / model_file
+    if not entry.is_file():
+        raise FileDiscoveryError(
+            f"No mapping file found for model '{model_id}'. "
+            "Check that the model_id is correct and a mapping JSON is bundled."
+        )
+    return json.loads(entry.read_text(encoding="utf-8"))
+
+
+def _find_variable_entry(
+    all_mappings: dict, cmor_name: str
+) -> tuple[str, dict] | None:
+    """Return ``(component, variable_entry)`` for *cmor_name*, or ``None``."""
+    for component in _COMPONENT_SEARCH_ORDER:
+        comp_data = all_mappings.get(component, {})
+        if cmor_name in comp_data:
+            return component, comp_data[cmor_name]
+    return None
+
+
+def _extract_year_from_path(path: Path) -> int | None:
+    """Parse the start year from a model output filename.
+
+    Handles all known ACCESS filename conventions:
+
+    Legacy patterns
+    ~~~~~~~~~~~~~~~
+    * ``ocean-2d-tos-1mon-mean-y_1850.nc``   → ``1850``  (ocean, annual file)
+    * ``iceh-1monthly-mean_1850-01.nc``       → ``1850``  (ice, YYYY-MM suffix)
+    * ``aiihca.pa-185001_mon.nc``             → ``1850``  (atmosphere, embedded YYYYMM)
+
+    Proposed unified pattern (``YYYYMM-YYYYMM`` range)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    * ``tos_mean_ocean_1mon_185001-185012.nc`` → ``1850``  (start of range)
+    * ``wt_mean_ocean_1yr_234501-234512.nc``   → ``2345``
+    """
+    name = path.stem  # strip .nc extension
+    # Unified pattern: _YYYYMM-YYYYMM at end of stem (start of time range)
+    m = re.search(r"_(\d{6})-\d{6}$", name)
+    if m:
+        return int(m.group(1)[:4])
+    # Legacy: _YYYY or _YYYY-MM at end of stem (ocean annual, ice monthly)
+    m = re.search(r"_(\d{4})(?:-\d{2})?$", name)
+    if m:
+        return int(m.group(1))
+    # Legacy: embedded YYYYMM inside stem (atmosphere: pa-185001_mon)
+    m = re.search(r"-(\d{4})\d{2}(?:_|$)", name)
+    if m:
+        return int(m.group(1))
+    # Fallback: last 4-digit sequence that looks like a plausible year
+    candidates = [int(y) for y in re.findall(r"\d{4}", name) if 1000 <= int(y) <= 2999]
+    return candidates[-1] if candidates else None
+
+
+def _build_patterns(
+    var_entry: dict,
+    component: str,
+    freq: str,
+    file_discovery_cfg: dict,
+) -> list[str]:
+    """Return a list of relative glob patterns (relative to ``input_root``).
+
+    Patterns are built from the per-variable ``file_pattern`` override if
+    present, otherwise from the component-level ``frequency_patterns`` in
+    ``file_discovery_cfg``.
+
+    Each pattern is relative to the run root so that the caller can prepend
+    ``input_root`` before globbing.
+    """
+    # --- Per-variable explicit override ---
+    explicit = var_entry.get("file_pattern")
+    if explicit:
+        # Explicit patterns are already relative to input_root
+        return [explicit] if isinstance(explicit, str) else list(explicit)
+
+    # --- Component-level config ---
+    comp_cfg = file_discovery_cfg.get("components", {}).get(component)
+    if comp_cfg is None:
+        raise FileDiscoveryError(
+            f"No file_discovery config for component '{component}'. "
+            "Add a 'file_discovery.components.{component}' block to model_info "
+            "or a per-variable 'file_pattern' to the mapping entry."
+        )
+
+    freq_patterns = comp_cfg.get("frequency_patterns", {})
+    file_glob = freq_patterns.get(freq)
+    if file_glob is None:
+        raise FileDiscoveryError(
+            f"No pattern for frequency '{freq}' under component '{component}'. "
+            f"Available frequencies: {list(freq_patterns)}."
+        )
+
+    subdir = comp_cfg.get("subdir", "")
+    output_dir_pattern = file_discovery_cfg.get(
+        "output_dir_pattern", "output[0-9][0-9][0-9]"
+    )
+
+    if "{model_var}" in file_glob:
+        # Per-variable files (e.g. ocean): one pattern per model variable
+        model_variables = var_entry.get("model_variables") or []
+        if not model_variables:
+            raise FileDiscoveryError(
+                f"Pattern '{file_glob}' requires {{model_var}} substitution but "
+                "the mapping entry has no 'model_variables'."
+            )
+        return [
+            f"{output_dir_pattern}/{subdir}/{file_glob.replace('{model_var}', mv)}"
+            for mv in model_variables
+        ]
+    else:
+        # Single file per frequency (atmosphere, sea-ice): all vars packed in
+        return [f"{output_dir_pattern}/{subdir}/{file_glob}"]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def discover_files(
+    input_root: str | Path,
+    compound_name: str,
+    model_id: str = "ACCESS-ESM1.6",
+    start_year: Optional[int] = None,
+    end_year: Optional[int] = None,
+) -> list[Path]:
+    """Discover raw model output files for a CMIP variable.
+
+    Parameters
+    ----------
+    input_root:
+        Root directory of the payu archive (contains ``output000/``,
+        ``output001/``, …).
+    compound_name:
+        CMIP compound name such as ``"Omon.tos"`` or ``"Amon.tas"``.
+    model_id:
+        ACCESS model identifier that selects the mapping JSON.
+        Defaults to ``"ACCESS-ESM1.6"``.
+    start_year:
+        When given, files whose year (parsed from the filename) is strictly
+        before *start_year* are excluded.  No file I/O is performed.
+    end_year:
+        When given, files whose year is strictly after *end_year* are excluded.
+
+    Returns
+    -------
+    list[Path]
+        Sorted, deduplicated list of matching :class:`~pathlib.Path` objects.
+
+    Raises
+    ------
+    FileDiscoveryError
+        If the variable has no mapping, the component has no
+        ``file_discovery`` config, or the frequency is not recognised.
+    ValueError
+        If *compound_name* is not in ``"table.variable"`` format.
+
+    Examples
+    --------
+    Discover all monthly ocean surface-temperature files::
+
+        files = discover_files("/g/data/.../archive", "Omon.tos")
+
+    Restrict to a decade::
+
+        files = discover_files(
+            "/g/data/.../archive", "Amon.tas",
+            start_year=1990, end_year=1999,
+        )
+    """
+    if "." not in compound_name:
+        raise ValueError(
+            f"Invalid compound_name '{compound_name}'. "
+            "Expected 'table.variable' format, e.g. 'Omon.tos'."
+        )
+
+    input_root = Path(input_root)
+    table, cmor_name = compound_name.split(".", 1)
+
+    all_mappings = _load_full_mappings(model_id)
+    model_info = all_mappings.get("model_info", {})
+    file_discovery_cfg = model_info.get("file_discovery", {})
+
+    # Locate the variable in the mapping
+    found = _find_variable_entry(all_mappings, cmor_name)
+    if found is None:
+        raise FileDiscoveryError(
+            f"Variable '{cmor_name}' not found in mappings for model '{model_id}'. "
+            "Add a mapping entry or specify an explicit 'file_pattern' in the mapping."
+        )
+    component, var_entry = found
+
+    # Determine output frequency from the CMIP table name
+    freq = _TABLE_TO_FREQ.get(table)
+    if freq is None:
+        raise FileDiscoveryError(
+            f"Unknown CMIP table '{table}' — cannot determine output frequency. "
+            "Add it to file_discovery._TABLE_TO_FREQ or use a per-variable "
+            "'file_pattern' in the mapping entry."
+        )
+
+    # Build glob patterns (relative to input_root)
+    patterns = _build_patterns(var_entry, component, freq, file_discovery_cfg)
+
+    # Glob
+    found_paths: set[Path] = set()
+    for pattern in patterns:
+        full_pattern = str(input_root / pattern)
+        for match in _glob.glob(full_pattern):
+            found_paths.add(Path(match))
+
+    # Year-based filtering — filename-only, no file I/O
+    if start_year is not None or end_year is not None:
+        filtered: set[Path] = set()
+        for p in found_paths:
+            year = _extract_year_from_path(p)
+            if year is None:
+                # Cannot parse year — keep the file to be safe
+                filtered.add(p)
+                continue
+            if start_year is not None and year < start_year:
+                continue
+            if end_year is not None and year > end_year:
+                continue
+            filtered.add(p)
+        found_paths = filtered
+
+    return sorted(found_paths)

--- a/src/access_moppy/file_discovery.py
+++ b/src/access_moppy/file_discovery.py
@@ -31,7 +31,7 @@ import re
 from functools import cache
 from importlib.resources import files
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 __all__ = ["discover_files", "FileDiscoveryError"]
 
@@ -151,12 +151,12 @@ def _extract_year_from_path(path: Path) -> int | None:
     m = re.search(r"_(\d{6})-\d{6}$", name)
     if m:
         return int(m.group(1)[:4])
-    # Legacy: _YYYY or _YYYY-MM at end of stem (ocean annual, ice monthly)
-    m = re.search(r"_(\d{4})(?:-\d{2})?$", name)
+    # Newer ACCESS convention: trailing _YYYY_MM (e.g. "...-mean-ym_0001_01")
+    m = re.search(r"_(\d{4})_\d{2}$", name)
     if m:
         return int(m.group(1))
-    # Spinup / alternative legacy: _YYYY_MM with underscore separator
-    m = re.search(r"_(\d{4})_\d{2}$", name)
+    # Legacy: _YYYY or _YYYY-MM at end of stem (ocean annual, ice monthly)
+    m = re.search(r"_(\d{4})(?:-\d{2})?$", name)
     if m:
         return int(m.group(1))
     # Legacy: embedded YYYYMM inside stem (atmosphere: pa-185001_mon)
@@ -208,26 +208,35 @@ def _build_patterns(
             f"Available frequencies: {list(freq_patterns)}."
         )
 
+    # A frequency may map to a single glob (string) or several alternative
+    # globs (list).  The list form lets one mapping cover multiple raw-output
+    # naming conventions that appear in different experiments — e.g. the legacy
+    # "1mon-mean-y_*" and the newer "1monthly-mean-ym_*" ocean layouts.
+    globs = [file_glob] if isinstance(file_glob, str) else list(file_glob)
+
     subdir = comp_cfg.get("subdir", "")
     output_dir_pattern = file_discovery_cfg.get(
         "output_dir_pattern", "output[0-9][0-9][0-9]"
     )
 
-    if "{model_var}" in file_glob:
-        # Per-variable files (e.g. ocean): one pattern per model variable
-        model_variables = var_entry.get("model_variables") or []
-        if not model_variables:
-            raise FileDiscoveryError(
-                f"Pattern '{file_glob}' requires {{model_var}} substitution but "
-                "the mapping entry has no 'model_variables'."
+    patterns: list[str] = []
+    for file_glob in globs:
+        if "{model_var}" in file_glob:
+            # Per-variable files (e.g. ocean): one pattern per model variable
+            model_variables = var_entry.get("model_variables") or []
+            if not model_variables:
+                raise FileDiscoveryError(
+                    f"Pattern '{file_glob}' requires {{model_var}} substitution but "
+                    "the mapping entry has no 'model_variables'."
+                )
+            patterns.extend(
+                f"{output_dir_pattern}/{subdir}/{file_glob.replace('{model_var}', mv)}"
+                for mv in model_variables
             )
-        return [
-            f"{output_dir_pattern}/{subdir}/{file_glob.replace('{model_var}', mv)}"
-            for mv in model_variables
-        ]
-    else:
-        # Single file per frequency (atmosphere, sea-ice): all vars packed in
-        return [f"{output_dir_pattern}/{subdir}/{file_glob}"]
+        else:
+            # Single file per frequency (atmosphere, sea-ice): all vars packed in
+            patterns.append(f"{output_dir_pattern}/{subdir}/{file_glob}")
+    return patterns
 
 
 # ---------------------------------------------------------------------------
@@ -235,12 +244,112 @@ def _build_patterns(
 # ---------------------------------------------------------------------------
 
 
+def _diagnose_no_files(
+    input_root: Path,
+    compound_name: str,
+    model_id: str,
+    start_year: Optional[int],
+    end_year: Optional[int],
+) -> str:
+    """Return a human-readable explanation of why ``discover_files`` found nothing.
+
+    Called only when the main discovery returns an empty list.  Performs a
+    second, cheaper pass to distinguish three failure modes:
+
+    1. Year-filter excluded all matches — reports the years actually present.
+    2. Glob matched nothing — reports the output directories searched and the
+       patterns used.
+    3. No output directories exist at all — suggests checking the archive root.
+    """
+    table, cmor_name = compound_name.split(".", 1)
+    all_mappings = _load_full_mappings(model_id)
+    model_info = all_mappings.get("model_info", {})
+    file_discovery_cfg = model_info.get("file_discovery", {})
+
+    found = _find_variable_entry(all_mappings, cmor_name)
+    if found is None:
+        return ""  # already handled by FileDiscoveryError before we reach this
+
+    component, var_entry = found
+    freq = _TABLE_TO_FREQ.get(table)
+    if freq is None:
+        return ""
+
+    try:
+        patterns = _build_patterns(var_entry, component, freq, file_discovery_cfg)
+    except FileDiscoveryError:
+        return ""
+
+    # Glob without any year filter
+    pre_filter: list[Path] = []
+    for pattern in patterns:
+        pre_filter.extend(Path(m) for m in _glob.glob(str(input_root / pattern)))
+
+    if pre_filter:
+        # Files exist — year filter was the culprit
+        years = sorted(
+            y for p in pre_filter if (y := _extract_year_from_path(p)) is not None
+        )
+        year_range = f"{years[0]}–{years[-1]}" if years else "unknown"
+        parts = []
+        if start_year is not None:
+            parts.append(f"start_year={start_year}")
+        if end_year is not None:
+            parts.append(f"end_year={end_year}")
+        requested = ", ".join(parts)
+        return (
+            f"{len(pre_filter)} file(s) matched the '{freq}' pattern for '{cmor_name}' "
+            f"(available years: {year_range}), but none fell within the requested "
+            f"range ({requested})."
+        )
+
+    # No glob matches — check whether output directories exist at all
+    output_dir_pattern = file_discovery_cfg.get(
+        "output_dir_pattern", "output[0-9][0-9][0-9]"
+    )
+    output_dirs = sorted(input_root.glob(output_dir_pattern))
+    if not output_dirs:
+        return (
+            f"No directories matching '{output_dir_pattern}' found under "
+            f"'{input_root}'. Check that 'input_folder' points to the payu "
+            "archive root (the directory that contains output000/, output001/, …)."
+        )
+
+    dir_summary = (
+        f"{output_dirs[0].name}…{output_dirs[-1].name}"
+        if len(output_dirs) > 1
+        else output_dirs[0].name
+    )
+    return (
+        f"No '{freq}' files for '{cmor_name}' found in {len(output_dirs)} output "
+        f"director(y/ies) ({dir_summary}). "
+        f"Patterns searched: {patterns}."
+    )
+
+
+def _parse_year_arg(value: Union[int, str, None], param: str) -> Optional[int]:
+    """Normalise a *start_year* / *end_year* argument to a plain ``int``.
+
+    Accepts integers directly and zero-padded strings such as ``"0001"``
+    (common in pi-control experiments whose calendar begins at year 1).
+    """
+    if value is None or isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"'{param}' must be an integer or a zero-padded year string "
+            f"(e.g. 1 or '0001'), got {value!r}."
+        ) from None
+
+
 def discover_files(
     input_root: str | Path,
     compound_name: str,
     model_id: str = "ACCESS-ESM1.6",
-    start_year: Optional[int] = None,
-    end_year: Optional[int] = None,
+    start_year: Union[int, str, None] = None,
+    end_year: Union[int, str, None] = None,
 ) -> list[Path]:
     """Discover raw model output files for a CMIP variable.
 
@@ -257,8 +366,11 @@ def discover_files(
     start_year:
         When given, files whose year (parsed from the filename) is strictly
         before *start_year* are excluded.  No file I/O is performed.
+        Accepts an ``int`` or a zero-padded string (e.g. ``"0001"``), which
+        is useful for pi-control experiments whose calendar starts at year 1.
     end_year:
         When given, files whose year is strictly after *end_year* are excluded.
+        Accepts the same formats as *start_year*.
 
     Returns
     -------
@@ -286,6 +398,9 @@ def discover_files(
             start_year=1990, end_year=1999,
         )
     """
+    start_year = _parse_year_arg(start_year, "start_year")
+    end_year = _parse_year_arg(end_year, "end_year")
+
     if "." not in compound_name:
         raise ValueError(
             f"Invalid compound_name '{compound_name}'. "

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -56,17 +56,35 @@
                 "ocean": {
                     "subdir": "ocean",
                     "frequency_patterns": {
-                        "mon": "ocean-*-{model_var}-1mon*-mean-*_*.nc",
-                        "day": "ocean-*-{model_var}-1day-mean-y_*.nc",
-                        "yr":  "ocean-*-{model_var}-1yr-mean-y_*.nc",
-                        "fx":  "ocean-*-{model_var}-fx.nc"
+                        "mon": [
+                            "ocean-*-{model_var}-1mon-mean-y_*.nc",
+                            "ocean-*-{model_var}-1monthly-*-ym_*.nc"
+                        ],
+                        "day": [
+                            "ocean-*-{model_var}-1day-mean-y_*.nc",
+                            "ocean-*-{model_var}-1daily-*-ym_*.nc"
+                        ],
+                        "yr": [
+                            "ocean-*-{model_var}-1yr-mean-y_*.nc",
+                            "ocean-*-{model_var}-1yearly-*-ym_*.nc"
+                        ],
+                        "fx": [
+                            "ocean-*-{model_var}-fx.nc",
+                            "ocean-*-{model_var}.nc"
+                        ]
                     }
                 },
                 "oceanBgchem": {
                     "subdir": "ocean",
                     "frequency_patterns": {
-                        "mon": "ocean-*-{model_var}-1mon*-mean-*_*.nc",
-                        "yr":  "ocean-*-{model_var}-1yr-mean-y_*.nc"
+                        "mon": [
+                            "ocean-*-{model_var}-1mon-mean-y_*.nc",
+                            "oceanbgc-*-{model_var}-1monthly-*-ym_*.nc"
+                        ],
+                        "yr": [
+                            "ocean-*-{model_var}-1yr-mean-y_*.nc",
+                            "oceanbgc-*-{model_var}-1yearly-*-ym_*.nc"
+                        ]
                     }
                 }
             }

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -10,7 +10,127 @@
             "oceanBgchem",
             "sea_ice"
         ],
-        "description": "Variable mappings for ACCESS-ESM1.6 Earth System Model"
+        "description": "Variable mappings for ACCESS-ESM1.6 Earth System Model",
+        "file_discovery": {
+            "output_dir_pattern": "output[0-9][0-9][0-9]",
+            "components": {
+                "aerosol": {
+                    "subdir": "atmosphere/netCDF",
+                    "frequency_patterns": {
+                        "mon": "*.pa-*_mon.nc",
+                        "day": "*.pe-*_dai.nc",
+                        "3hr": "*.pi-*_3hr.nc",
+                        "6hr": "*.pj-*_6hr.nc"
+                    }
+                },
+                "atmosphere": {
+                    "subdir": "atmosphere/netCDF",
+                    "frequency_patterns": {
+                        "mon": "*.pa-*_mon.nc",
+                        "day": "*.pe-*_dai.nc",
+                        "3hr": "*.pi-*_3hr.nc",
+                        "6hr": "*.pj-*_6hr.nc",
+                        "subhr": "*.pc-*.nc"
+                    }
+                },
+                "land": {
+                    "subdir": "atmosphere/netCDF",
+                    "frequency_patterns": {
+                        "mon": "*.pa-*_mon.nc",
+                        "day": "*.pe-*_dai.nc"
+                    }
+                },
+                "landIce": {
+                    "subdir": "atmosphere/netCDF",
+                    "frequency_patterns": {
+                        "mon": "*.pa-*_mon.nc"
+                    }
+                },
+                "sea_ice": {
+                    "subdir": "ice",
+                    "frequency_patterns": {
+                        "mon": "iceh-1monthly-mean_*.nc",
+                        "day": "iceh-1daily-mean_*.nc"
+                    }
+                },
+                "ocean": {
+                    "subdir": "ocean",
+                    "frequency_patterns": {
+                        "mon": "ocean-*-{model_var}-1mon-mean-y_*.nc",
+                        "day": "ocean-*-{model_var}-1day-mean-y_*.nc",
+                        "yr":  "ocean-*-{model_var}-1yr-mean-y_*.nc",
+                        "fx":  "ocean-*-{model_var}-fx.nc"
+                    }
+                },
+                "oceanBgchem": {
+                    "subdir": "ocean",
+                    "frequency_patterns": {
+                        "mon": "ocean-*-{model_var}-1mon-mean-y_*.nc",
+                        "yr":  "ocean-*-{model_var}-1yr-mean-y_*.nc"
+                    }
+                }
+            }
+        },
+        "file_discovery_unified": {
+            "_comment": "Proposed unified naming scheme (ACCESS-ESM1.6 future layout). Activate by pointing file_discovery at this block or by using a dedicated mapping file. All components use one-variable-per-file following the pattern: {model_var}_*_{realm}_{freq}_*.nc",
+            "output_dir_pattern": "output[0-9][0-9][0-9]",
+            "components": {
+                "aerosol": {
+                    "subdir": "atmosphere",
+                    "realm_label": "atm",
+                    "frequency_patterns": {
+                        "mon": "{model_var}_*_atm_1mon_*.nc",
+                        "day": "{model_var}_*_atm_1day_*.nc",
+                        "fx":  "{model_var}_atm_fx.nc"
+                    }
+                },
+                "atmosphere": {
+                    "subdir": "atmosphere",
+                    "realm_label": "atm",
+                    "frequency_patterns": {
+                        "mon": "{model_var}_*_atm_1mon_*.nc",
+                        "day": "{model_var}_*_atm_1day_*.nc",
+                        "3hr": "{model_var}_*_atm_3hr_*.nc",
+                        "6hr": "{model_var}_*_atm_6hr_*.nc",
+                        "fx":  "{model_var}_atm_fx.nc"
+                    }
+                },
+                "land": {
+                    "subdir": "atmosphere",
+                    "realm_label": "atm",
+                    "frequency_patterns": {
+                        "mon": "{model_var}_*_atm_1mon_*.nc",
+                        "day": "{model_var}_*_atm_1day_*.nc"
+                    }
+                },
+                "sea_ice": {
+                    "subdir": "ice",
+                    "realm_label": "ice",
+                    "frequency_patterns": {
+                        "mon": "{model_var}_*_ice_1mon_*.nc",
+                        "day": "{model_var}_*_ice_1day_*.nc"
+                    }
+                },
+                "ocean": {
+                    "subdir": "ocean",
+                    "realm_label": "ocean",
+                    "frequency_patterns": {
+                        "mon": "{model_var}_*_ocean_1mon_*.nc",
+                        "day": "{model_var}_*_ocean_1day_*.nc",
+                        "yr":  "{model_var}_*_ocean_1yr_*.nc",
+                        "fx":  "{model_var}_ocean_fx.nc"
+                    }
+                },
+                "oceanBgchem": {
+                    "subdir": "ocean",
+                    "realm_label": "ocnBgchem",
+                    "frequency_patterns": {
+                        "mon": "{model_var}_*_ocnBgchem_1mon_*.nc",
+                        "yr":  "{model_var}_*_ocnBgchem_1yr_*.nc"
+                    }
+                }
+            }
+        }
     },
     "aerosol": {
         "od550aer": {

--- a/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
+++ b/src/access_moppy/mappings/ACCESS-ESM1.6_mappings.json
@@ -56,7 +56,7 @@
                 "ocean": {
                     "subdir": "ocean",
                     "frequency_patterns": {
-                        "mon": "ocean-*-{model_var}-1mon-mean-y_*.nc",
+                        "mon": "ocean-*-{model_var}-1mon*-mean-*_*.nc",
                         "day": "ocean-*-{model_var}-1day-mean-y_*.nc",
                         "yr":  "ocean-*-{model_var}-1yr-mean-y_*.nc",
                         "fx":  "ocean-*-{model_var}-fx.nc"
@@ -65,7 +65,7 @@
                 "oceanBgchem": {
                     "subdir": "ocean",
                     "frequency_patterns": {
-                        "mon": "ocean-*-{model_var}-1mon-mean-y_*.nc",
+                        "mon": "ocean-*-{model_var}-1mon*-mean-*_*.nc",
                         "yr":  "ocean-*-{model_var}-1yr-mean-y_*.nc"
                     }
                 }

--- a/src/access_moppy/templates/cmor_job_script.j2
+++ b/src/access_moppy/templates/cmor_job_script.j2
@@ -32,6 +32,7 @@ export INPUT_FOLDER="{{ config.get('input_folder') }}"
 export OUTPUT_FOLDER="{{ config.get('output_folder') }}"
 export DRS_ROOT="{{ config.get('drs_root', '') }}"
 export CMIP_VERSION="{{ config.get('cmip_version', 'CMIP6') }}"
+export MODEL_ID="{{ config.get('model_id', 'ACCESS-ESM1.6') }}"
 
 # If jobfs is available, set up temporary directory
 {% if config.get('jobfs') %}

--- a/src/access_moppy/templates/cmor_python_script.j2
+++ b/src/access_moppy/templates/cmor_python_script.j2
@@ -87,7 +87,7 @@ def main():
             patterns = pattern if isinstance(pattern, list) else [pattern]
             input_files = []
             for p in patterns:
-                input_files.extend(glob.glob(input_folder + p))
+                input_files.extend(glob.glob(os.path.join(input_folder, p), recursive=True))
         else:
             # Auto-discover using the model mapping file_discovery config
             from access_moppy.file_discovery import discover_files, FileDiscoveryError

--- a/src/access_moppy/templates/cmor_python_script.j2
+++ b/src/access_moppy/templates/cmor_python_script.j2
@@ -82,6 +82,11 @@ def main():
         file_patterns = {{ config.get('file_patterns', {}) | tojson }}
         model_id = os.environ.get('MODEL_ID', 'ACCESS-ESM1.6')
 
+        # Optional year-range filtering for auto-discovery (pi-control / spinup runs).
+        # Accepts integers or zero-padded strings (e.g. "0001").
+        start_year = {{ config['start_year'] | tojson if 'start_year' in config else 'None' }}
+        end_year   = {{ config['end_year']   | tojson if 'end_year'   in config else 'None' }}
+
         pattern = file_patterns.get(variable)
         if pattern:
             patterns = pattern if isinstance(pattern, list) else [pattern]
@@ -90,10 +95,15 @@ def main():
                 input_files.extend(glob.glob(os.path.join(input_folder, p), recursive=True))
         else:
             # Auto-discover using the model mapping file_discovery config
-            from access_moppy.file_discovery import discover_files, FileDiscoveryError
+            from access_moppy.file_discovery import (
+                FileDiscoveryError,
+                _diagnose_no_files,
+                discover_files,
+            )
             try:
                 input_files = [str(f) for f in discover_files(
-                    input_folder, variable, model_id=model_id
+                    input_folder, variable, model_id=model_id,
+                    start_year=start_year, end_year=end_year,
                 )]
             except FileDiscoveryError as exc:
                 raise ValueError(
@@ -103,7 +113,11 @@ def main():
                 ) from exc
 
         if not input_files:
-            raise ValueError(f'No files found for variable {variable}')
+            diag = _diagnose_no_files(
+                Path(input_folder), variable, model_id,
+                start_year=start_year, end_year=end_year,
+            )
+            raise ValueError(f"No files found for variable '{variable}'. {diag}")
 
         print(f'Processing {variable} with {len(input_files)} files')
 

--- a/src/access_moppy/templates/cmor_python_script.j2
+++ b/src/access_moppy/templates/cmor_python_script.j2
@@ -77,19 +77,33 @@ def main():
         drs_root = os.environ.get('DRS_ROOT') or None
         cmip_version = os.environ.get('CMIP_VERSION', 'CMIP6')
 
-        # File patterns
+        # File patterns — explicit overrides from the batch config take precedence;
+        # if none is supplied the mapping-driven auto-discovery is used instead.
         file_patterns = {{ config.get('file_patterns', {}) | tojson }}
+        model_id = os.environ.get('MODEL_ID', 'ACCESS-ESM1.6')
 
         pattern = file_patterns.get(variable)
-        if not pattern:
-            raise ValueError(f'No pattern found for variable {variable}')
+        if pattern:
+            patterns = pattern if isinstance(pattern, list) else [pattern]
+            input_files = []
+            for p in patterns:
+                input_files.extend(glob.glob(input_folder + p))
+        else:
+            # Auto-discover using the model mapping file_discovery config
+            from access_moppy.file_discovery import discover_files, FileDiscoveryError
+            try:
+                input_files = [str(f) for f in discover_files(
+                    input_folder, variable, model_id=model_id
+                )]
+            except FileDiscoveryError as exc:
+                raise ValueError(
+                    f"Could not auto-discover files for '{variable}': {exc}\n"
+                    "Add a 'file_patterns' entry in the batch config or a "
+                    "'file_pattern' field to the variable's mapping entry."
+                ) from exc
 
-        patterns = pattern if isinstance(pattern, list) else [pattern]
-        input_files = []
-        for p in patterns:
-            input_files.extend(glob.glob(input_folder + p))
         if not input_files:
-            raise ValueError(f'No files found for variable {variable} (patterns: {patterns})')
+            raise ValueError(f'No files found for variable {variable}')
 
         print(f'Processing {variable} with {len(input_files)} files')
 

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -771,7 +771,6 @@ class TestACCESSESMCMORiser:
                 ):
                     cmoriser.to_iris()
 
-
     @pytest.mark.unit
     def test_input_folder_discovers_files(self, valid_config, temp_dir):
         """input_folder triggers auto-discovery and populates input_paths."""
@@ -780,7 +779,9 @@ class TestACCESSESMCMORiser:
         with (
             patch("access_moppy.driver.load_model_mappings") as mock_load,
             patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
-            patch("access_moppy.driver.discover_files", return_value=discovered) as mock_disc,
+            patch(
+                "access_moppy.driver.discover_files", return_value=discovered
+            ) as mock_disc,
         ):
             mock_load.return_value = {"tas": {"units": "K"}}
             mock_instance = MagicMock()
@@ -811,7 +812,9 @@ class TestACCESSESMCMORiser:
         with (
             patch("access_moppy.driver.load_model_mappings") as mock_load,
             patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
-            patch("access_moppy.driver.discover_files", return_value=discovered) as mock_disc,
+            patch(
+                "access_moppy.driver.discover_files", return_value=discovered
+            ) as mock_disc,
         ):
             mock_load.return_value = {"tas": {"units": "K"}}
             mock_instance = MagicMock()
@@ -901,7 +904,9 @@ class TestACCESSESMCMORiser:
         with (
             patch("access_moppy.driver.load_model_mappings") as mock_load,
             patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
-            patch("access_moppy.driver.discover_files", return_value=discovered) as mock_disc,
+            patch(
+                "access_moppy.driver.discover_files", return_value=discovered
+            ) as mock_disc,
         ):
             mock_load.return_value = {"tas": {"units": "K"}}
             mock_instance = MagicMock()

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -772,6 +772,159 @@ class TestACCESSESMCMORiser:
                     cmoriser.to_iris()
 
 
+    @pytest.mark.unit
+    def test_input_folder_discovers_files(self, valid_config, temp_dir):
+        """input_folder triggers auto-discovery and populates input_paths."""
+        discovered = [Path("/archive/output000/atm/aiihca.pa-185001_mon.nc")]
+
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
+            patch("access_moppy.driver.discover_files", return_value=discovered) as mock_disc,
+        ):
+            mock_load.return_value = {"tas": {"units": "K"}}
+            mock_instance = MagicMock()
+            mock_instance.ds = xr.Dataset()
+            mock_atmos.return_value = mock_instance
+
+            cmoriser = ACCESS_ESM_CMORiser(
+                input_folder="/archive",
+                compound_name="Amon.tas",
+                output_path=temp_dir,
+                **valid_config,
+            )
+
+            mock_disc.assert_called_once_with(
+                "/archive",
+                "Amon.tas",
+                model_id="ACCESS-ESM1.6",
+                start_year=None,
+                end_year=None,
+            )
+            assert cmoriser.input_paths == [str(discovered[0])]
+
+    @pytest.mark.unit
+    def test_input_folder_passes_year_filters(self, valid_config, temp_dir):
+        """start_year and end_year are forwarded to discover_files."""
+        discovered = [Path("/archive/output000/atm/file.nc")]
+
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
+            patch("access_moppy.driver.discover_files", return_value=discovered) as mock_disc,
+        ):
+            mock_load.return_value = {"tas": {"units": "K"}}
+            mock_instance = MagicMock()
+            mock_instance.ds = xr.Dataset()
+            mock_atmos.return_value = mock_instance
+
+            ACCESS_ESM_CMORiser(
+                input_folder="/archive",
+                compound_name="Amon.tas",
+                output_path=temp_dir,
+                start_year=1900,
+                end_year=1950,
+                **valid_config,
+            )
+
+            mock_disc.assert_called_once_with(
+                "/archive",
+                "Amon.tas",
+                model_id="ACCESS-ESM1.6",
+                start_year=1900,
+                end_year=1950,
+            )
+
+    @pytest.mark.unit
+    def test_input_folder_and_input_data_together_raises(self, valid_config, temp_dir):
+        """Providing both input_folder and input_data must raise ValueError."""
+        with patch("access_moppy.driver.load_model_mappings") as mock_load:
+            mock_load.return_value = {"tas": {"units": "K"}}
+
+            with pytest.raises(
+                ValueError, match="Cannot specify both 'input_folder' and 'input_data'"
+            ):
+                ACCESS_ESM_CMORiser(
+                    input_data=["a.nc"],
+                    input_folder="/archive",
+                    compound_name="Amon.tas",
+                    output_path=temp_dir,
+                    **valid_config,
+                )
+
+    @pytest.mark.unit
+    def test_input_folder_no_files_found_raises(self, valid_config, temp_dir):
+        """Empty discovery result raises a clear ValueError."""
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.discover_files", return_value=[]),
+        ):
+            mock_load.return_value = {"tas": {"units": "K"}}
+
+            with pytest.raises(ValueError, match="No files found for"):
+                ACCESS_ESM_CMORiser(
+                    input_folder="/archive",
+                    compound_name="Amon.tas",
+                    output_path=temp_dir,
+                    **valid_config,
+                )
+
+    @pytest.mark.unit
+    def test_input_folder_discovery_error_raises_value_error(
+        self, valid_config, temp_dir
+    ):
+        """A FileDiscoveryError from discover_files is re-raised as ValueError."""
+        from access_moppy.file_discovery import FileDiscoveryError
+
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch(
+                "access_moppy.driver.discover_files",
+                side_effect=FileDiscoveryError("no pattern"),
+            ),
+        ):
+            mock_load.return_value = {"tas": {"units": "K"}}
+
+            with pytest.raises(ValueError, match="Could not auto-discover files"):
+                ACCESS_ESM_CMORiser(
+                    input_folder="/archive",
+                    compound_name="Amon.tas",
+                    output_path=temp_dir,
+                    **valid_config,
+                )
+
+    @pytest.mark.unit
+    def test_input_folder_uses_model_id_for_discovery(self, valid_config, temp_dir):
+        """model_id is forwarded to discover_files instead of the default."""
+        discovered = [Path("/archive/output000/atm/file.nc")]
+
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
+            patch("access_moppy.driver.discover_files", return_value=discovered) as mock_disc,
+        ):
+            mock_load.return_value = {"tas": {"units": "K"}}
+            mock_instance = MagicMock()
+            mock_instance.ds = xr.Dataset()
+            mock_atmos.return_value = mock_instance
+
+            ACCESS_ESM_CMORiser(
+                input_folder="/archive",
+                compound_name="Amon.tas",
+                output_path=temp_dir,
+                model_id="ACCESS-CM2",
+                **valid_config,
+            )
+
+            mock_disc.assert_called_once_with(
+                "/archive",
+                "Amon.tas",
+                model_id="ACCESS-CM2",
+                start_year=None,
+                end_year=None,
+            )
+
+
 def _make_driver_without_init(dataset, cmor_name="tas"):
     """
     Build an ACCESS_ESM_CMORiser instance bypassing __init__ entirely.

--- a/tests/unit/test_file_discovery.py
+++ b/tests/unit/test_file_discovery.py
@@ -1,0 +1,343 @@
+"""Unit tests for access_moppy.file_discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from access_moppy.file_discovery import (
+    FileDiscoveryError,
+    _TABLE_TO_FREQ,
+    _build_patterns,
+    _extract_year_from_path,
+    _find_variable_entry,
+    _load_full_mappings,
+    discover_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_year_from_path
+# ---------------------------------------------------------------------------
+
+
+class TestExtractYearFromPath:
+    @pytest.mark.parametrize(
+        "filename, expected",
+        [
+            # Ocean annual (legacy)
+            ("ocean-2d-surface_temp-1mon-mean-y_1850.nc", 1850),
+            ("ocean-3d-temp-1yr-mean-y_2014.nc", 2014),
+            # Ocean fixed (no year) — returns None
+            ("ocean-2d-area_t-fx.nc", None),
+            # Ice monthly (legacy)
+            ("iceh-1monthly-mean_1850-01.nc", 1850),
+            ("iceh-1daily-mean_2010-12.nc", 2010),
+            # Atmosphere embedded YYYYMM (legacy)
+            ("aiihca.pa-185001_mon.nc", 1850),
+            ("aiihca.pe-201512_dai.nc", 2015),
+            ("aiihca.pi-185006_3hr.nc", 1850),
+            # Proposed unified YYYYMM-YYYYMM range (new naming scheme)
+            ("tos_mean_ocean_1mon_185001-185012.nc", 1850),
+            ("wt_mean_ocean_1yr_234501-234512.nc", 2345),
+            ("tas_mean_atm_1mon_200101-200112.nc", 2001),
+        ],
+    )
+    def test_known_patterns(self, filename, expected):
+        assert _extract_year_from_path(Path(filename)) == expected
+
+    def test_unrecognised_returns_none(self):
+        assert _extract_year_from_path(Path("no_year_here.nc")) is None
+
+
+# ---------------------------------------------------------------------------
+# _TABLE_TO_FREQ
+# ---------------------------------------------------------------------------
+
+
+class TestTableToFreq:
+    def test_common_tables_present(self):
+        for table in ("Amon", "Omon", "SImon", "day", "Ofx", "fx", "Oyr"):
+            assert table in _TABLE_TO_FREQ, f"Missing table: {table}"
+
+    def test_monthly_tables_map_to_mon(self):
+        for table in ("Amon", "Lmon", "Omon", "SImon", "AERmon"):
+            assert _TABLE_TO_FREQ[table] == "mon"
+
+
+# ---------------------------------------------------------------------------
+# _load_full_mappings
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFullMappings:
+    def test_loads_esm16(self):
+        mappings = _load_full_mappings("ACCESS-ESM1.6")
+        assert "model_info" in mappings
+        assert "ocean" in mappings
+        assert "atmosphere" in mappings
+
+    def test_file_discovery_block_present(self):
+        mappings = _load_full_mappings("ACCESS-ESM1.6")
+        fd = mappings["model_info"]["file_discovery"]
+        assert "output_dir_pattern" in fd
+        assert "components" in fd
+        assert "ocean" in fd["components"]
+        assert "atmosphere" in fd["components"]
+        assert "sea_ice" in fd["components"]
+
+    def test_missing_model_raises(self):
+        with pytest.raises(FileDiscoveryError, match="No mapping file found"):
+            _load_full_mappings("NONEXISTENT-MODEL-XYZ")
+
+
+# ---------------------------------------------------------------------------
+# _find_variable_entry
+# ---------------------------------------------------------------------------
+
+
+class TestFindVariableEntry:
+    def setup_method(self):
+        self.mappings = _load_full_mappings("ACCESS-ESM1.6")
+
+    def test_ocean_variable_found(self):
+        component, entry = _find_variable_entry(self.mappings, "tos")
+        assert component == "ocean"
+        assert "model_variables" in entry
+
+    def test_atmosphere_variable_found(self):
+        component, entry = _find_variable_entry(self.mappings, "tas")
+        assert component == "atmosphere"
+
+    def test_sea_ice_variable_found(self):
+        component, entry = _find_variable_entry(self.mappings, "siconc")
+        assert component == "sea_ice"
+
+    def test_unknown_variable_returns_none(self):
+        assert _find_variable_entry(self.mappings, "totally_unknown_var_xyz") is None
+
+
+# ---------------------------------------------------------------------------
+# _build_patterns
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPatterns:
+    def setup_method(self):
+        mappings = _load_full_mappings("ACCESS-ESM1.6")
+        self.fd_cfg = mappings["model_info"]["file_discovery"]
+
+    def test_atmosphere_monthly_no_model_var(self):
+        # Atmosphere: all variables packed in one file; no {model_var}
+        var_entry = {"model_variables": ["fld_s30i297"]}
+        patterns = _build_patterns(var_entry, "atmosphere", "mon", self.fd_cfg)
+        assert len(patterns) == 1
+        assert "{model_var}" not in patterns[0]
+        assert "*.pa-*_mon.nc" in patterns[0]
+
+    def test_ocean_monthly_one_model_var(self):
+        var_entry = {"model_variables": ["surface_temp"]}
+        patterns = _build_patterns(var_entry, "ocean", "mon", self.fd_cfg)
+        assert len(patterns) == 1
+        assert "surface_temp" in patterns[0]
+        assert "{model_var}" not in patterns[0]
+
+    def test_ocean_multi_model_vars_produces_multiple_patterns(self):
+        var_entry = {"model_variables": ["ty_trans_rho", "ty_trans_rho_gm"]}
+        patterns = _build_patterns(var_entry, "ocean", "mon", self.fd_cfg)
+        assert len(patterns) == 2
+        assert any("ty_trans_rho-1mon" in p or "ty_trans_rho" in p for p in patterns)
+
+    def test_per_variable_file_pattern_overrides_component_config(self):
+        var_entry = {
+            "model_variables": ["surface_temp"],
+            "file_pattern": "output*/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc",
+        }
+        patterns = _build_patterns(var_entry, "ocean", "mon", self.fd_cfg)
+        assert patterns == [
+            "output*/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc"
+        ]
+
+    def test_unknown_component_raises(self):
+        with pytest.raises(FileDiscoveryError, match="No file_discovery config"):
+            _build_patterns({}, "nonexistent_component", "mon", self.fd_cfg)
+
+    def test_unknown_freq_raises(self):
+        with pytest.raises(FileDiscoveryError, match="No pattern for frequency"):
+            _build_patterns({}, "atmosphere", "subhr_nonexistent", self.fd_cfg)
+
+    def test_ocean_missing_model_variables_raises(self):
+        var_entry = {"model_variables": []}
+        with pytest.raises(FileDiscoveryError, match="no 'model_variables'"):
+            _build_patterns(var_entry, "ocean", "mon", self.fd_cfg)
+
+    def test_sea_ice_monthly_no_model_var(self):
+        var_entry = {"model_variables": ["aice"]}
+        patterns = _build_patterns(var_entry, "sea_ice", "mon", self.fd_cfg)
+        assert len(patterns) == 1
+        assert "iceh-1monthly-mean" in patterns[0]
+
+
+# ---------------------------------------------------------------------------
+# discover_files (integration-style, using a fake directory tree)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverFiles:
+    """Tests for the top-level discover_files function.
+
+    A temporary directory is used as a fake archive root; discover_files must
+    return only the files that actually exist and match the pattern.
+    """
+
+    def _make_archive(self, tmp_path: Path, filenames: list[tuple[str, str]]) -> Path:
+        """Create a fake archive tree.  ``filenames`` is a list of (subdir, name) tuples."""
+        for subdir, name in filenames:
+            d = tmp_path / subdir
+            d.mkdir(parents=True, exist_ok=True)
+            (d / name).touch()
+        return tmp_path
+
+    def test_atmosphere_monthly(self, tmp_path):
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/atmosphere/netCDF", "aiihca.pa-185001_mon.nc"),
+                ("output000/atmosphere/netCDF", "aiihca.pa-185002_mon.nc"),
+                ("output001/atmosphere/netCDF", "aiihca.pa-185101_mon.nc"),
+                # Should NOT match a daily file when asking for monthly
+                ("output000/atmosphere/netCDF", "aiihca.pe-185001_dai.nc"),
+            ],
+        )
+        result = discover_files(archive, "Amon.tas")
+        names = [p.name for p in result]
+        assert "aiihca.pa-185001_mon.nc" in names
+        assert "aiihca.pa-185002_mon.nc" in names
+        assert "aiihca.pa-185101_mon.nc" in names
+        # Daily file must NOT appear in a monthly query
+        assert "aiihca.pe-185001_dai.nc" not in names
+
+    def test_ocean_monthly_per_variable(self, tmp_path):
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
+                ("output001/ocean", "ocean-2d-surface_temp-1mon-mean-y_1851.nc"),
+                ("output000/ocean", "ocean-2d-eta_t-1mon-mean-y_1850.nc"),  # different var
+            ],
+        )
+        result = discover_files(archive, "Omon.tos")
+        names = [p.name for p in result]
+        assert "ocean-2d-surface_temp-1mon-mean-y_1850.nc" in names
+        assert "ocean-2d-surface_temp-1mon-mean-y_1851.nc" in names
+        # Different model variable should NOT be included
+        assert "ocean-2d-eta_t-1mon-mean-y_1850.nc" not in names
+
+    def test_sea_ice_monthly(self, tmp_path):
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ice", "iceh-1monthly-mean_1850-01.nc"),
+                ("output000/ice", "iceh-1monthly-mean_1850-02.nc"),
+                ("output000/ice", "iceh-1daily-mean_1850-01.nc"),  # daily, should NOT appear
+            ],
+        )
+        result = discover_files(archive, "SImon.siconc")
+        names = [p.name for p in result]
+        assert "iceh-1monthly-mean_1850-01.nc" in names
+        assert "iceh-1monthly-mean_1850-02.nc" in names
+        assert "iceh-1daily-mean_1850-01.nc" not in names
+
+    def test_year_filtering_start(self, tmp_path):
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
+                ("output001/ocean", "ocean-2d-surface_temp-1mon-mean-y_1900.nc"),
+                ("output002/ocean", "ocean-2d-surface_temp-1mon-mean-y_1950.nc"),
+            ],
+        )
+        result = discover_files(archive, "Omon.tos", start_year=1900)
+        years = {_extract_year_from_path(p) for p in result}
+        assert 1850 not in years
+        assert 1900 in years
+        assert 1950 in years
+
+    def test_year_filtering_end(self, tmp_path):
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
+                ("output001/ocean", "ocean-2d-surface_temp-1mon-mean-y_1900.nc"),
+                ("output002/ocean", "ocean-2d-surface_temp-1mon-mean-y_1950.nc"),
+            ],
+        )
+        result = discover_files(archive, "Omon.tos", end_year=1900)
+        years = {_extract_year_from_path(p) for p in result}
+        assert 1850 in years
+        assert 1900 in years
+        assert 1950 not in years
+
+    def test_year_filtering_range(self, tmp_path):
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
+                ("output001/ocean", "ocean-2d-surface_temp-1mon-mean-y_1900.nc"),
+                ("output002/ocean", "ocean-2d-surface_temp-1mon-mean-y_1950.nc"),
+            ],
+        )
+        result = discover_files(archive, "Omon.tos", start_year=1900, end_year=1900)
+        assert len(result) == 1
+        assert _extract_year_from_path(result[0]) == 1900
+
+    def test_no_files_found_returns_empty(self, tmp_path):
+        result = discover_files(tmp_path, "Omon.tos")
+        assert result == []
+
+    def test_invalid_compound_name_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid compound_name"):
+            discover_files(tmp_path, "no_dot_here")
+
+    def test_unknown_variable_raises(self, tmp_path):
+        with pytest.raises(FileDiscoveryError, match="not found in mappings"):
+            discover_files(tmp_path, "Omon.total_nonexistent_variable_xyz")
+
+    def test_unknown_table_raises(self, tmp_path):
+        with pytest.raises(FileDiscoveryError, match="Unknown CMIP table"):
+            discover_files(tmp_path, "FAKEX.tos")
+
+    def test_explicit_file_pattern_in_mapping(self, tmp_path):
+        """A per-variable file_pattern in the mapping entry overrides auto-discovery."""
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
+            ],
+        )
+        fake_entry = {
+            "model_variables": ["surface_temp"],
+            "file_pattern": "output[0-9][0-9][0-9]/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc",
+        }
+        mappings = _load_full_mappings("ACCESS-ESM1.6")
+        fd_cfg = mappings["model_info"]["file_discovery"]
+        patterns = _build_patterns(fake_entry, "ocean", "mon", fd_cfg)
+        # Should use the explicit pattern, not the auto one
+        assert patterns == [
+            "output[0-9][0-9][0-9]/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc"
+        ]
+
+    def test_result_is_sorted_and_deduplicated(self, tmp_path):
+        # Multi-var ocean mapping: if two model_vars happen to match the same
+        # physical file (unlikely but guard against duplicates in output)
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
+                ("output001/ocean", "ocean-2d-surface_temp-1mon-mean-y_1851.nc"),
+            ],
+        )
+        result = discover_files(archive, "Omon.tos")
+        assert result == sorted(set(result))

--- a/tests/unit/test_file_discovery.py
+++ b/tests/unit/test_file_discovery.py
@@ -10,6 +10,7 @@ from access_moppy.file_discovery import (
     _TABLE_TO_FREQ,
     FileDiscoveryError,
     _build_patterns,
+    _diagnose_no_files,
     _extract_year_from_path,
     _find_variable_entry,
     _load_full_mappings,
@@ -477,3 +478,53 @@ class TestDiscoverFiles:
         )
         result = discover_files(archive, "Omon.tos")
         assert result == sorted(set(result))
+
+
+# ---------------------------------------------------------------------------
+# _diagnose_no_files
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseNoFiles:
+    """Tests for the three diagnostic branches of _diagnose_no_files."""
+
+    @staticmethod
+    def _make_archive(tmp_path, files):
+        for subdir, name in files:
+            p = tmp_path / subdir
+            p.mkdir(parents=True, exist_ok=True)
+            (p / name).touch()
+        return tmp_path
+
+    def test_year_filter_excluded_all_files(self, tmp_path):
+        # Files exist (years 1850–1851) but the requested range is 1900–1950.
+        # _diagnose_no_files should report the available years and the
+        # requested range, not claim there are no files at all.
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
+                ("output001/ocean", "ocean-2d-surface_temp-1mon-mean-y_1851.nc"),
+            ],
+        )
+        msg = _diagnose_no_files(archive, "Omon.tos", "ACCESS-ESM1.6", 1900, 1950)
+        assert "1850" in msg
+        assert "1851" in msg
+        assert "start_year=1900" in msg
+        assert "end_year=1950" in msg
+
+    def test_no_matching_files_reports_patterns(self, tmp_path):
+        # output directories exist but contain no files matching the pattern.
+        archive = self._make_archive(
+            tmp_path,
+            [("output000/ocean", "unexpected_file_format.nc")],
+        )
+        msg = _diagnose_no_files(archive, "Omon.tos", "ACCESS-ESM1.6", None, None)
+        assert "output000" in msg
+        assert msg  # non-empty
+
+    def test_no_output_dirs_reports_missing_dirs(self, tmp_path):
+        # Completely empty archive — no output* directories at all.
+        msg = _diagnose_no_files(tmp_path, "Omon.tos", "ACCESS-ESM1.6", None, None)
+        assert "output" in msg.lower()
+        assert str(tmp_path) in msg

--- a/tests/unit/test_file_discovery.py
+++ b/tests/unit/test_file_discovery.py
@@ -3,20 +3,18 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 from access_moppy.file_discovery import (
-    FileDiscoveryError,
     _TABLE_TO_FREQ,
+    FileDiscoveryError,
     _build_patterns,
     _extract_year_from_path,
     _find_variable_entry,
     _load_full_mappings,
     discover_files,
 )
-
 
 # ---------------------------------------------------------------------------
 # _extract_year_from_path
@@ -156,9 +154,7 @@ class TestBuildPatterns:
             "file_pattern": "output*/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc",
         }
         patterns = _build_patterns(var_entry, "ocean", "mon", self.fd_cfg)
-        assert patterns == [
-            "output*/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc"
-        ]
+        assert patterns == ["output*/ocean/ocean-2d-surface_temp-1mon-mean-y_*.nc"]
 
     def test_unknown_component_raises(self):
         with pytest.raises(FileDiscoveryError, match="No file_discovery config"):
@@ -225,7 +221,10 @@ class TestDiscoverFiles:
             [
                 ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
                 ("output001/ocean", "ocean-2d-surface_temp-1mon-mean-y_1851.nc"),
-                ("output000/ocean", "ocean-2d-eta_t-1mon-mean-y_1850.nc"),  # different var
+                (
+                    "output000/ocean",
+                    "ocean-2d-eta_t-1mon-mean-y_1850.nc",
+                ),  # different var
             ],
         )
         result = discover_files(archive, "Omon.tos")
@@ -241,7 +240,10 @@ class TestDiscoverFiles:
             [
                 ("output000/ice", "iceh-1monthly-mean_1850-01.nc"),
                 ("output000/ice", "iceh-1monthly-mean_1850-02.nc"),
-                ("output000/ice", "iceh-1daily-mean_1850-01.nc"),  # daily, should NOT appear
+                (
+                    "output000/ice",
+                    "iceh-1daily-mean_1850-01.nc",
+                ),  # daily, should NOT appear
             ],
         )
         result = discover_files(archive, "SImon.siconc")
@@ -311,7 +313,7 @@ class TestDiscoverFiles:
 
     def test_explicit_file_pattern_in_mapping(self, tmp_path):
         """A per-variable file_pattern in the mapping entry overrides auto-discovery."""
-        archive = self._make_archive(
+        self._make_archive(
             tmp_path,
             [
                 ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),

--- a/tests/unit/test_file_discovery.py
+++ b/tests/unit/test_file_discovery.py
@@ -136,17 +136,22 @@ class TestBuildPatterns:
         assert "*.pa-*_mon.nc" in patterns[0]
 
     def test_ocean_monthly_one_model_var(self):
+        # The ocean "mon" frequency lists two naming conventions (legacy
+        # "1mon-mean-y_" and newer "1monthly-mean-ym_"), so one model variable
+        # yields one pattern per convention.
         var_entry = {"model_variables": ["surface_temp"]}
         patterns = _build_patterns(var_entry, "ocean", "mon", self.fd_cfg)
-        assert len(patterns) == 1
-        assert "surface_temp" in patterns[0]
-        assert "{model_var}" not in patterns[0]
+        assert len(patterns) == 2
+        assert all("surface_temp" in p for p in patterns)
+        assert all("{model_var}" not in p for p in patterns)
 
     def test_ocean_multi_model_vars_produces_multiple_patterns(self):
+        # Two model variables × two naming conventions per frequency.
         var_entry = {"model_variables": ["ty_trans_rho", "ty_trans_rho_gm"]}
         patterns = _build_patterns(var_entry, "ocean", "mon", self.fd_cfg)
-        assert len(patterns) == 2
-        assert any("ty_trans_rho-1mon" in p or "ty_trans_rho" in p for p in patterns)
+        assert len(patterns) == 4
+        assert all("{model_var}" not in p for p in patterns)
+        assert any("ty_trans_rho_gm" in p for p in patterns)
 
     def test_per_variable_file_pattern_overrides_component_config(self):
         var_entry = {
@@ -233,6 +238,106 @@ class TestDiscoverFiles:
         assert "ocean-2d-surface_temp-1mon-mean-y_1851.nc" in names
         # Different model variable should NOT be included
         assert "ocean-2d-eta_t-1mon-mean-y_1850.nc" not in names
+
+    def test_ocean_monthly_newer_naming_convention(self, tmp_path):
+        # Newer experiments name ocean output "1monthly-mean-ym_YYYY_MM"
+        # instead of the legacy "1mon-mean-y_YYYY".  Discovery must handle both
+        # (including the "-max-" statistic variant) without a per-variable
+        # file_pattern.
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc"),
+                ("output000/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_02.nc"),
+                # other variable — must not be included
+                ("output000/ocean", "ocean-2d-eta_t-1monthly-mean-ym_0001_01.nc"),
+                # daily — must not appear in a monthly query
+                ("output000/ocean", "ocean-2d-surface_temp-1daily-mean-ym_0001_01.nc"),
+            ],
+        )
+        result = discover_files(archive, "Omon.tos")
+        names = [p.name for p in result]
+        assert "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc" in names
+        assert "ocean-2d-surface_temp-1monthly-mean-ym_0001_02.nc" in names
+        assert "ocean-2d-eta_t-1monthly-mean-ym_0001_01.nc" not in names
+        assert "ocean-2d-surface_temp-1daily-mean-ym_0001_01.nc" not in names
+
+    def test_ocean_mixed_conventions_both_discovered(self, tmp_path):
+        # Legacy and newer-named files for the same variable are both returned.
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
+                ("output001/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc"),
+            ],
+        )
+        names = [p.name for p in discover_files(archive, "Omon.tos")]
+        assert "ocean-2d-surface_temp-1mon-mean-y_1850.nc" in names
+        assert "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc" in names
+
+    def test_ocean_fx_both_conventions_no_overmatch(self, tmp_path):
+        # Fixed fields are "-fx.nc" (legacy) or plain ".nc" (newer).  Both must
+        # match, but a time-varying file for the same diagnostic must NOT be
+        # pulled into an fx query by the plain ".nc" pattern.
+        #
+        # Built from a synthetic mapping entry rather than a real CMOR variable:
+        # standard ocean fx fields (e.g. areacello) are formula-derived with an
+        # empty model_variables list, so they are not auto-discovered.
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-area_t.nc"),  # newer fx
+                ("output000/ocean", "ocean-2d-area_t-fx.nc"),  # legacy fx
+                # time-varying — must NOT be treated as fx
+                ("output000/ocean", "ocean-2d-area_t-1monthly-mean-ym_0001_01.nc"),
+            ],
+        )
+        mappings = _load_full_mappings("ACCESS-ESM1.6")
+        fd_cfg = mappings["model_info"]["file_discovery"]
+        patterns = _build_patterns(
+            {"model_variables": ["area_t"]}, "ocean", "fx", fd_cfg
+        )
+        names = set()
+        for pat in patterns:
+            names.update(p.name for p in archive.glob(pat))
+        assert "ocean-2d-area_t.nc" in names
+        assert "ocean-2d-area_t-fx.nc" in names
+        assert "ocean-2d-area_t-1monthly-mean-ym_0001_01.nc" not in names
+
+    def test_year_extraction_newer_convention(self, tmp_path):
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc"),
+                ("output005/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0005_01.nc"),
+                ("output010/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0010_01.nc"),
+            ],
+        )
+        result = discover_files(archive, "Omon.tos", start_year=5, end_year=5)
+        assert len(result) == 1
+        assert _extract_year_from_path(result[0]) == 5
+
+    def test_zero_padded_string_year_args(self, tmp_path):
+        # pi-control archives often label years as "0001", "0100" etc.
+        # discover_files must accept these zero-padded strings in start_year /
+        # end_year and treat them identically to the equivalent integer.
+        archive = self._make_archive(
+            tmp_path,
+            [
+                ("output000/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc"),
+                ("output050/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0050_01.nc"),
+                ("output100/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0100_01.nc"),
+            ],
+        )
+        # String args "0001" and "0100" must behave identically to int 1 and 100
+        result_str = discover_files(archive, "Omon.tos", start_year="0001", end_year="0050")
+        result_int = discover_files(archive, "Omon.tos", start_year=1, end_year=50)
+        assert sorted(result_str) == sorted(result_int)
+        assert len(result_str) == 2
+
+    def test_invalid_year_arg_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="start_year"):
+            discover_files(tmp_path, "Omon.tos", start_year="not_a_year")
 
     def test_sea_ice_monthly(self, tmp_path):
         archive = self._make_archive(

--- a/tests/unit/test_file_discovery.py
+++ b/tests/unit/test_file_discovery.py
@@ -247,8 +247,14 @@ class TestDiscoverFiles:
         archive = self._make_archive(
             tmp_path,
             [
-                ("output000/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc"),
-                ("output000/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_02.nc"),
+                (
+                    "output000/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc",
+                ),
+                (
+                    "output000/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0001_02.nc",
+                ),
                 # other variable — must not be included
                 ("output000/ocean", "ocean-2d-eta_t-1monthly-mean-ym_0001_01.nc"),
                 # daily — must not appear in a monthly query
@@ -268,7 +274,10 @@ class TestDiscoverFiles:
             tmp_path,
             [
                 ("output000/ocean", "ocean-2d-surface_temp-1mon-mean-y_1850.nc"),
-                ("output001/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc"),
+                (
+                    "output001/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc",
+                ),
             ],
         )
         names = [p.name for p in discover_files(archive, "Omon.tos")]
@@ -308,9 +317,18 @@ class TestDiscoverFiles:
         archive = self._make_archive(
             tmp_path,
             [
-                ("output000/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc"),
-                ("output005/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0005_01.nc"),
-                ("output010/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0010_01.nc"),
+                (
+                    "output000/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc",
+                ),
+                (
+                    "output005/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0005_01.nc",
+                ),
+                (
+                    "output010/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0010_01.nc",
+                ),
             ],
         )
         result = discover_files(archive, "Omon.tos", start_year=5, end_year=5)
@@ -324,13 +342,24 @@ class TestDiscoverFiles:
         archive = self._make_archive(
             tmp_path,
             [
-                ("output000/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc"),
-                ("output050/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0050_01.nc"),
-                ("output100/ocean", "ocean-2d-surface_temp-1monthly-mean-ym_0100_01.nc"),
+                (
+                    "output000/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0001_01.nc",
+                ),
+                (
+                    "output050/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0050_01.nc",
+                ),
+                (
+                    "output100/ocean",
+                    "ocean-2d-surface_temp-1monthly-mean-ym_0100_01.nc",
+                ),
             ],
         )
         # String args "0001" and "0100" must behave identically to int 1 and 100
-        result_str = discover_files(archive, "Omon.tos", start_year="0001", end_year="0050")
+        result_str = discover_files(
+            archive, "Omon.tos", start_year="0001", end_year="0050"
+        )
         result_int = discover_files(archive, "Omon.tos", start_year=1, end_year=50)
         assert sorted(result_str) == sorted(result_int)
         assert len(result_str) == 2


### PR DESCRIPTION
## Problem

The batch CMORiser currently requires users to manually specify a `file_patterns` entry for every variable in the batch config. This is tedious for large variable lists, error-prone (wrong globs silently produce empty file lists), and duplicates knowledge that is already encoded in the variable mapping — we already know which model diagnostic names to expect and what component they belong to, so it makes no sense to ask the user to re-encode that as a file path.

The problem is compounded by the structural differences between components: atmosphere packs all variables for a given frequency into a single UM file, sea ice does the same with CICE output, while ocean produces one file per diagnostic. Any hand-written glob must implicitly know about these conventions.

## Solution

File discovery is now driven by a `file_discovery` config block embedded in `model_info` of the mapping JSON. The block describes, per component, the output subdirectory and a set of frequency-keyed glob patterns. Ocean patterns use a `{model_var}` placeholder that is substituted at discovery time with each entry in the variable's `model_variables` list — naturally handling multi-variable derivations by collecting files for every required diagnostic. Atmosphere and sea-ice patterns have no placeholder because all variables at a given frequency live in the same file.

`discover_files(archive_root, compound_name)` is the single public entry point. It infers the component and output frequency from the CMIP compound name (e.g. `Omon.tos` → ocean, monthly), applies the appropriate pattern, and returns a sorted, deduplicated list of paths. An optional `start_year` / `end_year` pair filters the result by parsing the year from each filename — no files are opened, so this is cheap even across thousands of files.

The batch templates fall back to auto-discovery when no explicit `file_patterns` entry is present in the batch config, making `file_patterns` fully optional. It remains available as an escape hatch for non-standard layouts or time-range subsets.

## Future layout changes

The system is intentionally layout-agnostic at the code level. When ACCESS-ESM1.6 moves to a unified one-variable-per-file naming scheme across all components, adapting MOPPy requires only updating (or adding) the `file_discovery` block in the mapping JSON — or pointing `model_id` at a new mapping file. A `file_discovery_unified` companion block is already included in the mapping to document the proposed new pattern. Old and new runs can be processed side-by-side by using different `model_id` values in each batch config.

## Changes
- file_discovery.py — new module (`discover_files`, `FileDiscoveryError`, internal helpers)
- ACCESS-ESM1.6_mappings.json — `file_discovery` and `file_discovery_unified` blocks in `model_info`
- cmor_python_script.j2 / cmor_job_script.j2 — auto-discovery fallback, `MODEL_ID` env var
- batch_config.yml — `file_patterns` demoted to optional, `model_id` added
- mapping_reference.rst / batch_processing.rst — new *File Discovery* section, updated config reference
- Getting_started.ipynb — demo cells for atmosphere, ocean, sea ice, and year-range filtering
- test_file_discovery.py — 343-line unit suite

## Validation
- `pytest test_file_discovery.py -v` — all tests pass
- `pytest tests/unit -q` — no regressions
- `ruff check file_discovery.py tests/unit/test_file_discovery.py` — passed