### PR TITLE
feat: add mip-cmor-tables backend for CMIP6Plus (CMIP7-ready)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,7 @@
 	path = src/access_moppy/vocabularies/CMIP6Plus_CVs
 	url = git@github.com:WCRP-CMIP/CMIP6Plus_CVs.git
     branch = main
+[submodule "src/access_moppy/vocabularies/mip_cmor_tables"]
+	path = src/access_moppy/vocabularies/mip_cmor_tables
+	url = https://github.com/PCMDI/mip-cmor-tables.git
+	branch = main

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -22,6 +22,7 @@ from access_moppy.utilities import (
     load_model_mappings,
 )
 from access_moppy.vocabulary_processors import (
+    CMIP6PlusMIPVocabulary,
     CMIP6PlusVocabulary,
     CMIP6Vocabulary,
     CMIP7Vocabulary,
@@ -309,7 +310,17 @@ class ACCESS_ESM_CMORiser:
                     parent_info=self.parent_info,
                 )
             elif self.cmip_version == "CMIP6Plus":
-                self.vocab = CMIP6PlusVocabulary(
+                # Auto-select MIP backend when the table name uses the new MIP
+                # naming scheme (APmon, OPmon, LPmon, …) rather than the legacy
+                # CMIP6 names (Amon, Omon, Lmon, …).
+                table_id = self.cmip6_compound_name.split(".")[0]
+                _mip_prefixes = ("AP", "AE", "AC", "OP", "OB", "LP", "LI", "SI", "GIA", "GIG")
+                vocab_cls = (
+                    CMIP6PlusMIPVocabulary
+                    if table_id.startswith(_mip_prefixes)
+                    else CMIP6PlusVocabulary
+                )
+                self.vocab = vocab_cls(
                     compound_name=self.cmip6_compound_name,
                     experiment_id=experiment_id,
                     source_id=source_id,

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -314,7 +314,18 @@ class ACCESS_ESM_CMORiser:
                 # naming scheme (APmon, OPmon, LPmon, …) rather than the legacy
                 # CMIP6 names (Amon, Omon, Lmon, …).
                 table_id = self.cmip6_compound_name.split(".")[0]
-                _mip_prefixes = ("AP", "AE", "AC", "OP", "OB", "LP", "LI", "SI", "GIA", "GIG")
+                _mip_prefixes = (
+                    "AP",
+                    "AE",
+                    "AC",
+                    "OP",
+                    "OB",
+                    "LP",
+                    "LI",
+                    "SI",
+                    "GIA",
+                    "GIG",
+                )
                 vocab_cls = (
                     CMIP6PlusMIPVocabulary
                     if table_id.startswith(_mip_prefixes)

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -32,16 +32,34 @@ except ImportError:
 _SUBMONTHLY_INPUT_VARIABLES = {"tasmax", "tasmin"}
 _MONTHLY_TABLE_IDS = {
     # Legacy CMIP6 table names
-    "Amon", "Lmon", "Omon", "SImon", "CFmon", "mon",
+    "Amon",
+    "Lmon",
+    "Omon",
+    "SImon",
+    "CFmon",
+    "mon",
     # New MIP CMOR table names (mip-cmor-tables)
-    "APmon", "APmonLev", "APmonZ", "APmonClim", "APmonClimLev",
-    "AEmon", "AEmonLev", "AEmonZ",
-    "ACmon", "ACmonZ",
-    "OPmon", "OPmonLev", "OPmonZ", "OPmonClim", "OPmonClimLev",
-    "OBmon", "OBmonLev",
+    "APmon",
+    "APmonLev",
+    "APmonZ",
+    "APmonClim",
+    "APmonClimLev",
+    "AEmon",
+    "AEmonLev",
+    "AEmonZ",
+    "ACmon",
+    "ACmonZ",
+    "OPmon",
+    "OPmonLev",
+    "OPmonZ",
+    "OPmonClim",
+    "OPmonClimLev",
+    "OBmon",
+    "OBmonLev",
     "LPmon",
     "LImon",
-    "GIAmon", "GIGmon",
+    "GIAmon",
+    "GIGmon",
 }
 
 logger = logging.getLogger(__name__)

--- a/src/access_moppy/utilities.py
+++ b/src/access_moppy/utilities.py
@@ -30,7 +30,19 @@ except ImportError:
     DATA_REQUEST_API_AVAILABLE = False
 
 _SUBMONTHLY_INPUT_VARIABLES = {"tasmax", "tasmin"}
-_MONTHLY_TABLE_IDS = {"Amon", "Lmon", "Omon", "SImon", "CFmon", "mon"}
+_MONTHLY_TABLE_IDS = {
+    # Legacy CMIP6 table names
+    "Amon", "Lmon", "Omon", "SImon", "CFmon", "mon",
+    # New MIP CMOR table names (mip-cmor-tables)
+    "APmon", "APmonLev", "APmonZ", "APmonClim", "APmonClimLev",
+    "AEmon", "AEmonLev", "AEmonZ",
+    "ACmon", "ACmonZ",
+    "OPmon", "OPmonLev", "OPmonZ", "OPmonClim", "OPmonClimLev",
+    "OBmon", "OBmonLev",
+    "LPmon",
+    "LImon",
+    "GIAmon", "GIGmon",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -601,13 +613,20 @@ class MappingNotFoundWarning(UserWarning):
 
 def parse_cmip6_table_frequency(compound_name: str) -> pd.Timedelta:
     """
-    Parse CMIP6 table frequency from compound name.
+    Parse table frequency from a compound name.
+
+    Supports both legacy CMIP6 table names (e.g. ``Amon.tas``, ``3hr.pr``)
+    and the new MIP CMOR table names used by ``mip-cmor-tables``
+    (e.g. ``APmon.tas``, ``OPday.thetao``).  For the new scheme, prefer
+    calling :func:`access_moppy.vocabulary_processors.parse_mip_table_frequency`
+    directly; this function falls through to it for unknown table IDs so that
+    existing callers work without modification.
 
     Args:
-        compound_name: CMIP6 compound name (e.g., 'Amon.tas', '3hr.pr', 'day.tasmax')
+        compound_name: dot-separated compound name (e.g., 'Amon.tas', 'APmon.tas')
 
     Returns:
-        pandas Timedelta representing the target CMIP6 frequency
+        pandas Timedelta representing the target frequency
 
     Raises:
         ValueError: if compound name format is invalid or frequency not recognized
@@ -619,7 +638,6 @@ def parse_cmip6_table_frequency(compound_name: str) -> pd.Timedelta:
             f"Invalid compound name format: {compound_name}. Expected 'table.variable'"
         )
 
-    # Validate that both table and variable are non-empty
     if not table_id or not variable:
         raise ValueError(
             f"Invalid compound name format: {compound_name}. Both table and variable must be non-empty."
@@ -628,21 +646,21 @@ def parse_cmip6_table_frequency(compound_name: str) -> pd.Timedelta:
     # Map CMIP6 table IDs to their frequencies
     frequency_mapping = {
         # Common atmospheric tables
-        "Amon": pd.Timedelta(days=30),  # Monthly (approximate)
-        "Aday": pd.Timedelta(days=1),  # Daily
-        "A3hr": pd.Timedelta(hours=3),  # 3-hourly
-        "A6hr": pd.Timedelta(hours=6),  # 6-hourly
-        "AsubhR": pd.Timedelta(minutes=30),  # Sub-hourly
+        "Amon": pd.Timedelta(days=30),
+        "Aday": pd.Timedelta(days=1),
+        "A3hr": pd.Timedelta(hours=3),
+        "A6hr": pd.Timedelta(hours=6),
+        "AsubhR": pd.Timedelta(minutes=30),
         # Ocean tables
-        "Omon": pd.Timedelta(days=30),  # Monthly ocean
-        "Oday": pd.Timedelta(days=1),  # Daily ocean
-        "Oyr": pd.Timedelta(days=365),  # Yearly ocean
+        "Omon": pd.Timedelta(days=30),
+        "Oday": pd.Timedelta(days=1),
+        "Oyr": pd.Timedelta(days=365),
         # Land tables
-        "Lmon": pd.Timedelta(days=30),  # Monthly land
-        "Lday": pd.Timedelta(days=1),  # Daily land
+        "Lmon": pd.Timedelta(days=30),
+        "Lday": pd.Timedelta(days=1),
         # Sea ice tables
-        "SImon": pd.Timedelta(days=30),  # Monthly sea ice
-        "SIday": pd.Timedelta(days=1),  # Daily sea ice
+        "SImon": pd.Timedelta(days=30),
+        "SIday": pd.Timedelta(days=1),
         # Additional frequency tables
         "3hr": pd.Timedelta(hours=3),
         "6hr": pd.Timedelta(hours=6),
@@ -660,12 +678,22 @@ def parse_cmip6_table_frequency(compound_name: str) -> pd.Timedelta:
         "6hrPlevPt": pd.Timedelta(hours=6),
     }
 
-    if table_id not in frequency_mapping:
-        raise ValueError(
-            f"Unknown CMIP6 table ID: {table_id}. Cannot determine target frequency."
-        )
+    if table_id in frequency_mapping:
+        return frequency_mapping[table_id]
 
-    return frequency_mapping[table_id]
+    # Fall through to the MIP CMOR table frequency map (APmon, OPmon, …).
+    from access_moppy.vocabulary_processors import parse_mip_table_frequency
+
+    try:
+        return parse_mip_table_frequency(compound_name)
+    except ValueError:
+        pass
+
+    raise ValueError(
+        f"Unknown table ID: {table_id!r}. Cannot determine target frequency. "
+        f"Supported legacy CMIP6 tables: {sorted(frequency_mapping)}. "
+        f"New MIP CMOR table names (APmon, OPmon, …) are also supported."
+    )
 
 
 def is_frequency_compatible(

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -2120,3 +2120,398 @@ class CMIP7Vocabulary:
 
     def __repr__(self) -> str:
         return f"<CMIP7Vocabulary table={self.table} physical_parameter={self.physical_parameter} branded_name={self.branded_name} frequency={self.frequency} region={self.region} experiment={self.experiment_id} source={self.source_id}>"
+
+
+# ---------------------------------------------------------------------------
+# mip-cmor-tables backend
+# ---------------------------------------------------------------------------
+# The mip-cmor-tables repository (https://github.com/PCMDI/mip-cmor-tables)
+# is the *generic* table framework that underpins newer CMIP phases.
+# Key structural differences from the legacy cmip6-cmor-tables:
+#
+# * Table names use a new two-part realm+frequency scheme:
+#     APmon   – Atmosphere Primary, monthly        (was: Amon)
+#     APday   – Atmosphere Primary, daily          (was: day / Aday)
+#     OPmon   – Ocean Primary, monthly             (was: Omon)
+#     LPmon   – Land Primary, monthly              (was: Lmon)
+#     SImon   – Sea Ice, monthly                   (same)
+#     …
+#   The full prefix taxonomy is documented in the Tables/ directory.
+#
+# * JSON files are named  MIP_<TableID>.json  (prefix is "MIP_", not "CMIP6_").
+#
+# * Auxiliary files (coordinate axes, formula terms) live in Auxillary_files/
+#   rather than Tables/, and are also prefixed with "MIP_".
+#
+# * The variable_entry schema is structurally identical to CMIP6 tables, so
+#   CMIP6Vocabulary._get_variable_entry / _get_axes / etc. all work unchanged
+#   once the correct table_dir is wired up.
+#
+# The CMIP6 code path is untouched; this backend is additive.
+# ---------------------------------------------------------------------------
+
+# Mapping: MIP table prefix → approximate pandas Timedelta.
+# Used by parse_mip_table_frequency() to infer output frequency from the
+# compound name without parsing the JSON file.
+_MIP_TABLE_FREQUENCY_MAP: Dict[str, "pd.Timedelta"] = {}  # populated lazily below
+
+
+def _build_mip_table_frequency_map():
+    """Lazily build the MIP table → frequency map (avoids pandas import at module level)."""
+    import pandas as pd
+
+    return {
+        # Atmosphere Primary
+        "APmon": pd.Timedelta(days=30),
+        "APday": pd.Timedelta(days=1),
+        "AP1hr": pd.Timedelta(hours=1),
+        "AP1hrPt": pd.Timedelta(hours=1),
+        "AP3hr": pd.Timedelta(hours=3),
+        "AP3hrPt": pd.Timedelta(hours=3),
+        "AP3hrPtLev": pd.Timedelta(hours=3),
+        "AP6hr": pd.Timedelta(hours=6),
+        "AP6hrPt": pd.Timedelta(hours=6),
+        "AP6hrPtLev": pd.Timedelta(hours=6),
+        "AP6hrPtZ": pd.Timedelta(hours=6),
+        "APdayLev": pd.Timedelta(days=1),
+        "APdayZ": pd.Timedelta(days=1),
+        "APfx": pd.Timedelta(days=0),
+        "APmonLev": pd.Timedelta(days=30),
+        "APmonZ": pd.Timedelta(days=30),
+        "APmonClim": pd.Timedelta(days=30),
+        "APmonClimLev": pd.Timedelta(days=30),
+        "APsubhrPt": pd.Timedelta(minutes=30),
+        "APsubhrPtLev": pd.Timedelta(minutes=30),
+        "APsubhrPtSite": pd.Timedelta(minutes=30),
+        # Atmosphere Extended / Chemistry
+        "AEmon": pd.Timedelta(days=30),
+        "AEday": pd.Timedelta(days=1),
+        "AE1hr": pd.Timedelta(hours=1),
+        "AE3hrPt": pd.Timedelta(hours=3),
+        "AE3hrPtLev": pd.Timedelta(hours=3),
+        "AE6hr": pd.Timedelta(hours=6),
+        "AE6hrPt": pd.Timedelta(hours=6),
+        "AE6hrPtLev": pd.Timedelta(hours=6),
+        "AEmonLev": pd.Timedelta(days=30),
+        "AEmonZ": pd.Timedelta(days=30),
+        "AEsubhrPt": pd.Timedelta(minutes=30),
+        "AEsubhrPtSite": pd.Timedelta(minutes=30),
+        # Atmosphere Cloud / CFMIP
+        "ACmon": pd.Timedelta(days=30),
+        "ACmonZ": pd.Timedelta(days=30),
+        # Ocean Primary
+        "OPmon": pd.Timedelta(days=30),
+        "OPday": pd.Timedelta(days=1),
+        "OP3hrPt": pd.Timedelta(hours=3),
+        "OPdec": pd.Timedelta(days=3650),
+        "OPdecLev": pd.Timedelta(days=3650),
+        "OPdecZ": pd.Timedelta(days=3650),
+        "OPfx": pd.Timedelta(days=0),
+        "OPmonLev": pd.Timedelta(days=30),
+        "OPmonZ": pd.Timedelta(days=30),
+        "OPmonClim": pd.Timedelta(days=30),
+        "OPmonClimLev": pd.Timedelta(days=30),
+        "OPyr": pd.Timedelta(days=365),
+        "OPyrLev": pd.Timedelta(days=365),
+        # Ocean Biogeochemistry
+        "OBmon": pd.Timedelta(days=30),
+        "OBday": pd.Timedelta(days=1),
+        "OBmonLev": pd.Timedelta(days=30),
+        "OByr": pd.Timedelta(days=365),
+        "OByrLev": pd.Timedelta(days=365),
+        # Land Primary
+        "LPmon": pd.Timedelta(days=30),
+        "LPday": pd.Timedelta(days=1),
+        "LP3hr": pd.Timedelta(hours=3),
+        "LP3hrPt": pd.Timedelta(hours=3),
+        "LP6hrPt": pd.Timedelta(hours=6),
+        "LPfx": pd.Timedelta(days=0),
+        "LPyr": pd.Timedelta(days=365),
+        "LPyrPt": pd.Timedelta(days=365),
+        # Land Ice
+        "LImon": pd.Timedelta(days=30),
+        "LIday": pd.Timedelta(days=1),
+        "LI3hrPt": pd.Timedelta(hours=3),
+        "LI6hrPt": pd.Timedelta(hours=6),
+        "LIfx": pd.Timedelta(days=0),
+        "LIsubhrPtSite": pd.Timedelta(minutes=30),
+        # Sea Ice
+        "SImon": pd.Timedelta(days=30),
+        "SIday": pd.Timedelta(days=1),
+        "SImonPt": pd.Timedelta(days=30),
+        # Glacial Ice: Antarctica / Greenland
+        "GIAfx": pd.Timedelta(days=0),
+        "GIAmon": pd.Timedelta(days=30),
+        "GIAyr": pd.Timedelta(days=365),
+        "GIGfx": pd.Timedelta(days=0),
+        "GIGmon": pd.Timedelta(days=30),
+        "GIGyr": pd.Timedelta(days=365),
+    }
+
+
+def parse_mip_table_frequency(compound_name: str) -> "pd.Timedelta":
+    """
+    Parse target frequency from a mip-cmor-tables compound name (``table.variable``).
+
+    Unlike the legacy :func:`parse_cmip6_table_frequency`, this function
+    understands the new two-part table naming scheme used by
+    ``mip-cmor-tables`` (e.g. ``APmon``, ``OPday``, ``LPmon``).  It falls
+    back to ``parse_cmip6_table_frequency`` so that callers do not need to
+    know which backend produced the compound name.
+
+    Parameters
+    ----------
+    compound_name:
+        Dot-separated compound name, e.g. ``APmon.tas`` or ``OPmon.thetao``.
+
+    Returns
+    -------
+    pandas.Timedelta
+    """
+    global _MIP_TABLE_FREQUENCY_MAP
+    if not _MIP_TABLE_FREQUENCY_MAP:
+        _MIP_TABLE_FREQUENCY_MAP = _build_mip_table_frequency_map()
+
+    try:
+        table_id, _ = compound_name.split(".", 1)
+    except ValueError:
+        raise ValueError(
+            f"Invalid compound name format: {compound_name!r}. Expected 'table.variable'"
+        )
+
+    if table_id in _MIP_TABLE_FREQUENCY_MAP:
+        return _MIP_TABLE_FREQUENCY_MAP[table_id]
+
+    raise ValueError(
+        f"Unknown MIP table ID: {table_id!r}. Cannot determine target frequency. "
+        f"Known MIP table prefixes: AP, AE, AC, OP, OB, LP, LI, SI, GIA, GIG. "
+        f"For legacy CMIP6 names (Amon, Omon, …) use parse_cmip6_table_frequency."
+    )
+
+
+class MIPCMORTablesBackend:
+    """
+    Mixin that wires a vocabulary class to the generic ``mip-cmor-tables``
+    table collection instead of the legacy ``cmip6-cmor-tables``.
+
+    Design intent
+    -------------
+    * ``CMIP6Vocabulary`` (and its existing subclass ``CMIP6PlusVocabulary``)
+      hardcode ``table_dir`` and ``table_prefix`` to point at the vendored
+      ``cmip6-cmor-tables/Tables/`` directory where files are named
+      ``CMIP6_<TableID>.json``.
+    * This mixin overrides **only** the two table-resolution methods
+      (``_table_filename`` and ``_load_table``) and the ``_get_axes`` /
+      ``_get_variable_suggestions`` helpers that reference known table names.
+    * Everything else – CV loading, global-attribute generation, DRS path
+      building – is inherited unchanged from the parent ``CMIP6Vocabulary``
+      (or ``CMIP6PlusVocabulary``).
+
+    Subclasses must set:
+        ``mip_table_dir``  – importlib resource path to the MIP Tables directory
+        ``mip_aux_dir``    – importlib resource path to the Auxillary_files dir
+        ``mip_table_prefix`` – file-name prefix (default: ``"MIP"``)
+
+    This class must appear **before** the base vocabulary class in the MRO so
+    that Python's MRO resolves overridden methods here first.
+    """
+
+    mip_table_dir: str = "access_moppy.vocabularies.mip_cmor_tables.Tables"
+    mip_aux_dir: str = "access_moppy.vocabularies.mip_cmor_tables.Auxillary_files"
+    mip_table_prefix: str = "MIP"
+
+    # Known MIP table IDs for variable-not-found suggestions.
+    _MIP_COMMON_TABLES: List[str] = [
+        "APmon", "APday", "APmonLev",
+        "AEmon", "AEday",
+        "OPmon", "OPday",
+        "LPmon", "LPday",
+        "SImon", "SIday",
+        "LImon",
+        "OBmon",
+        "APfx", "OPfx", "LIfx",
+    ]
+
+    def _table_filename(self, key: str) -> str:
+        return f"{self.mip_table_prefix}_{key}.json"
+
+    def _load_table(self) -> Dict[str, Any]:
+        entry = files(self.mip_table_dir) / self._table_filename(self.table)
+
+        if not entry.exists():
+            raise FileNotFoundError(
+                f"MIP CMOR table file not found for table='{self.table}' "
+                f"(looked for '{self._table_filename(self.table)}' in '{self.mip_table_dir}'). "
+                f"Available tables use the MIP naming scheme: APmon, APday, OPmon, LPmon, SImon, …"
+            )
+
+        with as_file(entry) as path:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+
+    def _get_variable_suggestions(self) -> List[str]:
+        suggestions = []
+        found_in_tables = []
+
+        for table in self._MIP_COMMON_TABLES:
+            if table == self.table:
+                continue
+
+            try:
+                table_resource = files(self.mip_table_dir) / self._table_filename(table)
+                with as_file(table_resource) as table_path:
+                    with open(table_path, "r", encoding="utf-8") as f:
+                        table_data = json.load(f)
+                if self.cmor_name in table_data.get("variable_entry", {}):
+                    found_in_tables.append(table)
+            except (FileNotFoundError, KeyError):
+                continue
+
+        if found_in_tables:
+            suggestions.append(
+                f"Variable '{self.cmor_name}' is available in MIP table(s): "
+                + ", ".join(found_in_tables)
+            )
+            suggestions.append(f"Try using: {found_in_tables[0]}.{self.cmor_name}")
+
+        try:
+            current_table_data = self._load_table()
+            available_vars = list(current_table_data.get("variable_entry", {}).keys())
+            similar_vars = [
+                v for v in available_vars
+                if len(v) > 2 and (
+                    self.cmor_name.lower() in v.lower()
+                    or v.lower() in self.cmor_name.lower()
+                    or (len(self.cmor_name) >= 3 and len(v) >= 3
+                        and self.cmor_name[:3].lower() == v[:3].lower())
+                )
+            ]
+            if similar_vars:
+                suggestions.append(
+                    f"Similar variables in {self.table} table: "
+                    + ", ".join(similar_vars[:5])
+                )
+            elif available_vars:
+                sample = ", ".join(available_vars[:10])
+                if len(available_vars) > 10:
+                    sample += f" (and {len(available_vars) - 10} more)"
+                suggestions.append(f"Available variables in {self.table} table: {sample}")
+        except Exception:
+            pass
+
+        suggestions.append(
+            "See https://github.com/PCMDI/mip-cmor-tables for the full MIP CMOR table listing."
+        )
+        return suggestions
+
+    def _get_axes(self, mapping) -> Dict[str, Any]:
+        """Load axes from MIP_coordinate.json in Auxillary_files/."""
+        coord_entry = files(self.mip_aux_dir) / f"{self.mip_table_prefix}_coordinate.json"
+
+        with as_file(coord_entry) as path:
+            with open(path, "r", encoding="utf-8") as f:
+                axes = json.load(f)["axis_entry"]
+
+        dims = self.variable["dimensions"]
+        # MIP tables store dimensions as a list; CMIP6 stores them as a space-sep string.
+        if isinstance(dims, str):
+            dims = dims.split()
+
+        vars_required = {}
+        for dim in dims:
+            if dim in axes and dim not in ["alevel"]:
+                coord = axes[dim]
+                vars_required[dim] = {k: v for k, v in coord.items() if v != ""}
+
+        var_mapping = list(mapping.values())[0]
+
+        if "zaxis" in var_mapping:
+            zaxis_type = var_mapping["zaxis"].get("type", {})
+            zcoord = axes.get(zaxis_type, {}).get("out_name")
+            if zcoord:
+                vars_required[zcoord] = {
+                    k: v for k, v in axes[zaxis_type].items() if v != ""
+                }
+            zfactors_str = axes.get(zaxis_type, {}).get("z_factors", "")
+            if zfactors_str:
+                parts = zfactors_str.split()
+                zfactors = {
+                    parts[i].rstrip(":"): parts[i + 1]
+                    for i in range(0, len(parts), 2)
+                    if i + 1 < len(parts)
+                }
+                formula_entry = (
+                    files(self.mip_aux_dir)
+                    / f"{self.mip_table_prefix}_formula_terms.json"
+                )
+                with as_file(formula_entry) as fpath:
+                    with open(fpath, "r", encoding="utf-8") as ff:
+                        formula_terms = json.load(ff)["formula_entry"]
+                for factor_name in zfactors:
+                    if factor_name in formula_terms:
+                        zcoord_ft = formula_terms[factor_name]
+                        vars_required[factor_name] = {
+                            k: v for k, v in zcoord_ft.items() if v != ""
+                        }
+
+        extended_mapping = var_mapping["dimensions"] | var_mapping.get("zaxis", {}).get(
+            "coordinate_variables", {}
+        )
+        inverted_extended_mapping = {v: k for k, v in extended_mapping.items()}
+        vars_rename_map = {}
+        for _, v in vars_required.items():
+            input_dim = inverted_extended_mapping.get(v["out_name"])
+            if input_dim:
+                vars_rename_map[input_dim] = v["out_name"]
+
+        self.axes = vars_required
+        return vars_required, vars_rename_map
+
+
+class CMIP6PlusMIPVocabulary(MIPCMORTablesBackend, CMIP6PlusVocabulary):
+    """
+    CMIP6Plus vocabulary backed by ``mip-cmor-tables`` (APmon, OPmon, …).
+
+    This class targets the new MIP CMOR table naming scheme while keeping the
+    CMIP6Plus controlled vocabularies (experiment_id, source_id, …) and
+    global-attribute / DRS logic intact.
+
+    Usage
+    -----
+    Use this class exactly like ``CMIP6PlusVocabulary`` but pass the new MIP
+    table names in the compound name::
+
+        vocab = CMIP6PlusMIPVocabulary(
+            compound_name="APmon.tas",
+            experiment_id="historical",
+            source_id="ACCESS-CM2",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+        )
+
+    Table name mapping (legacy → new MIP scheme)
+    ---------------------------------------------
+    Legacy CMIP6   →   MIP table
+    Amon           →   APmon
+    day            →   APday  (atmosphere) / LPday (land) / OPday (ocean)
+    Omon           →   OPmon
+    Lmon           →   LPmon
+    SImon          →   SImon   (unchanged)
+    AERmon         →   AEmon
+    Emon           →   (no direct equivalent; use APmon or AEmon)
+    fx / Ofx       →   APfx / OPfx
+
+    See https://github.com/PCMDI/mip-cmor-tables/tree/main/Tables for the
+    full list of available tables.
+    """
+
+    # CV pointers are inherited from CMIP6PlusVocabulary unchanged.
+    # Table pointers are inherited from MIPCMORTablesBackend.
+
+    def __repr__(self) -> str:
+        return (
+            f"<CMIP6PlusMIPVocabulary variable={self.cmor_name} "
+            f"table={self.table} "
+            f"experiment={self.experiment_id} "
+            f"source={self.source_id}>"
+        )

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -5,7 +5,10 @@ import warnings
 from datetime import datetime, timezone
 from importlib.resources import as_file, files
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 import numpy as np
 import xarray as xr
@@ -2322,14 +2325,22 @@ class MIPCMORTablesBackend:
 
     # Known MIP table IDs for variable-not-found suggestions.
     _MIP_COMMON_TABLES: List[str] = [
-        "APmon", "APday", "APmonLev",
-        "AEmon", "AEday",
-        "OPmon", "OPday",
-        "LPmon", "LPday",
-        "SImon", "SIday",
+        "APmon",
+        "APday",
+        "APmonLev",
+        "AEmon",
+        "AEday",
+        "OPmon",
+        "OPday",
+        "LPmon",
+        "LPday",
+        "SImon",
+        "SIday",
         "LImon",
         "OBmon",
-        "APfx", "OPfx", "LIfx",
+        "APfx",
+        "OPfx",
+        "LIfx",
     ]
 
     def _table_filename(self, key: str) -> str:
@@ -2378,12 +2389,17 @@ class MIPCMORTablesBackend:
             current_table_data = self._load_table()
             available_vars = list(current_table_data.get("variable_entry", {}).keys())
             similar_vars = [
-                v for v in available_vars
-                if len(v) > 2 and (
+                v
+                for v in available_vars
+                if len(v) > 2
+                and (
                     self.cmor_name.lower() in v.lower()
                     or v.lower() in self.cmor_name.lower()
-                    or (len(self.cmor_name) >= 3 and len(v) >= 3
-                        and self.cmor_name[:3].lower() == v[:3].lower())
+                    or (
+                        len(self.cmor_name) >= 3
+                        and len(v) >= 3
+                        and self.cmor_name[:3].lower() == v[:3].lower()
+                    )
                 )
             ]
             if similar_vars:
@@ -2395,7 +2411,9 @@ class MIPCMORTablesBackend:
                 sample = ", ".join(available_vars[:10])
                 if len(available_vars) > 10:
                     sample += f" (and {len(available_vars) - 10} more)"
-                suggestions.append(f"Available variables in {self.table} table: {sample}")
+                suggestions.append(
+                    f"Available variables in {self.table} table: {sample}"
+                )
         except Exception:
             pass
 
@@ -2406,7 +2424,9 @@ class MIPCMORTablesBackend:
 
     def _get_axes(self, mapping) -> Dict[str, Any]:
         """Load axes from MIP_coordinate.json in Auxillary_files/."""
-        coord_entry = files(self.mip_aux_dir) / f"{self.mip_table_prefix}_coordinate.json"
+        coord_entry = (
+            files(self.mip_aux_dir) / f"{self.mip_table_prefix}_coordinate.json"
+        )
 
         with as_file(coord_entry) as path:
             with open(path, "r", encoding="utf-8") as f:

--- a/tests/unit/test_mip_cmor_tables_vocabulary.py
+++ b/tests/unit/test_mip_cmor_tables_vocabulary.py
@@ -1,0 +1,588 @@
+"""
+Tests for the mip-cmor-tables backend and CMIP6PlusMIPVocabulary.
+
+Covers:
+* MIPCMORTablesBackend._table_filename / _load_table routing
+* CMIP6PlusMIPVocabulary instantiation with APmon / OPmon / LPmon / APday tables
+* Variable metadata retrieval for tas, pr, psl, ua, va, zg, hur
+* parse_mip_table_frequency for the new table name scheme
+* parse_cmip6_table_frequency fall-through to MIP names
+* _MONTHLY_TABLE_IDS includes new MIP table names
+* Driver CMIP6Plus auto-selection of CMIP6PlusMIPVocabulary
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from access_moppy.vocabulary_processors import (
+    CMIP6PlusMIPVocabulary,
+    MIPCMORTablesBackend,
+    parse_mip_table_frequency,
+)
+from access_moppy.utilities import (
+    _MONTHLY_TABLE_IDS,
+    parse_cmip6_table_frequency,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_MOCK_VOCAB = {
+    "experiment_id": {
+        "historical": {
+            "experiment": "historical",
+            "activity_id": ["CMIP"],
+            "required_model_components": ["AOGCM"],
+            "parent_experiment_id": ["piControl"],
+        }
+    },
+    "activity_id": {"CMIP": "CMIP DECK"},
+    "source_id": {
+        "ACCESS-CM2": {
+            "label": "ACCESS-CM2",
+            "institution_id": ["CSIRO-ARCCSS"],
+            "license_info": {
+                "id": "CC BY 4.0",
+                "url": "https://creativecommons.org/licenses/by/4.0/",
+            },
+            "release_year": "2019",
+            "model_component": {
+                "atmos": {
+                    "description": "mock atmosphere",
+                    "native_nominal_resolution": "250 km",
+                },
+                "ocean": {
+                    "description": "mock ocean",
+                    "native_nominal_resolution": "100 km",
+                },
+            },
+        }
+    },
+    "institution_id": {"CSIRO-ARCCSS": "CSIRO-ARCCSS"},
+}
+
+_MOCK_PARENT_INFO = {
+    "parent_experiment_id": "piControl",
+    "parent_activity_id": "CMIP",
+    "parent_mip_era": "CMIP6Plus",
+    "parent_source_id": "ACCESS-CM2",
+    "parent_variant_label": "r1i1p1f1",
+    "parent_time_units": "days since 0001-01-01 00:00:00",
+    "branch_time_in_child": 0.0,
+    "branch_time_in_parent": 0.0,
+    "branch_method": "standard",
+}
+
+
+def _make_table(variable_entries: dict) -> dict:
+    """Helper to build a minimal MIP table dict around variable entries."""
+    return {
+        "Header": {
+            "Conventions": "CF-1.7 CMIP-6.5",
+            "data_specs_version": "6.5.0.0",
+            "product": "model-output",
+            "missing_value": "1e20",
+            "int_missing_value": "-999",
+            "table_id": "APmon",
+        },
+        "variable_entry": variable_entries,
+    }
+
+
+_ATMOS_VARS = {
+    "tas": {
+        "frequency": "mon",
+        "modeling_realm": "atmos",
+        "units": "K",
+        "type": "real",
+        "dimensions": ["longitude", "latitude", "time", "height2m"],
+        "long_name": "Near-Surface Air Temperature",
+        "standard_name": "air_temperature",
+        "cell_methods": "area: time: mean",
+        "cell_measures": "area: areacella",
+        "out_name": "tas",
+        "positive": "",
+        "valid_max": "",
+        "valid_min": "",
+    },
+    "pr": {
+        "frequency": "mon",
+        "modeling_realm": "atmos",
+        "units": "kg m-2 s-1",
+        "type": "real",
+        "dimensions": ["longitude", "latitude", "time"],
+        "long_name": "Precipitation",
+        "standard_name": "precipitation_flux",
+        "cell_methods": "area: time: mean",
+        "cell_measures": "area: areacella",
+        "out_name": "pr",
+        "positive": "",
+        "valid_max": "",
+        "valid_min": "",
+    },
+    "psl": {
+        "frequency": "mon",
+        "modeling_realm": "atmos",
+        "units": "Pa",
+        "type": "real",
+        "dimensions": ["longitude", "latitude", "time"],
+        "long_name": "Sea Level Pressure",
+        "standard_name": "air_pressure_at_mean_sea_level",
+        "cell_methods": "area: time: mean",
+        "cell_measures": "area: areacella",
+        "out_name": "psl",
+        "positive": "",
+        "valid_max": "",
+        "valid_min": "",
+    },
+    "ua": {
+        "frequency": "mon",
+        "modeling_realm": "atmos",
+        "units": "m s-1",
+        "type": "real",
+        "dimensions": ["longitude", "latitude", "plev19", "time"],
+        "long_name": "Eastward Wind",
+        "standard_name": "eastward_wind",
+        "cell_methods": "time: mean",
+        "cell_measures": "area: areacella",
+        "out_name": "ua",
+        "positive": "",
+        "valid_max": "",
+        "valid_min": "",
+    },
+    "va": {
+        "frequency": "mon",
+        "modeling_realm": "atmos",
+        "units": "m s-1",
+        "type": "real",
+        "dimensions": ["longitude", "latitude", "plev19", "time"],
+        "long_name": "Northward Wind",
+        "standard_name": "northward_wind",
+        "cell_methods": "time: mean",
+        "cell_measures": "area: areacella",
+        "out_name": "va",
+        "positive": "",
+        "valid_max": "",
+        "valid_min": "",
+    },
+    "zg": {
+        "frequency": "mon",
+        "modeling_realm": "atmos",
+        "units": "m",
+        "type": "real",
+        "dimensions": ["longitude", "latitude", "plev19", "time"],
+        "long_name": "Geopotential Height",
+        "standard_name": "geopotential_height",
+        "cell_methods": "time: mean",
+        "cell_measures": "area: areacella",
+        "out_name": "zg",
+        "positive": "",
+        "valid_max": "",
+        "valid_min": "",
+    },
+    "hur": {
+        "frequency": "mon",
+        "modeling_realm": "atmos",
+        "units": "%",
+        "type": "real",
+        "dimensions": ["longitude", "latitude", "plev19", "time"],
+        "long_name": "Relative Humidity",
+        "standard_name": "relative_humidity",
+        "cell_methods": "time: mean",
+        "cell_measures": "area: areacella",
+        "out_name": "hur",
+        "positive": "",
+        "valid_max": "",
+        "valid_min": "",
+    },
+}
+
+_MOCK_APMON_TABLE = _make_table(_ATMOS_VARS)
+
+
+def _make_vocab(compound_name: str, *, mock_table=None) -> CMIP6PlusMIPVocabulary:
+    """Return a fully-mocked CMIP6PlusMIPVocabulary instance."""
+    table = mock_table or _MOCK_APMON_TABLE
+    with (
+        patch.object(
+            CMIP6PlusMIPVocabulary,
+            "_load_controlled_vocab",
+            return_value=_MOCK_VOCAB,
+        ),
+        patch.object(CMIP6PlusMIPVocabulary, "_load_table", return_value=table),
+    ):
+        return CMIP6PlusMIPVocabulary(
+            compound_name=compound_name,
+            experiment_id="historical",
+            source_id="ACCESS-CM2",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+            activity_id="CMIP",
+            parent_info=_MOCK_PARENT_INFO,
+        )
+
+
+# ---------------------------------------------------------------------------
+# MIPCMORTablesBackend unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMIPCMORTablesBackend:
+    @pytest.mark.unit
+    def test_table_filename_uses_mip_prefix(self):
+        """_table_filename returns MIP_<TableID>.json."""
+
+        class _Stub(MIPCMORTablesBackend):
+            pass
+
+        stub = _Stub()
+        assert stub._table_filename("APmon") == "MIP_APmon.json"
+        assert stub._table_filename("OPmon") == "MIP_OPmon.json"
+        assert stub._table_filename("LPmon") == "MIP_LPmon.json"
+        assert stub._table_filename("SImon") == "MIP_SImon.json"
+        assert stub._table_filename("coordinate") == "MIP_coordinate.json"
+
+    @pytest.mark.unit
+    def test_load_table_raises_for_unknown_table(self):
+        """_load_table raises FileNotFoundError for a nonexistent table."""
+        vocab = _make_vocab("APmon.tas")
+        vocab.table = "Amon"  # legacy name – should not exist in MIP tables
+        with pytest.raises(FileNotFoundError, match="MIP CMOR table file not found"):
+            # Bypass the mock so it hits the real filesystem lookup
+            with patch.object(
+                CMIP6PlusMIPVocabulary, "_load_table", wraps=MIPCMORTablesBackend._load_table
+            ):
+                MIPCMORTablesBackend._load_table(vocab)
+
+
+# ---------------------------------------------------------------------------
+# CMIP6PlusMIPVocabulary – instantiation and CV inheritance
+# ---------------------------------------------------------------------------
+
+
+class TestCMIP6PlusMIPVocabularyInstantiation:
+    @pytest.mark.unit
+    def test_inherits_cmip6plus_cv_dir(self):
+        """cv_dir still points at CMIP6Plus_CVs (not CMIP6_CVs)."""
+        vocab = _make_vocab("APmon.tas")
+        assert "CMIP6Plus" in vocab.cv_dir
+
+    @pytest.mark.unit
+    def test_mip_era_is_cmip6plus(self):
+        vocab = _make_vocab("APmon.tas")
+        assert vocab.mip_era == "CMIP6Plus"
+
+    @pytest.mark.unit
+    def test_table_parsed_correctly(self):
+        vocab = _make_vocab("APmon.tas")
+        assert vocab.table == "APmon"
+        assert vocab.cmor_name == "tas"
+
+    @pytest.mark.unit
+    def test_ocean_table_parses(self):
+        ocean_table = _make_table(
+            {
+                "thetao": {
+                    "frequency": "mon",
+                    "modeling_realm": "ocean",
+                    "units": "degC",
+                    "type": "real",
+                    "dimensions": ["longitude", "latitude", "olevel", "time"],
+                    "long_name": "Sea Water Potential Temperature",
+                    "standard_name": "sea_water_potential_temperature",
+                    "cell_methods": "time: mean",
+                    "cell_measures": "area: areacello volume: volcello",
+                    "out_name": "thetao",
+                    "positive": "",
+                    "valid_max": "",
+                    "valid_min": "",
+                }
+            }
+        )
+        vocab = _make_vocab("OPmon.thetao", mock_table=ocean_table)
+        assert vocab.table == "OPmon"
+        assert vocab.cmor_name == "thetao"
+
+    @pytest.mark.unit
+    def test_repr_identifies_class(self):
+        vocab = _make_vocab("APmon.tas")
+        assert "CMIP6PlusMIPVocabulary" in repr(vocab)
+        assert "APmon" in repr(vocab)
+        assert "tas" in repr(vocab)
+
+
+# ---------------------------------------------------------------------------
+# Variable metadata for the target variable set
+# ---------------------------------------------------------------------------
+
+
+class TestCMIP6PlusMIPVariableMetadata:
+    @pytest.mark.unit
+    @pytest.mark.parametrize("varname", ["tas", "pr", "psl", "ua", "va", "zg", "hur"])
+    def test_variable_entry_loaded(self, varname):
+        """variable entry is populated for all target variables."""
+        vocab = _make_vocab(f"APmon.{varname}")
+        assert vocab.variable is not None
+        assert vocab.variable["units"] == _ATMOS_VARS[varname]["units"]
+        assert vocab.variable["standard_name"] == _ATMOS_VARS[varname]["standard_name"]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("varname", ["tas", "pr", "psl", "ua", "va", "zg", "hur"])
+    def test_fill_value_defaults_set(self, varname):
+        vocab = _make_vocab(f"APmon.{varname}")
+        assert vocab.get_cmip_missing_value() == pytest.approx(1e20)
+        assert vocab.get_cmip_fill_value() == pytest.approx(1e20)
+
+    @pytest.mark.unit
+    def test_variable_not_found_raises_with_suggestions(self):
+        vocab = _make_vocab("APmon.tas")
+        # Patch _get_variable_suggestions on MIPCMORTablesBackend so it returns a canned list
+        with patch.object(
+            CMIP6PlusMIPVocabulary,
+            "_get_variable_suggestions",
+            return_value=["Try APmon.pr"],
+        ):
+            from access_moppy.vocabulary_processors import VariableNotFoundError
+
+            # Force re-evaluation of _get_variable_entry with an unknown name
+            vocab.cmor_name = "nonexistent_var_xyz"
+            with pytest.raises(VariableNotFoundError, match="nonexistent_var_xyz"):
+                vocab._get_variable_entry()
+
+
+# ---------------------------------------------------------------------------
+# Global attributes
+# ---------------------------------------------------------------------------
+
+
+class TestCMIP6PlusMIPGlobalAttributes:
+    @pytest.mark.unit
+    def test_mip_era_attribute(self):
+        vocab = _make_vocab("APmon.tas")
+        with patch.object(CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}):
+            attrs = vocab.get_required_global_attributes()
+        assert attrs["mip_era"] == "CMIP6Plus"
+
+    @pytest.mark.unit
+    def test_table_id_attribute_uses_mip_table(self):
+        vocab = _make_vocab("APmon.tas")
+        with patch.object(CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}):
+            attrs = vocab.get_required_global_attributes()
+        assert attrs["table_id"] == "APmon"
+
+    @pytest.mark.unit
+    def test_variable_id_attribute(self):
+        vocab = _make_vocab("APmon.tas")
+        with patch.object(CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}):
+            attrs = vocab.get_required_global_attributes()
+        assert attrs["variable_id"] == "tas"
+
+    @pytest.mark.unit
+    def test_license_mentions_cmip6plus(self):
+        vocab = _make_vocab("APmon.tas")
+        with patch.object(CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}):
+            attrs = vocab.get_required_global_attributes()
+        assert "CMIP6Plus" in attrs["license"]
+
+
+# ---------------------------------------------------------------------------
+# parse_mip_table_frequency
+# ---------------------------------------------------------------------------
+
+
+class TestParseMIPTableFrequency:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "compound_name, expected_days",
+        [
+            ("APmon.tas", 30),
+            ("APday.tasmax", 1),
+            ("OPmon.thetao", 30),
+            ("OPday.tos", 1),
+            ("LPmon.mrso", 30),
+            ("LPday.mrso", 1),
+            ("SImon.siconc", 30),
+            ("SIday.siconc", 1),
+            ("LImon.snw", 30),
+            ("OBmon.dissic", 30),
+            ("APfx.orog", 0),
+            ("OPfx.deptho", 0),
+        ],
+    )
+    def test_known_mip_tables(self, compound_name, expected_days):
+        import pandas as pd
+
+        result = parse_mip_table_frequency(compound_name)
+        assert result == pd.Timedelta(days=expected_days)
+
+    @pytest.mark.unit
+    def test_subdaily_tables(self):
+        import pandas as pd
+
+        assert parse_mip_table_frequency("AP3hr.pr") == pd.Timedelta(hours=3)
+        assert parse_mip_table_frequency("AP6hr.ua") == pd.Timedelta(hours=6)
+        assert parse_mip_table_frequency("AP1hr.pr") == pd.Timedelta(hours=1)
+
+    @pytest.mark.unit
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Invalid compound name"):
+            parse_mip_table_frequency("APmon")
+
+    @pytest.mark.unit
+    def test_unknown_mip_table_raises_value_error(self):
+        """Legacy CMIP6 names like Amon are not in the MIP map – should raise."""
+        with pytest.raises(ValueError, match="Unknown MIP table ID"):
+            parse_mip_table_frequency("Amon.tas")
+
+
+# ---------------------------------------------------------------------------
+# parse_cmip6_table_frequency fall-through
+# ---------------------------------------------------------------------------
+
+
+class TestParseCMIP6TableFrequencyFallThrough:
+    @pytest.mark.unit
+    def test_legacy_names_still_work(self):
+        import pandas as pd
+
+        assert parse_cmip6_table_frequency("Amon.tas") == pd.Timedelta(days=30)
+        assert parse_cmip6_table_frequency("Omon.thetao") == pd.Timedelta(days=30)
+        assert parse_cmip6_table_frequency("day.pr") == pd.Timedelta(days=1)
+
+    @pytest.mark.unit
+    def test_new_mip_names_work_via_fallthrough(self):
+        import pandas as pd
+
+        assert parse_cmip6_table_frequency("APmon.tas") == pd.Timedelta(days=30)
+        assert parse_cmip6_table_frequency("OPmon.thetao") == pd.Timedelta(days=30)
+        assert parse_cmip6_table_frequency("LPday.mrso") == pd.Timedelta(days=1)
+
+    @pytest.mark.unit
+    def test_completely_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown table ID"):
+            parse_cmip6_table_frequency("XYZUNKNOWN.foo")
+
+
+# ---------------------------------------------------------------------------
+# _MONTHLY_TABLE_IDS
+# ---------------------------------------------------------------------------
+
+
+class TestMonthlyTableIDs:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "table_id",
+        [
+            # Legacy CMIP6 names must still be present
+            "Amon", "Lmon", "Omon", "SImon", "CFmon",
+            # New MIP names
+            "APmon", "APmonLev", "APmonZ",
+            "AEmon", "OPmon", "LPmon", "LImon", "OBmon",
+            "GIAmon", "GIGmon",
+        ],
+    )
+    def test_monthly_ids_present(self, table_id):
+        assert table_id in _MONTHLY_TABLE_IDS
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("table_id", ["APday", "OPday", "LPday", "AP3hr"])
+    def test_non_monthly_ids_absent(self, table_id):
+        assert table_id not in _MONTHLY_TABLE_IDS
+
+
+# ---------------------------------------------------------------------------
+# Driver auto-selection
+# ---------------------------------------------------------------------------
+
+
+class TestDriverAutoSelectsMIPVocabulary:
+    @pytest.fixture
+    def mock_vocab_attrs(self):
+        """Minimal mock vocab instance attributes used by the driver post-init."""
+        v = type("MockVocab", (), {})()
+        v.table = "APmon"
+        v.cmor_name = "tas"
+        v.variable = {
+            "frequency": "mon",
+            "modeling_realm": "atmos",
+            "dimensions": "longitude latitude time height2m",
+            "units": "K",
+            "type": "real",
+            "missing_value": 1e20,
+            "_FillValue": 1e20,
+        }
+        v.cmip_table = {
+            "Header": {
+                "Conventions": "CF-1.7",
+                "data_specs_version": "6.5.0.0",
+                "product": "model-output",
+            }
+        }
+        return v
+
+    @pytest.mark.unit
+    def test_apmon_selects_mip_vocabulary(self, mock_vocab_attrs, tmp_path):
+        """Driver picks CMIP6PlusMIPVocabulary for APmon compound names."""
+        from access_moppy.driver import ACCESS_ESM_CMORiser
+
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.CMIP6PlusMIPVocabulary") as mock_mip,
+            patch("access_moppy.driver.CMIP6PlusVocabulary") as mock_legacy,
+        ):
+            mock_load.return_value = {"tas": {"units": "K"}}
+            mock_mip.return_value = mock_vocab_attrs
+
+            try:
+                ACCESS_ESM_CMORiser(
+                    input_paths=["test.nc"],
+                    compound_name="APmon.tas",
+                    cmip_version="CMIP6Plus",
+                    experiment_id="historical",
+                    source_id="ACCESS-CM2",
+                    variant_label="r1i1p1f1",
+                    grid_label="gn",
+                    output_path=str(tmp_path),
+                )
+            except Exception:
+                pass
+
+            mock_mip.assert_called_once()
+            mock_legacy.assert_not_called()
+
+    @pytest.mark.unit
+    def test_amon_selects_legacy_vocabulary(self, mock_vocab_attrs, tmp_path):
+        """Driver picks CMIP6PlusVocabulary for legacy Amon compound names."""
+        from access_moppy.driver import ACCESS_ESM_CMORiser
+
+        mock_vocab_attrs.table = "Amon"
+        mock_vocab_attrs.cmip_table["Header"]["data_specs_version"] = "01.00.33"
+
+        with (
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.CMIP6PlusMIPVocabulary") as mock_mip,
+            patch("access_moppy.driver.CMIP6PlusVocabulary") as mock_legacy,
+        ):
+            mock_load.return_value = {"tas": {"units": "K"}}
+            mock_legacy.return_value = mock_vocab_attrs
+
+            try:
+                ACCESS_ESM_CMORiser(
+                    input_paths=["test.nc"],
+                    compound_name="Amon.tas",
+                    cmip_version="CMIP6Plus",
+                    experiment_id="historical",
+                    source_id="ACCESS-CM2",
+                    variant_label="r1i1p1f1",
+                    grid_label="gn",
+                    output_path=str(tmp_path),
+                )
+            except Exception:
+                pass
+
+            mock_legacy.assert_called_once()
+            mock_mip.assert_not_called()

--- a/tests/unit/test_mip_cmor_tables_vocabulary.py
+++ b/tests/unit/test_mip_cmor_tables_vocabulary.py
@@ -11,21 +11,19 @@ Covers:
 * Driver CMIP6Plus auto-selection of CMIP6PlusMIPVocabulary
 """
 
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from access_moppy.utilities import (
+    _MONTHLY_TABLE_IDS,
+    parse_cmip6_table_frequency,
+)
 from access_moppy.vocabulary_processors import (
     CMIP6PlusMIPVocabulary,
     MIPCMORTablesBackend,
     parse_mip_table_frequency,
 )
-from access_moppy.utilities import (
-    _MONTHLY_TABLE_IDS,
-    parse_cmip6_table_frequency,
-)
-
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -254,7 +252,9 @@ class TestMIPCMORTablesBackend:
         with pytest.raises(FileNotFoundError, match="MIP CMOR table file not found"):
             # Bypass the mock so it hits the real filesystem lookup
             with patch.object(
-                CMIP6PlusMIPVocabulary, "_load_table", wraps=MIPCMORTablesBackend._load_table
+                CMIP6PlusMIPVocabulary,
+                "_load_table",
+                wraps=MIPCMORTablesBackend._load_table,
             ):
                 MIPCMORTablesBackend._load_table(vocab)
 
@@ -363,28 +363,36 @@ class TestCMIP6PlusMIPGlobalAttributes:
     @pytest.mark.unit
     def test_mip_era_attribute(self):
         vocab = _make_vocab("APmon.tas")
-        with patch.object(CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}):
+        with patch.object(
+            CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}
+        ):
             attrs = vocab.get_required_global_attributes()
         assert attrs["mip_era"] == "CMIP6Plus"
 
     @pytest.mark.unit
     def test_table_id_attribute_uses_mip_table(self):
         vocab = _make_vocab("APmon.tas")
-        with patch.object(CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}):
+        with patch.object(
+            CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}
+        ):
             attrs = vocab.get_required_global_attributes()
         assert attrs["table_id"] == "APmon"
 
     @pytest.mark.unit
     def test_variable_id_attribute(self):
         vocab = _make_vocab("APmon.tas")
-        with patch.object(CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}):
+        with patch.object(
+            CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}
+        ):
             attrs = vocab.get_required_global_attributes()
         assert attrs["variable_id"] == "tas"
 
     @pytest.mark.unit
     def test_license_mentions_cmip6plus(self):
         vocab = _make_vocab("APmon.tas")
-        with patch.object(CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}):
+        with patch.object(
+            CMIP6PlusMIPVocabulary, "get_parent_experiment_attrs", return_value={}
+        ):
             attrs = vocab.get_required_global_attributes()
         assert "CMIP6Plus" in attrs["license"]
 
@@ -478,11 +486,22 @@ class TestMonthlyTableIDs:
         "table_id",
         [
             # Legacy CMIP6 names must still be present
-            "Amon", "Lmon", "Omon", "SImon", "CFmon",
+            "Amon",
+            "Lmon",
+            "Omon",
+            "SImon",
+            "CFmon",
             # New MIP names
-            "APmon", "APmonLev", "APmonZ",
-            "AEmon", "OPmon", "LPmon", "LImon", "OBmon",
-            "GIAmon", "GIGmon",
+            "APmon",
+            "APmonLev",
+            "APmonZ",
+            "AEmon",
+            "OPmon",
+            "LPmon",
+            "LImon",
+            "OBmon",
+            "GIAmon",
+            "GIGmon",
         ],
     )
     def test_monthly_ids_present(self, table_id):


### PR DESCRIPTION
## Summary

Adds support for the [mip-cmor-tables](https://github.com/PCMDI/mip-cmor-tables) infrastructure as the shared table backend for CMIP6Plus, with a design that is ready to be extended to CMIP7.

## Motivation

- The legacy `cmip6-cmor-tables` (Amon, Omon, …) is frozen with CMIP6 and will not be extended.
- CMIP6Plus and CMIP7 use a new two-part realm+frequency table naming scheme (APmon, OPmon, LPmon, …).
- `mip-cmor-tables` is the PCMDI-maintained generic backend for this scheme.

## CMIP6 is untouched

`CMIP6Vocabulary` and its `cmip6_cmor_tables/Tables/CMIP6_*.json` path are **frozen and untouched**. No existing CMIP6 behaviour changes.

## What changed

### New: `MIPCMORTablesBackend` mixin (`vocabulary_processors.py`)

A focused mixin that overrides only the table-resolution methods:

- `_table_filename` → `MIP_<TableID>.json`
- `_load_table` → reads from `mip_cmor_tables/Tables/`
- `_get_axes` → reads from `mip_cmor_tables/Auxillary_files/MIP_coordinate.json`
- `_get_variable_suggestions` → searches MIP table names

Everything else (CV loading, global-attribute generation, DRS path building) is inherited unchanged from the parent class.

### New: `CMIP6PlusMIPVocabulary`

```python
class CMIP6PlusMIPVocabulary(MIPCMORTablesBackend, CMIP6PlusVocabulary):
    ...
```

Uses CMIP6Plus CVs + MIP CMOR tables.

### Table name mapping

| Legacy CMIP6 | New MIP scheme |
|---|---|
| Amon | APmon |
| Omon | OPmon |
| Lmon | LPmon |
| day | APday / LPday / OPday |
| SImon | SImon (unchanged) |
| AERmon | AEmon |
| fx / Ofx | APfx / OPfx |

### Driver auto-selection

`ACCESS_ESM_CMORiser` now automatically picks `CMIP6PlusMIPVocabulary` when the CMIP6Plus table name starts with a known MIP realm prefix (`AP`, `AE`, `AC`, `OP`, `OB`, `LP`, `LI`, `SI`, `GIA`, `GIG`), and falls back to `CMIP6PlusVocabulary` for legacy names.

### Frequency parsing

- New `parse_mip_table_frequency()` handles the MIP scheme.
- `parse_cmip6_table_frequency()` falls through to it for unknown IDs, so all existing callers work with both naming systems.
- `_MONTHLY_TABLE_IDS` extended with all MIP monthly table names.

### New submodule

`src/access_moppy/vocabularies/mip_cmor_tables` → `https://github.com/PCMDI/mip-cmor-tables` (branch: main)

## CMIP7 status

`CMIP7Vocabulary` (backed by `cmip7-cmor-tables`) is **not changed**. Wiring `MIPCMORTablesBackend` into CMIP7 is a follow-up task — CMIP7 has a different compound-name format and per-source JSON CV files.

## Tests

- 65 new tests in `tests/unit/test_mip_cmor_tables_vocabulary.py`
- 0 regressions (1141 total unit tests pass)
- Target variables covered: `tas`, `pr`, `psl`, `ua`, `va`, `zg`, `hur`

## Checklist

- [x] CMIP6 code path untouched
- [x] New backend is purely additive
- [x] `mip-cmor-tables` submodule added
- [x] `CMIP6PlusMIPVocabulary` implemented
- [x] Driver auto-selects MIP vs legacy vocabulary
- [x] Frequency parsing extended (no recursion)
- [x] Unit tests (65 new)
- [ ] Integration test with real ACCESS-CM2 output
- [ ] CMIP7 follow-up (`CMIP7MIPVocabulary`)
