### PR TITLE
Add temporary CMIP7 ACCESS source shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           pixi-version: latest
           environments: test
 
+      - name: Refresh CMIP7 vocabularies to latest upstream
+        run: |
+          git submodule sync -- src/access_moppy/vocabularies/CMIP7_CVs src/access_moppy/vocabularies/cmip7-cmor-tables
+          git submodule update --init --remote src/access_moppy/vocabularies/CMIP7_CVs src/access_moppy/vocabularies/cmip7-cmor-tables
+
       - name: Create default config file
         run: |
           mkdir -p ~/.moppy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Refresh CMIP7 vocabularies to latest upstream
         run: |
           git submodule sync -- src/access_moppy/vocabularies/CMIP7_CVs src/access_moppy/vocabularies/cmip7-cmor-tables
-          git submodule update --init --remote src/access_moppy/vocabularies/CMIP7_CVs src/access_moppy/vocabularies/cmip7-cmor-tables
+          git -C src/access_moppy/vocabularies/CMIP7_CVs fetch origin production
+          git -C src/access_moppy/vocabularies/CMIP7_CVs checkout --detach FETCH_HEAD
+          git -C src/access_moppy/vocabularies/cmip7-cmor-tables fetch origin main
+          git -C src/access_moppy/vocabularies/cmip7-cmor-tables checkout --detach FETCH_HEAD
 
       - name: Create default config file
         run: |

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Refresh CMIP7 vocabularies to latest upstream
         run: |
           git submodule sync -- src/access_moppy/vocabularies/CMIP7_CVs src/access_moppy/vocabularies/cmip7-cmor-tables
-          git submodule update --init --remote src/access_moppy/vocabularies/CMIP7_CVs src/access_moppy/vocabularies/cmip7-cmor-tables
+          git -C src/access_moppy/vocabularies/CMIP7_CVs fetch origin production
+          git -C src/access_moppy/vocabularies/CMIP7_CVs checkout --detach FETCH_HEAD
+          git -C src/access_moppy/vocabularies/cmip7-cmor-tables fetch origin main
+          git -C src/access_moppy/vocabularies/cmip7-cmor-tables checkout --detach FETCH_HEAD
 
       - name: Create default config file
         run: |

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           pixi-version: latest
 
+      - name: Refresh CMIP7 vocabularies to latest upstream
+        run: |
+          git submodule sync -- src/access_moppy/vocabularies/CMIP7_CVs src/access_moppy/vocabularies/cmip7-cmor-tables
+          git submodule update --init --remote src/access_moppy/vocabularies/CMIP7_CVs src/access_moppy/vocabularies/cmip7-cmor-tables
+
       - name: Create default config file
         run: |
           mkdir -p ~/.moppy

--- a/docs/source/CMORise_ILAMB_workflow.md
+++ b/docs/source/CMORise_ILAMB_workflow.md
@@ -6,11 +6,10 @@ The workflow uses ACCESS-MOPPy's batch processing system to CMORise multiple lan
 atmosphere, and biogeochemistry variables in parallel on NCI's Gadi HPC.
 
 :::{note}
-ACCESS-ESM1-6 is not yet officially registered in the CMIP controlled vocabularies.
-As a temporary workaround, we use ACCESS-ESM1-5 as the `source_id` during CMORisation.
-This means some outputs may appear labelled as ACCESS-ESM1-5, which can be confusing.
-We are aware of this limitation and plan to remove it as soon as ACCESS-ESM1-6 is
-validated and added to the CMIP vocabulary.
+ACCESS-MOPPy currently injects a temporary CMIP7 controlled-vocabulary override for
+`ACCESS-ESM1-6` so CMIP7 workflows can use the real `source_id` before the bundled
+CMIP7 CV snapshot is updated. This shim is intended to be removed once the official
+CMIP7 CVs include `ACCESS-ESM1-6`.
 :::
 
 ---
@@ -136,12 +135,13 @@ variables:
   # --- Omon ---
   # Omon.hfds  # TODO: add ocean file pattern once known
 
-# CMIP6 metadata
+# CMIP7 metadata
 experiment_id: historical
-source_id: ACCESS-ESM1-5
+source_id: ACCESS-ESM1-6
 variant_label: r1i1p1f1
 grid_label: gn
 activity_id: CMIP
+cmip_version: CMIP7
 
 # Input and output paths
 input_folder: "/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/production/historical-02"
@@ -338,13 +338,13 @@ conn.commit()
 ## Output Structure
 
 When `drs_root` is **not** set (the default for this workflow), all CMORised
-files land directly in `output_folder` with CMIP6-standard filenames:
+files land directly in `output_folder` with CMIP-standard filenames:
 
 ```
 output_folder/
-├── pr_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
-├── tas_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
-├── gpp_Lmon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc
+├── pr_Amon_ACCESS-ESM1-6_historical_r1i1p1f1_gn_185001-201412.nc
+├── tas_Amon_ACCESS-ESM1-6_historical_r1i1p1f1_gn_185001-201412.nc
+├── gpp_Lmon_ACCESS-ESM1-6_historical_r1i1p1f1_gn_185001-201412.nc
 ├── ...
 └── cmor_tasks.db
 ```

--- a/docs/source/batch_processing.rst
+++ b/docs/source/batch_processing.rst
@@ -59,12 +59,13 @@ Complete configuration file specification:
      - Omon.tos
      - Amon.tas
 
-   # Required: CMIP6 metadata
+   # Required: CMIP metadata
    experiment_id: "piControl"
-   source_id: "ACCESS-ESM1-5"
+   source_id: "ACCESS-ESM1-6"
    variant_label: "r1i1p1f1"
    grid_label: "gn"
    activity_id: "CMIP"
+   cmip_version: "CMIP7"
 
    # Required: File locations
    input_folder: "/g/data/project/model_output"
@@ -92,7 +93,7 @@ Complete configuration file specification:
      conda activate moppy_env
 
    # Optional Settings
-   drs_root: "/scratch/project/cmor_output/CMIP6"  # Enable DRS structure
+   drs_root: "/scratch/project/cmor_output/CMIP7"  # Enable DRS structure
    script_dir: "PATH-TO-SCRIPTS"  # Custom directory for generated scripts
    wait_for_completion: false         # Wait for all jobs before exit
    database_path: "/custom/db/path"   # Custom database location

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -296,12 +296,13 @@ Create a YAML configuration file specifying your batch processing parameters:
      - Amon.ts
      - Omon.zos
 
-   # CMIP6 metadata
+   # CMIP7 metadata
    experiment_id: piControl
-   source_id: ACCESS-ESM1-5
+   source_id: ACCESS-ESM1-6
    variant_label: r1i1p1f1
    grid_label: gn
    activity_id: CMIP
+   cmip_version: CMIP7
 
    # Input and output paths
    input_folder: "/g/data/p73/archive/CMIP7/ACCESS-ESM1-6/spinup/JuneSpinUp-JuneSpinUp-bfaa9c5b"
@@ -442,7 +443,7 @@ Configuration Options
 **Required Parameters:**
 
 - ``variables``: List of variables to process (format: ``table.variable``)
-- ``experiment_id``, ``source_id``, ``variant_label``, ``grid_label``: CMIP6 metadata
+- ``experiment_id``, ``source_id``, ``variant_label``, ``grid_label``: CMIP metadata
 - ``input_folder``: Root directory containing input files
 - ``output_folder``: Directory for CMORised output
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -206,7 +206,7 @@ CMIP7 Support with Full Branded Names
 
 ACCESS-MOPPy also supports the new CMIP7 compound name format, which uses full branded names instead of the table.variable format used in CMIP6. CMIP7 introduces a more descriptive naming convention that includes detailed information about the data processing and grid specifications.
 
-The CMIP7 format follows the pattern: ``realm.variable.operation.frequency.domain`` (e.g., ``atmos.tas.tavg-h2m-hxy-u.mon.glb``)
+The CMIP7 format follows the pattern: ``realm.variable.operation.frequency.domain`` (e.g., ``atmos.rsds.tavg-u-hxy-u.mon.GLB``)
 
 This provides more explicit information about:
 
@@ -223,16 +223,15 @@ Here's how to use CMIP7 compound names with ACCESS-MOPPy:
 
 .. code-block:: python
 
-   # Example: CMIP7 compound name for atmospheric temperature
+   # Example: CMIP7 compound name for surface downwelling shortwave radiation
    cmip7_cmoriser = ACCESS_ESM_CMORiser(
        input_data=files,  # Can reuse the same atmospheric files
-       compound_name="atmos.tas.tavg-h2m-hxy-u.mon.glb",  # CMIP7 full branded name
+       compound_name="atmos.rsds.tavg-u-hxy-u.mon.GLB",  # CMIP7 full branded name
        experiment_id="piControl-spinup",
-       source_id="pcmdi-test-1-0",  # CMIP7 test source identifier
+       source_id="ACCESS-ESM1-6",
        variant_label="r1i1p1f1",
        grid_label="gn",
        activity_id="CMIP",
-       parent_info=parent_experiment_config,
        cmip_version="CMIP7"  # Explicit CMIP7 support
    )
 
@@ -256,7 +255,7 @@ The table below shows the key differences between CMIP6 and CMIP7 compound name 
      - ``realm.variable.operation.frequency.domain``
    * - **Example**
      - ``Amon.tas``
-     - ``atmos.tas.tavg-h2m-hxy-u.mon.glb``
+     - ``atmos.rsds.tavg-u-hxy-u.mon.GLB``
    * - **Information**
      - Table and variable only
      - Detailed processing and grid info

--- a/docs/source/mapping_reference.rst
+++ b/docs/source/mapping_reference.rst
@@ -555,7 +555,7 @@ CMIP7 Compound Name Translation
 
 CMIP7 uses a longer "branded" compound name format:
 ``realm.variable.operation.frequency.domain``
-(e.g. ``atmos.tas.tavg-h2m-hxy-u.mon.glb``).
+(e.g. ``atmos.rsds.tavg-u-hxy-u.mon.GLB``).
 
 The files ``cmip7_to_cmip6_compound_name_mapping.json`` and
 ``cmip6_to_cmip7_compound_name_mapping.json`` provide a bidirectional look-up

--- a/notebooks/Getting_started.ipynb
+++ b/notebooks/Getting_started.ipynb
@@ -1015,6 +1015,8 @@
     "- `cmip_version=\"CMIP6Plus\"` uses CMIP6Plus vocabularies\n",
     "- `cmip_version=\"CMIP7\"` uses CMIP7 vocabularies\n",
     "\n",
+    "For CMIP7 you can either pass a CMIP6-style `table.variable` name when a mapping exists, or use the explicit CMIP7 branded name directly. The example below uses the full branded name for the ACCESS-ESM1.6 spinup dataset so it is easy to copy into a real CMIP7 workflow.\n",
+    "\n",
     "```python\n",
     "from access_moppy import ACCESS_ESM_CMORiser\n",
     "\n",
@@ -1043,7 +1045,28 @@
     ")\n",
     "```\n",
     "\n",
-    "> Tip: Use `source_id`, `experiment_id`, and related metadata values that exist in the selected vocabulary set, because CMIP6 and CMIP6Plus entries are not always identical."
+    "> Tip: Use `source_id`, `experiment_id`, and related metadata values that exist in the selected vocabulary set. For CMIP7 branded names, include the region suffix such as `.GLB`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Real CMIP7 example using the ACCESS-ESM1.6 spinup dataset\n",
+    "cmip7_cmoriser = ACCESS_ESM_CMORiser(\n",
+    "    input_data=files,\n",
+    "    compound_name=\"atmos.rsds.tavg-u-hxy-u.mon.GLB\",\n",
+    "    experiment_id=\"piControl-spinup\",\n",
+    "    source_id=\"ACCESS-ESM1-6\",\n",
+    "    variant_label=\"r1i1p1f1\",\n",
+    "    grid_label=\"gn\",\n",
+    "    activity_id=\"CMIP\",\n",
+    "    cmip_version=\"CMIP7\",\n",
+    ")\n",
+    "\n",
+    "cmip7_cmoriser.variable_mapping\n"
    ]
   },
   {

--- a/notebooks/Getting_started.ipynb
+++ b/notebooks/Getting_started.ipynb
@@ -1043,17 +1043,7 @@
     "    activity_id=\"CMIP\",\n",
     "    cmip_version=\"CMIP6Plus\",\n",
     ")\n",
-    "```\n",
     "\n",
-    "> Tip: Use `source_id`, `experiment_id`, and related metadata values that exist in the selected vocabulary set. For CMIP7 branded names, include the region suffix such as `.GLB`.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Real CMIP7 example using the ACCESS-ESM1.6 spinup dataset\n",
     "cmip7_cmoriser = ACCESS_ESM_CMORiser(\n",
     "    input_data=files,\n",
@@ -1066,7 +1056,9 @@
     "    cmip_version=\"CMIP7\",\n",
     ")\n",
     "\n",
-    "cmip7_cmoriser.variable_mapping\n"
+    "```\n",
+    "\n",
+    "> Tip: Use `source_id`, `experiment_id`, and related metadata values that exist in the selected vocabulary set. For CMIP7 branded names, include the region suffix such as `.GLB`.\n"
    ]
   },
   {

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -765,9 +765,7 @@ class CMORiser:
 
             # Report the standardization
             missing_value = self.vocab.get_cmip_missing_value()
-            logger.debug(
-                "Final %s missing value applied: %s", mip_era, missing_value
-            )
+            logger.debug("Final %s missing value applied: %s", mip_era, missing_value)
         else:
             logger.warning(
                 "Cannot standardize missing values for %s: vocabulary not available",

--- a/src/access_moppy/base.py
+++ b/src/access_moppy/base.py
@@ -727,15 +727,15 @@ class CMORiser:
 
     def standardize_missing_values(self):
         """
-        Standardize missing values in the main variable to CMIP6 requirements.
+        Standardize missing values in the main variable to the active CMIP requirements.
 
         At this point, missing values should already be normalized to NaN from
         early processing, and XArray's built-in missing value propagation should
         have handled derivation calculations correctly. This method converts NaN
-        to the final CMIP6-compliant missing value.
+        to the final CMIP-compliant missing value.
 
         This is particularly important for:
-        - Final CMIP6 compliance (converting NaN to 1e20)
+        - Final CMIP compliance (converting NaN to the vocabulary missing value)
         - Ensuring consistent metadata attributes
         """
         if (
@@ -743,8 +743,10 @@ class CMORiser:
             and self.vocab
             and self.cmor_name in self.ds.data_vars
         ):
+            mip_era = getattr(self.vocab, "mip_era", self.vocab.__class__.__name__)
             logger.debug(
-                "Applying final CMIP6 missing value standardization for %s",
+                "Applying final %s missing value standardization for %s",
+                mip_era,
                 self.cmor_name,
             )
 
@@ -763,7 +765,9 @@ class CMORiser:
 
             # Report the standardization
             missing_value = self.vocab.get_cmip_missing_value()
-            logger.debug("Final CMIP6 missing value applied: %s", missing_value)
+            logger.debug(
+                "Final %s missing value applied: %s", mip_era, missing_value
+            )
         else:
             logger.warning(
                 "Cannot standardize missing values for %s: vocabulary not available",

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -196,6 +196,19 @@ class ACCESS_ESM_CMORiser:
         self.compound_name = compound_name
         if cmip_version == "CMIP7":
             cmip6_equivalent = _get_cmip7_to_cmip6_mapping(compound_name)
+            if cmip6_equivalent is None:
+                # Allow callers to pass the CMIP6 equivalent directly while using
+                # CMIP7 vocabularies/DRS, e.g. "Amon.rsdt" for a CMIP7 run.
+                if compound_name.count(".") == 1:
+                    cmip6_equivalent = compound_name
+                else:
+                    raise ValueError(
+                        "Could not map CMIP7 compound name "
+                        f"'{compound_name}' to a CMIP6 equivalent. "
+                        "Pass a valid CMIP7 compound name such as "
+                        "'atmos.rsdt.tavg-u-hxy-u.mon.GLB' or provide the "
+                        "CMIP6 equivalent in 'table.variable' form."
+                    )
             # Load variable mapping to check if this is an internal calculation
             raw_mapping = load_model_mappings(cmip6_equivalent, model_id=model_id)
             _warn_if_mapping_missing(raw_mapping, cmip6_equivalent, model_id)

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -206,6 +206,14 @@ class ACCESS_ESM_CMORiser:
                     cmip7_compound_name = load_cmip6_to_cmip7_mapping().get(
                         cmip6_equivalent, compound_name
                     )
+                elif compound_name.count(".") == 3:
+                    raise ValueError(
+                        "Could not map CMIP7 compound name "
+                        f"'{compound_name}' to a CMIP6 equivalent. "
+                        "This looks like a CMIP7 branded name missing its region "
+                        "suffix. If you mean the global field, try "
+                        f"'{compound_name}.GLB'."
+                    )
                 else:
                     raise ValueError(
                         "Could not map CMIP7 compound name "

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -16,6 +16,7 @@ from access_moppy.sea_ice import SeaIce_CMORiser
 from access_moppy.utilities import (
     MappingNotFoundWarning,
     VariableMapping,
+    load_cmip6_to_cmip7_mapping,
     _get_cmip7_to_cmip6_mapping,
     _model_mapping_file_exists,
     get_bundled_resource_path,
@@ -196,11 +197,15 @@ class ACCESS_ESM_CMORiser:
         self.compound_name = compound_name
         if cmip_version == "CMIP7":
             cmip6_equivalent = _get_cmip7_to_cmip6_mapping(compound_name)
+            cmip7_compound_name = compound_name
             if cmip6_equivalent is None:
                 # Allow callers to pass the CMIP6 equivalent directly while using
                 # CMIP7 vocabularies/DRS, e.g. "Amon.rsdt" for a CMIP7 run.
                 if compound_name.count(".") == 1:
                     cmip6_equivalent = compound_name
+                    cmip7_compound_name = load_cmip6_to_cmip7_mapping().get(
+                        cmip6_equivalent, compound_name
+                    )
                 else:
                     raise ValueError(
                         "Could not map CMIP7 compound name "
@@ -217,7 +222,7 @@ class ACCESS_ESM_CMORiser:
             )
             table, cmor_name = cmip6_equivalent.split(".")
             self.cmip6_compound_name = cmip6_equivalent
-            self.cmip7_compound_name = compound_name
+            self.cmip7_compound_name = cmip7_compound_name
         else:
             raw_mapping = load_model_mappings(compound_name, model_id=model_id)
             _warn_if_mapping_missing(raw_mapping, compound_name, model_id)

--- a/src/access_moppy/driver.py
+++ b/src/access_moppy/driver.py
@@ -16,10 +16,10 @@ from access_moppy.sea_ice import SeaIce_CMORiser
 from access_moppy.utilities import (
     MappingNotFoundWarning,
     VariableMapping,
-    load_cmip6_to_cmip7_mapping,
     _get_cmip7_to_cmip6_mapping,
     _model_mapping_file_exists,
     get_bundled_resource_path,
+    load_cmip6_to_cmip7_mapping,
     load_model_mappings,
 )
 from access_moppy.vocabulary_processors import (

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -1982,15 +1982,21 @@ class CMIP7Vocabulary:
 
     def _load_project_cv(self, cv_name: str) -> Dict[str, Any]:
         """Load a project controlled vocabulary JSON file"""
-        try:
-            cv_file = files(self.cv_dir) / "project" / f"{cv_name}.json"
-            with as_file(cv_file) as path:
-                with open(path, "r", encoding="utf-8") as f:
-                    return json.load(f)
-        except FileNotFoundError:
-            raise ValueError(
-                f"Project CV '{cv_name}' not found in CMIP7 controlled vocabularies."
-            )
+        candidates = [
+            files(self.cv_dir) / "project" / f"{cv_name}.json",
+            files(self.cv_dir) / f"{cv_name}.json",
+        ]
+        for cv_file in candidates:
+            try:
+                with as_file(cv_file) as path:
+                    with open(path, "r", encoding="utf-8") as f:
+                        return json.load(f)
+            except FileNotFoundError:
+                continue
+
+        raise ValueError(
+            f"Project CV '{cv_name}' not found in CMIP7 controlled vocabularies."
+        )
 
     def _get_drs_specs(self) -> str:
         """Get DRS specifications from CMIP7 controlled vocabularies"""

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -26,7 +26,7 @@ _CV_CACHE: Dict[str, Dict[str, Any]] = {}
 _CMIP7_TEMP_ACCESS_INSTITUTION_ID = "ACCESS-CMIP-Consortium"
 _CMIP7_TEMP_SOURCE_WARNED: set[str] = set()
 _CMIP7_TEMP_SOURCE_OVERRIDES: Dict[str, Dict[str, Any]] = {
-    "ACCESS-ESM1-5": {
+    "ACCESS-ESM1-6": {
         "activity_participation": [
             "CMIP",
             "TIPMIP",
@@ -34,10 +34,10 @@ _CMIP7_TEMP_SOURCE_OVERRIDES: Dict[str, Dict[str, Any]] = {
         ],
         "cohort": ["Published"],
         "institution_id": [_CMIP7_TEMP_ACCESS_INSTITUTION_ID],
-        "label": "ACCESS-ESM1.5",
+        "label": "ACCESS-ESM1.6",
         "label_extended": (
             "Australian Community Climate and Earth System Simulator "
-            "Earth System Model Version 1.5"
+            "Earth System Model Version 1.6"
         ),
         "license_info": {
             "exceptions_contact": "@csiro.au <- access_csiro",
@@ -95,7 +95,7 @@ _CMIP7_TEMP_SOURCE_OVERRIDES: Dict[str, Dict[str, Any]] = {
             },
         },
         "release_year": "2019",
-        "source_id": "ACCESS-ESM1-5",
+        "source_id": "ACCESS-ESM1-6",
     }
 }
 

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -1283,6 +1283,7 @@ class CMIP6PlusVocabulary(CMIP6Vocabulary):
 
 
 class CMIP7Vocabulary:
+    mip_era = "CMIP7"
     cv_dir = "access_moppy.vocabularies.CMIP7_CVs"
     table_dir = "access_moppy.vocabularies.cmip7-cmor-tables.tables"
 

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -1414,7 +1414,9 @@ class CMIP7Vocabulary:
 
         for candidate in ordered_candidates:
             try:
-                experiment_file = files(self.cv_dir) / "experiment" / f"{candidate}.json"
+                experiment_file = (
+                    files(self.cv_dir) / "experiment" / f"{candidate}.json"
+                )
                 with as_file(experiment_file) as path:
                     with open(path, "r", encoding="utf-8") as f:
                         return json.load(f)

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -27,12 +27,65 @@ _CMIP7_TEMP_ACCESS_INSTITUTION_ID = "ACCESS-CMIP-Consortium"
 _CMIP7_TEMP_SOURCE_WARNED: set[str] = set()
 _CMIP7_TEMP_SOURCE_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "ACCESS-ESM1-6": {
+        "validation_key": "ACCESS-ESM1-6",
+        "ui_label": "ACCESS-ESM1-6",
+        "name": "ACCESS-ESM1-6",
         "activity_participation": [
             "CMIP",
             "TIPMIP",
             "TBIMIP",
         ],
+        "calendar": ["proleptic-gregorian"],
         "cohort": ["Published"],
+        "coupled_components": [
+            ["atmosphere", "ocean"],
+            ["atmosphere", "sea ice"],
+            ["ocean", "sea ice"],
+        ],
+        "description": (
+            "The model is an updated version of ACCESS-ESM1-5, as used for "
+            "CMIP6 (Ziehn et al., 2020). Its dynamic components are the UK "
+            "Met Office Unified Model atmosphere (v7.3) in a configuration "
+            "similar to HadGEM2 including CLASSIC aerosols, with the CABLE "
+            "land surface model (v3) including land biogeochemistry. The "
+            "atmosphere is coupled to the MOM5 ocean with WOMBATlite "
+            "biogeochemistry and CICE5 sea-ice using the OASIS-MCT coupler. "
+            "Chemistry is prescribed including monthly mean, zonally-averaged "
+            "ozone. Volcano forcing is prescribed as stratospheric optical "
+            "depth as monthly means in four equal area latitude bands. "
+            "Land-ice is represented by an ice tile in the land surface "
+            "model. A grid-cell is either completely ice or ice-free and the "
+            "ice tile distribution does not change in time. The main "
+            "differences from ACCESS-ESM1.5 include corrections to how "
+            "convective momentum transport had been applied in the atmosphere, "
+            "a change to ocean albedo to better match observations, a "
+            "correction to the passing of ocean carbon fluxes into the "
+            "atmosphere, updates to improve energy and water conservation "
+            "across the land and atmosphere, inclusion of 3 new plant "
+            "functional types (c4 crops and two Australian tree types), "
+            "improvements to the treatment of land-use change, updates to "
+            "some of the land parameterisations or parameter values, the "
+            "inclusion of a pseudo-iceberg scheme for distributing runoff "
+            "from Antarctica and Greenland and a substantial update to ocean "
+            "biogeochemistry. Many aspects of the model infrastructure have "
+            "also been improved to ensure greater provenance, better support "
+            "for users and enhanced model throughput. A manuscript describing "
+            "ACCESS-ESM1.6 is in preparation (Ziehn et al.)."
+        ),
+        "dynamic_components": [
+            "atmosphere",
+            "land surface and subsurface",
+            "aerosol",
+            "ocean",
+            "ocean biogeochemistry",
+            "sea ice",
+        ],
+        "embedded_components": [
+            ["aerosol", "atmosphere"],
+            ["land surface and subsurface", "atmosphere"],
+            ["ocean biogeochemistry", "ocean"],
+        ],
+        "family": "access-esm",
         "institution_id": [_CMIP7_TEMP_ACCESS_INSTITUTION_ID],
         "label": "ACCESS-ESM1.6",
         "label_extended": (
@@ -94,8 +147,23 @@ _CMIP7_TEMP_SOURCE_OVERRIDES: Dict[str, Dict[str, Any]] = {
                 "native_nominal_resolution": "100 km",
             },
         },
+        "model_components": [
+            "aerosol_classic_h102_v106",
+            "atmosphere_um7.3_h102_v106",
+            "land_surface_cable3_h102_v105",
+            "ocean-biogeochemistry_wombatlite_h109_v109",
+            "ocean_mom5_h109_v109",
+            "sea_ice_cice5_h109_no-vertical",
+        ],
+        "omitted_components": [],
+        "prescribed_components": [
+            "atmospheric chemistry",
+            "land ice",
+        ],
+        "references": ["https://doi.org/10.1071/ES19035"],
         "release_year": "2026",
         "source_id": "ACCESS-ESM1-6",
+        "@id": "access-esm1-6",
     }
 }
 

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -1345,9 +1345,8 @@ class CMIP7Vocabulary:
             merged_source.update(official_source)
 
             if (
-                (not official_source or "institution_id" not in official_source)
-                and source_id not in _CMIP7_TEMP_SOURCE_WARNED
-            ):
+                not official_source or "institution_id" not in official_source
+            ) and source_id not in _CMIP7_TEMP_SOURCE_WARNED:
                 _CMIP7_TEMP_SOURCE_WARNED.add(source_id)
                 warnings.warn(
                     f"Using temporary CMIP7 controlled vocabulary override for "

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -2,6 +2,7 @@ import json
 import re
 import uuid
 import warnings
+from copy import deepcopy
 from datetime import datetime, timezone
 from importlib.resources import as_file, files
 from pathlib import Path
@@ -18,6 +19,85 @@ from access_moppy import _creator
 # Module-level cache so that controlled-vocabulary JSON files are read from disk
 # only once per cv_dir, regardless of how many vocabulary objects are created.
 _CV_CACHE: Dict[str, Dict[str, Any]] = {}
+
+# Temporary CMIP7 ACCESS source shim.
+# Remove this override once the upstream CMIP7 CV bundle includes the official
+# ACCESS source and institution registration.
+_CMIP7_TEMP_ACCESS_INSTITUTION_ID = "ACCESS-CMIP-Consortium"
+_CMIP7_TEMP_SOURCE_WARNED: set[str] = set()
+_CMIP7_TEMP_SOURCE_OVERRIDES: Dict[str, Dict[str, Any]] = {
+    "ACCESS-ESM1-5": {
+        "activity_participation": [
+            "CMIP",
+            "TIPMIP",
+            "TBIMIP",
+        ],
+        "cohort": ["Published"],
+        "institution_id": [_CMIP7_TEMP_ACCESS_INSTITUTION_ID],
+        "label": "ACCESS-ESM1.5",
+        "label_extended": (
+            "Australian Community Climate and Earth System Simulator "
+            "Earth System Model Version 1.5"
+        ),
+        "license_info": {
+            "exceptions_contact": "@csiro.au <- access_csiro",
+            "history": (
+                "2019-11-12: initially published under CC BY-SA 4.0; "
+                "2022-06-10: relaxed to CC BY 4.0"
+            ),
+            "id": "CC BY 4.0",
+            "license": (
+                "Creative Commons Attribution 4.0 International "
+                "(CC BY 4.0; https://creativecommons.org/licenses/by/4.0/)"
+            ),
+            "source_specific_info": "",
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+        },
+        "model_component": {
+            "aerosol": {
+                "description": "CLASSIC (v1.0)",
+                "native_nominal_resolution": "250 km",
+            },
+            "atmos": {
+                "description": (
+                    "HadGAM2 (r1.1, N96; 192 x 145 longitude/latitude; "
+                    "38 levels; top level 39255 m)"
+                ),
+                "native_nominal_resolution": "250 km",
+            },
+            "atmosChem": {
+                "description": "none",
+                "native_nominal_resolution": "none",
+            },
+            "land": {
+                "description": "CABLE2.4",
+                "native_nominal_resolution": "250 km",
+            },
+            "landIce": {
+                "description": "none",
+                "native_nominal_resolution": "none",
+            },
+            "ocean": {
+                "description": (
+                    "ACCESS-OM2 (MOM5, tripolar primarily 1deg; "
+                    "360 x 300 longitude/latitude; 50 levels; "
+                    "top grid cell 0-10 m)"
+                ),
+                "native_nominal_resolution": "100 km",
+            },
+            "ocnBgchem": {
+                "description": "WOMBAT (same grid as ocean)",
+                "native_nominal_resolution": "100 km",
+            },
+            "seaIce": {
+                "description": "CICE4.1 (same grid as ocean)",
+                "native_nominal_resolution": "100 km",
+            },
+        },
+        "release_year": "2019",
+        "source_id": "ACCESS-ESM1-5",
+    }
+}
 
 
 class VariableNotFoundError(ValueError):
@@ -1247,13 +1327,47 @@ class CMIP7Vocabulary:
                 f"Experiment '{self.experiment_id}' not found in CMIP7 controlled vocabularies."
             )
 
+    def _load_source_metadata(self, source_id: str) -> Dict[str, Any]:
+        """Load CMIP7 source metadata, applying temporary ACCESS overrides if needed."""
+        official_source: Dict[str, Any] = {}
+
+        try:
+            source_file = files(self.cv_dir) / "source" / f"{source_id}.json"
+            with as_file(source_file) as path:
+                with open(path, "r", encoding="utf-8") as f:
+                    official_source = json.load(f)
+        except (FileNotFoundError, NotADirectoryError):
+            official_source = {}
+
+        override = _CMIP7_TEMP_SOURCE_OVERRIDES.get(source_id)
+        if override is not None:
+            merged_source = deepcopy(override)
+            merged_source.update(official_source)
+
+            if (
+                (not official_source or "institution_id" not in official_source)
+                and source_id not in _CMIP7_TEMP_SOURCE_WARNED
+            ):
+                _CMIP7_TEMP_SOURCE_WARNED.add(source_id)
+                warnings.warn(
+                    f"Using temporary CMIP7 controlled vocabulary override for "
+                    f"source_id '{source_id}'. Remove this shim once the bundled "
+                    f"CMIP7 CVs provide the official source/institution entry.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+
+            return merged_source
+
+        if official_source:
+            return official_source
+
+        raise FileNotFoundError(source_id)
+
     def _get_source(self) -> Dict[str, Any]:
         """Load source metadata from individual JSON file"""
         try:
-            source_file = files(self.cv_dir) / "source" / f"{self.source_id}.json"
-            with as_file(source_file) as path:
-                with open(path, "r", encoding="utf-8") as f:
-                    return json.load(f)
+            return self._load_source_metadata(self.source_id)
         except FileNotFoundError:
             raise ValueError(
                 f"Source '{self.source_id}' not found in CMIP7 controlled vocabularies."
@@ -1305,14 +1419,7 @@ class CMIP7Vocabulary:
 
         # Validate parent source exists
         try:
-            parent_source_file = (
-                files(self.cv_dir)
-                / "source"
-                / f"{parent_attrs['parent_source_id']}.json"
-            )
-            with as_file(parent_source_file) as path:
-                with open(path, "r", encoding="utf-8") as f:
-                    json.load(f)  # Just validate it exists and is valid JSON
+            self._load_source_metadata(parent_attrs["parent_source_id"])
         except FileNotFoundError:
             raise ValueError(
                 f"Invalid parent_source_id: {parent_attrs['parent_source_id']}"

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -94,7 +94,7 @@ _CMIP7_TEMP_SOURCE_OVERRIDES: Dict[str, Dict[str, Any]] = {
                 "native_nominal_resolution": "100 km",
             },
         },
-        "release_year": "2019",
+        "release_year": "2026",
         "source_id": "ACCESS-ESM1-6",
     }
 }

--- a/src/access_moppy/vocabulary_processors.py
+++ b/src/access_moppy/vocabulary_processors.py
@@ -25,6 +25,14 @@ _CV_CACHE: Dict[str, Dict[str, Any]] = {}
 # ACCESS source and institution registration.
 _CMIP7_TEMP_ACCESS_INSTITUTION_ID = "ACCESS-CMIP-Consortium"
 _CMIP7_TEMP_SOURCE_WARNED: set[str] = set()
+_CMIP7_EXPERIMENT_ALIASES: Dict[str, List[str]] = {
+    "piControl": ["picontrol", "esm-picontrol"],
+    "piControl-spinup": ["picontrol-spinup", "esm-picontrol-spinup"],
+    "picontrol": ["piControl", "esm-picontrol"],
+    "picontrol-spinup": ["piControl-spinup", "esm-picontrol-spinup"],
+    "esm-picontrol": ["picontrol", "piControl"],
+    "esm-picontrol-spinup": ["picontrol-spinup", "piControl-spinup"],
+}
 _CMIP7_TEMP_SOURCE_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "ACCESS-ESM1-6": {
         "validation_key": "ACCESS-ESM1-6",
@@ -1384,16 +1392,35 @@ class CMIP7Vocabulary:
     def _get_experiment(self) -> Dict[str, Any]:
         """Load experiment metadata from individual JSON file"""
         try:
-            experiment_file = (
-                files(self.cv_dir) / "experiment" / f"{self.experiment_id}.json"
-            )
-            with as_file(experiment_file) as path:
-                with open(path, "r", encoding="utf-8") as f:
-                    return json.load(f)
+            return self._load_experiment_metadata(self.experiment_id)
         except FileNotFoundError:
             raise ValueError(
                 f"Experiment '{self.experiment_id}' not found in CMIP7 controlled vocabularies."
             )
+
+    def _load_experiment_metadata(self, experiment_id: str) -> Dict[str, Any]:
+        """Load CMIP7 experiment metadata, trying known aliases for drifted IDs."""
+        candidates = [experiment_id]
+        candidates.extend(_CMIP7_EXPERIMENT_ALIASES.get(experiment_id, []))
+
+        # Avoid duplicate filesystem checks while preserving caller order.
+        seen: set[str] = set()
+        ordered_candidates = []
+        for candidate in candidates:
+            if candidate not in seen:
+                seen.add(candidate)
+                ordered_candidates.append(candidate)
+
+        for candidate in ordered_candidates:
+            try:
+                experiment_file = files(self.cv_dir) / "experiment" / f"{candidate}.json"
+                with as_file(experiment_file) as path:
+                    with open(path, "r", encoding="utf-8") as f:
+                        return json.load(f)
+            except FileNotFoundError:
+                continue
+
+        raise FileNotFoundError(experiment_id)
 
     def _load_source_metadata(self, source_id: str) -> Dict[str, Any]:
         """Load CMIP7 source metadata, applying temporary ACCESS overrides if needed."""
@@ -1471,14 +1498,7 @@ class CMIP7Vocabulary:
 
         # Validate parent experiment exists
         try:
-            parent_exp_file = (
-                files(self.cv_dir)
-                / "experiment"
-                / f"{parent_attrs['parent_experiment_id']}.json"
-            )
-            with as_file(parent_exp_file) as path:
-                with open(path, "r", encoding="utf-8") as f:
-                    json.load(f)  # Just validate it exists and is valid JSON
+            self._load_experiment_metadata(parent_attrs["parent_experiment_id"])
         except FileNotFoundError:
             raise ValueError(
                 f"Invalid parent_experiment_id: {parent_attrs['parent_experiment_id']}"

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -5,6 +5,7 @@ These tests focus on the core functionality of the CMORiser class
 without requiring complex dependencies or data files.
 """
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -82,6 +83,32 @@ class TestCMIP6CMORiser:
         )
 
         assert cmoriser.input_paths == ["single_file.nc"]
+
+    @pytest.mark.unit
+    def test_standardize_missing_values_logs_active_mip_era(
+        self, mock_vocab, mock_mapping, temp_dir, caplog
+    ):
+        """Debug logging uses the active vocabulary mip_era instead of hard-coded CMIP6."""
+        mock_vocab.standardize_missing_values = Mock(side_effect=lambda x, **kwargs: x)
+        mock_vocab.get_cmip_missing_value = Mock(return_value=1e20)
+        mock_vocab.mip_era = "CMIP7"
+
+        cmoriser = CMORiser(
+            input_paths=["test.nc"],
+            output_path=str(temp_dir),
+            vocab=mock_vocab,
+            variable_mapping=mock_mapping,
+            compound_name="Amon.tas",
+        )
+        cmoriser.ds = xr.Dataset(
+            {"tas": xr.DataArray(np.array([1.0, np.nan]), dims=["time"])}
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="access_moppy.base"):
+            cmoriser.standardize_missing_values()
+
+        assert "Applying final CMIP7 missing value standardization for tas" in caplog.text
+        assert "Final CMIP7 missing value applied: 1e+20" in caplog.text
 
     @pytest.mark.unit
     def test_init_with_drs_root(self, mock_vocab, mock_mapping, temp_dir):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -107,7 +107,9 @@ class TestCMIP6CMORiser:
         with caplog.at_level(logging.DEBUG, logger="access_moppy.base"):
             cmoriser.standardize_missing_values()
 
-        assert "Applying final CMIP7 missing value standardization for tas" in caplog.text
+        assert (
+            "Applying final CMIP7 missing value standardization for tas" in caplog.text
+        )
         assert "Final CMIP7 missing value applied: 1e+20" in caplog.text
 
     @pytest.mark.unit

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -563,6 +563,22 @@ class TestACCESSESMCMORiser:
                 )
 
     @pytest.mark.unit
+    def test_cmip7_missing_region_suffix_suggests_glb(
+        self, valid_config, temp_dir
+    ):
+        with patch(
+            "access_moppy.driver._get_cmip7_to_cmip6_mapping", return_value=None
+        ):
+            with pytest.raises(ValueError, match=r"atmos\.rsdt\.tavg-u-hxy-u\.mon\.GLB"):
+                ACCESS_ESM_CMORiser(
+                    input_paths=["test.nc"],
+                    compound_name="atmos.rsdt.tavg-u-hxy-u.mon",
+                    cmip_version="CMIP7",
+                    output_path=temp_dir,
+                    **valid_config,
+                )
+
+    @pytest.mark.unit
     def test_ocean_table_selects_om3_for_access_om3_source(
         self, valid_config, temp_dir
     ):

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -515,10 +515,14 @@ class TestACCESSESMCMORiser:
             patch(
                 "access_moppy.driver._get_cmip7_to_cmip6_mapping", return_value=None
             ) as mock_map,
+            patch("access_moppy.driver.load_cmip6_to_cmip7_mapping") as mock_reverse_map,
             patch("access_moppy.driver.load_model_mappings") as mock_load,
             patch("access_moppy.driver.CMIP7Vocabulary") as mock_vocab7,
             patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
         ):
+            mock_reverse_map.return_value = {
+                "Amon.rsdt": "atmos.rsdt.tavg-u-hxy-u.mon.GLB"
+            }
             mock_load.return_value = {"rsdt": {"units": "W m-2"}}
             mock_vocab7.return_value = MagicMock()
             mock_instance = MagicMock()
@@ -534,8 +538,9 @@ class TestACCESSESMCMORiser:
             )
 
             assert cmoriser.cmip6_compound_name == "Amon.rsdt"
-            assert cmoriser.cmip7_compound_name == "Amon.rsdt"
+            assert cmoriser.cmip7_compound_name == "atmos.rsdt.tavg-u-hxy-u.mon.GLB"
             mock_map.assert_called_once_with("Amon.rsdt")
+            mock_reverse_map.assert_called_once_with()
             mock_load.assert_called_once_with("Amon.rsdt", model_id=None)
             mock_vocab7.assert_called_once()
 

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -515,7 +515,9 @@ class TestACCESSESMCMORiser:
             patch(
                 "access_moppy.driver._get_cmip7_to_cmip6_mapping", return_value=None
             ) as mock_map,
-            patch("access_moppy.driver.load_cmip6_to_cmip7_mapping") as mock_reverse_map,
+            patch(
+                "access_moppy.driver.load_cmip6_to_cmip7_mapping"
+            ) as mock_reverse_map,
             patch("access_moppy.driver.load_model_mappings") as mock_load,
             patch("access_moppy.driver.CMIP7Vocabulary") as mock_vocab7,
             patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
@@ -551,9 +553,7 @@ class TestACCESSESMCMORiser:
         with patch(
             "access_moppy.driver._get_cmip7_to_cmip6_mapping", return_value=None
         ):
-            with pytest.raises(
-                ValueError, match="Could not map CMIP7 compound name"
-            ):
+            with pytest.raises(ValueError, match="Could not map CMIP7 compound name"):
                 ACCESS_ESM_CMORiser(
                     input_paths=["test.nc"],
                     compound_name="bad.cmip7.name.format",
@@ -563,13 +563,13 @@ class TestACCESSESMCMORiser:
                 )
 
     @pytest.mark.unit
-    def test_cmip7_missing_region_suffix_suggests_glb(
-        self, valid_config, temp_dir
-    ):
+    def test_cmip7_missing_region_suffix_suggests_glb(self, valid_config, temp_dir):
         with patch(
             "access_moppy.driver._get_cmip7_to_cmip6_mapping", return_value=None
         ):
-            with pytest.raises(ValueError, match=r"atmos\.rsdt\.tavg-u-hxy-u\.mon\.GLB"):
+            with pytest.raises(
+                ValueError, match=r"atmos\.rsdt\.tavg-u-hxy-u\.mon\.GLB"
+            ):
                 ACCESS_ESM_CMORiser(
                     input_paths=["test.nc"],
                     compound_name="atmos.rsdt.tavg-u-hxy-u.mon",

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -510,6 +510,54 @@ class TestACCESSESMCMORiser:
             mock_vocab7.assert_called_once()
 
     @pytest.mark.unit
+    def test_cmip7_accepts_cmip6_compound_name_fallback(self, valid_config, temp_dir):
+        with (
+            patch(
+                "access_moppy.driver._get_cmip7_to_cmip6_mapping", return_value=None
+            ) as mock_map,
+            patch("access_moppy.driver.load_model_mappings") as mock_load,
+            patch("access_moppy.driver.CMIP7Vocabulary") as mock_vocab7,
+            patch("access_moppy.driver.Atmosphere_CMORiser") as mock_atmos,
+        ):
+            mock_load.return_value = {"rsdt": {"units": "W m-2"}}
+            mock_vocab7.return_value = MagicMock()
+            mock_instance = MagicMock()
+            mock_instance.ds = xr.Dataset()
+            mock_atmos.return_value = mock_instance
+
+            cmoriser = ACCESS_ESM_CMORiser(
+                input_paths=["test.nc"],
+                compound_name="Amon.rsdt",
+                cmip_version="CMIP7",
+                output_path=temp_dir,
+                **valid_config,
+            )
+
+            assert cmoriser.cmip6_compound_name == "Amon.rsdt"
+            assert cmoriser.cmip7_compound_name == "Amon.rsdt"
+            mock_map.assert_called_once_with("Amon.rsdt")
+            mock_load.assert_called_once_with("Amon.rsdt", model_id=None)
+            mock_vocab7.assert_called_once()
+
+    @pytest.mark.unit
+    def test_cmip7_invalid_compound_name_raises_clear_error(
+        self, valid_config, temp_dir
+    ):
+        with patch(
+            "access_moppy.driver._get_cmip7_to_cmip6_mapping", return_value=None
+        ):
+            with pytest.raises(
+                ValueError, match="Could not map CMIP7 compound name"
+            ):
+                ACCESS_ESM_CMORiser(
+                    input_paths=["test.nc"],
+                    compound_name="bad.cmip7.name.format",
+                    cmip_version="CMIP7",
+                    output_path=temp_dir,
+                    **valid_config,
+                )
+
+    @pytest.mark.unit
     def test_ocean_table_selects_om3_for_access_om3_source(
         self, valid_config, temp_dir
     ):

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -849,6 +849,7 @@ def test_cmip7_parent_experiment_alias_is_validated():
         "branch_time_in_parent": 0.0,
         "branch_method": "standard",
     }
+
     def _mock_load_experiment_metadata(experiment_id):
         if experiment_id == "piControl-spinup":
             raise FileNotFoundError(experiment_id)

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -780,7 +780,7 @@ def test_cmip7_parent_source_validation_accepts_temporary_access_entry():
 
 @pytest.mark.unit
 def test_cmip7_experiment_alias_resolves_picontrol_spinup():
-    """CMIP7 accepts the CMIP-style piControl-spinup alias when loading experiments."""
+    """CMIP7 accepts aliased piControl-spinup-style experiment metadata."""
     mock_table = {
         "Header": {"table_id": "Amon"},
         "variable_entry": {
@@ -793,6 +793,15 @@ def test_cmip7_experiment_alias_resolves_picontrol_spinup():
         },
     }
     with (
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_experiment",
+            return_value={
+                "validation_key": "picontrol-spinup",
+                "activity": ["CMIP"],
+                "parent_experiment": ["none"],
+            },
+        ),
         patch.object(
             CMIP7Vocabulary,
             "_get_variable_entry",
@@ -840,11 +849,27 @@ def test_cmip7_parent_experiment_alias_is_validated():
         "branch_time_in_parent": 0.0,
         "branch_method": "standard",
     }
+    def _mock_load_experiment_metadata(experiment_id):
+        if experiment_id == "piControl-spinup":
+            raise FileNotFoundError(experiment_id)
+        if experiment_id == "picontrol-spinup":
+            return {
+                "validation_key": experiment_id,
+                "activity": ["CMIP"],
+                "parent_experiment": ["none"],
+            }
+        raise AssertionError(f"Unexpected experiment lookup: {experiment_id}")
+
     with (
         patch.object(
             CMIP7Vocabulary,
             "_get_experiment",
             return_value={"activity": ["CMIP"], "parent_experiment": ["esm-picontrol"]},
+        ),
+        patch.object(
+            CMIP7Vocabulary,
+            "_load_experiment_metadata",
+            side_effect=_mock_load_experiment_metadata,
         ),
         patch.object(
             CMIP7Vocabulary,

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -712,12 +712,12 @@ def test_cmip7_source_override_injects_temporary_access_entry():
         vocab = CMIP7Vocabulary(
             compound_name="Amon.tas",
             experiment_id="historical",
-            source_id="ACCESS-ESM1-5",
+            source_id="ACCESS-ESM1-6",
             variant_label="r1i1p1f1",
             grid_label="gn",
         )
 
-    assert vocab.source["source_id"] == "ACCESS-ESM1-5"
+    assert vocab.source["source_id"] == "ACCESS-ESM1-6"
     assert vocab.source["institution_id"] == [_CMIP7_TEMP_ACCESS_INSTITUTION_ID]
     assert vocab.source["model_component"]["atmos"]["native_nominal_resolution"] == "250 km"
 
@@ -740,7 +740,7 @@ def test_cmip7_parent_source_validation_accepts_temporary_access_entry():
         "parent_experiment_id": "esm-picontrol",
         "parent_activity_id": "CMIP",
         "parent_mip_era": "CMIP7",
-        "parent_source_id": "ACCESS-ESM1-5",
+        "parent_source_id": "ACCESS-ESM1-6",
         "parent_variant_label": "r1i1p1f1",
         "parent_time_units": "days since 0001-01-01 00:00:00",
         "branch_time_in_child": 0.0,
@@ -763,13 +763,13 @@ def test_cmip7_parent_source_validation_accepts_temporary_access_entry():
         vocab = CMIP7Vocabulary(
             compound_name="Amon.tas",
             experiment_id="historical",
-            source_id="ACCESS-ESM1-5",
+            source_id="ACCESS-ESM1-6",
             variant_label="r1i1p1f1",
             grid_label="gn",
             parent_info=parent_info,
         )
 
-    assert vocab.get_parent_experiment_attrs()["parent_source_id"] == "ACCESS-ESM1-5"
+    assert vocab.get_parent_experiment_attrs()["parent_source_id"] == "ACCESS-ESM1-6"
 
 
 def _make_cmip6_vocab(

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -862,7 +862,10 @@ def test_cmip7_parent_experiment_alias_is_validated():
             parent_info=parent_info,
         )
 
-    assert vocab.get_parent_experiment_attrs()["parent_experiment_id"] == "piControl-spinup"
+    assert (
+        vocab.get_parent_experiment_attrs()["parent_experiment_id"]
+        == "piControl-spinup"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -720,6 +720,7 @@ def test_cmip7_source_override_injects_temporary_access_entry():
         )
 
     assert vocab.source["source_id"] == "ACCESS-ESM1-6"
+    assert vocab.source["release_year"] == "2026"
     assert vocab.source["institution_id"] == [_CMIP7_TEMP_ACCESS_INSTITUTION_ID]
     assert (
         vocab.source["model_component"]["atmos"]["native_nominal_resolution"]

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -11,6 +11,7 @@ from access_moppy.vocabulary_processors import (
     CMIP6Vocabulary,
     CMIP7Vocabulary,
     VariableNotFoundError,
+    _CMIP7_TEMP_ACCESS_INSTITUTION_ID,
 )
 
 
@@ -678,6 +679,97 @@ def test_cmip7_generate_filename_numeric_time_branch(cmip7_vocab_instance):
 
     assert "202001" in filename
     assert "202002" in filename
+
+
+@pytest.mark.unit
+def test_cmip7_source_override_injects_temporary_access_entry():
+    """CMIP7 falls back to the temporary ACCESS source override when the CV lacks it."""
+    mock_table = {
+        "Header": {"table_id": "Amon"},
+        "variable_entry": {
+            "tas": {
+                "frequency": "mon",
+                "units": "K",
+                "type": "real",
+                "dimensions": "longitude latitude time",
+            }
+        },
+    }
+    with (
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_experiment",
+            return_value={"activity": ["CMIP"], "parent_experiment": ["none"]},
+        ),
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_variable_entry",
+            return_value=mock_table["variable_entry"]["tas"],
+        ),
+        patch.object(CMIP7Vocabulary, "_load_table", return_value=mock_table),
+        pytest.warns(UserWarning, match="temporary CMIP7 controlled vocabulary override"),
+    ):
+        vocab = CMIP7Vocabulary(
+            compound_name="Amon.tas",
+            experiment_id="historical",
+            source_id="ACCESS-ESM1-5",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+        )
+
+    assert vocab.source["source_id"] == "ACCESS-ESM1-5"
+    assert vocab.source["institution_id"] == [_CMIP7_TEMP_ACCESS_INSTITUTION_ID]
+    assert vocab.source["model_component"]["atmos"]["native_nominal_resolution"] == "250 km"
+
+
+@pytest.mark.unit
+def test_cmip7_parent_source_validation_accepts_temporary_access_entry():
+    """CMIP7 parent_source_id validation reuses the temporary ACCESS source override."""
+    mock_table = {
+        "Header": {"table_id": "Amon"},
+        "variable_entry": {
+            "tas": {
+                "frequency": "mon",
+                "units": "K",
+                "type": "real",
+                "dimensions": "longitude latitude time",
+            }
+        },
+    }
+    parent_info = {
+        "parent_experiment_id": "esm-picontrol",
+        "parent_activity_id": "CMIP",
+        "parent_mip_era": "CMIP7",
+        "parent_source_id": "ACCESS-ESM1-5",
+        "parent_variant_label": "r1i1p1f1",
+        "parent_time_units": "days since 0001-01-01 00:00:00",
+        "branch_time_in_child": 0.0,
+        "branch_time_in_parent": 0.0,
+        "branch_method": "standard",
+    }
+    with (
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_experiment",
+            return_value={"activity": ["CMIP"], "parent_experiment": ["esm-picontrol"]},
+        ),
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_variable_entry",
+            return_value=mock_table["variable_entry"]["tas"],
+        ),
+        patch.object(CMIP7Vocabulary, "_load_table", return_value=mock_table),
+    ):
+        vocab = CMIP7Vocabulary(
+            compound_name="Amon.tas",
+            experiment_id="historical",
+            source_id="ACCESS-ESM1-5",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+            parent_info=parent_info,
+        )
+
+    assert vocab.get_parent_experiment_attrs()["parent_source_id"] == "ACCESS-ESM1-5"
 
 
 def _make_cmip6_vocab(

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -904,6 +904,12 @@ def test_cmip7_load_project_cv_supports_flat_layout():
     assert "area_label" in area_cv
 
 
+@pytest.mark.unit
+def test_cmip7_vocabulary_exposes_mip_era():
+    """CMIP7Vocabulary defines mip_era so shared logging uses 'CMIP7'."""
+    assert CMIP7Vocabulary.mip_era == "CMIP7"
+
+
 def _make_cmip6_vocab(
     mock_vocab_data, mock_table_data, modeling_realm, source_components
 ):

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -865,6 +865,45 @@ def test_cmip7_parent_experiment_alias_is_validated():
     assert vocab.get_parent_experiment_attrs()["parent_experiment_id"] == "piControl-spinup"
 
 
+@pytest.mark.unit
+def test_cmip7_load_project_cv_supports_flat_layout():
+    """CMIP7 project CV loader supports the current flat bundled CV layout."""
+    mock_table = {
+        "Header": {"table_id": "Amon"},
+        "variable_entry": {
+            "tas": {
+                "frequency": "mon",
+                "units": "K",
+                "type": "real",
+                "dimensions": "longitude latitude time",
+            }
+        },
+    }
+    with (
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_experiment",
+            return_value={"activity": ["CMIP"], "parent_experiment": ["none"]},
+        ),
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_variable_entry",
+            return_value=mock_table["variable_entry"]["tas"],
+        ),
+        patch.object(CMIP7Vocabulary, "_load_table", return_value=mock_table),
+    ):
+        vocab = CMIP7Vocabulary(
+            compound_name="Amon.tas",
+            experiment_id="historical",
+            source_id="ACCESS-ESM1-6",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+        )
+
+    area_cv = vocab._load_project_cv("area_label")
+    assert "area_label" in area_cv
+
+
 def _make_cmip6_vocab(
     mock_vocab_data, mock_table_data, modeling_realm, source_components
 ):

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -778,6 +778,93 @@ def test_cmip7_parent_source_validation_accepts_temporary_access_entry():
     assert vocab.get_parent_experiment_attrs()["parent_source_id"] == "ACCESS-ESM1-6"
 
 
+@pytest.mark.unit
+def test_cmip7_experiment_alias_resolves_picontrol_spinup():
+    """CMIP7 accepts the CMIP-style piControl-spinup alias when loading experiments."""
+    mock_table = {
+        "Header": {"table_id": "Amon"},
+        "variable_entry": {
+            "tas": {
+                "frequency": "mon",
+                "units": "K",
+                "type": "real",
+                "dimensions": "longitude latitude time",
+            }
+        },
+    }
+    with (
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_variable_entry",
+            return_value=mock_table["variable_entry"]["tas"],
+        ),
+        patch.object(CMIP7Vocabulary, "_load_table", return_value=mock_table),
+    ):
+        vocab = CMIP7Vocabulary(
+            compound_name="Amon.tas",
+            experiment_id="piControl-spinup",
+            source_id="ACCESS-ESM1-6",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+        )
+
+    assert vocab.experiment["validation_key"] in {
+        "piControl-spinup",
+        "picontrol-spinup",
+        "esm-picontrol-spinup",
+    }
+
+
+@pytest.mark.unit
+def test_cmip7_parent_experiment_alias_is_validated():
+    """CMIP7 parent_experiment_id validation also accepts CMIP-style aliases."""
+    mock_table = {
+        "Header": {"table_id": "Amon"},
+        "variable_entry": {
+            "tas": {
+                "frequency": "mon",
+                "units": "K",
+                "type": "real",
+                "dimensions": "longitude latitude time",
+            }
+        },
+    }
+    parent_info = {
+        "parent_experiment_id": "piControl-spinup",
+        "parent_activity_id": "CMIP",
+        "parent_mip_era": "CMIP7",
+        "parent_source_id": "ACCESS-ESM1-6",
+        "parent_variant_label": "r1i1p1f1",
+        "parent_time_units": "days since 0001-01-01 00:00:00",
+        "branch_time_in_child": 0.0,
+        "branch_time_in_parent": 0.0,
+        "branch_method": "standard",
+    }
+    with (
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_experiment",
+            return_value={"activity": ["CMIP"], "parent_experiment": ["esm-picontrol"]},
+        ),
+        patch.object(
+            CMIP7Vocabulary,
+            "_get_variable_entry",
+            return_value=mock_table["variable_entry"]["tas"],
+        ),
+        patch.object(CMIP7Vocabulary, "_load_table", return_value=mock_table),
+    ):
+        vocab = CMIP7Vocabulary(
+            compound_name="Amon.tas",
+            experiment_id="historical",
+            source_id="ACCESS-ESM1-6",
+            variant_label="r1i1p1f1",
+            grid_label="gn",
+            parent_info=parent_info,
+        )
+
+    assert vocab.get_parent_experiment_attrs()["parent_experiment_id"] == "piControl-spinup"
+
+
 def _make_cmip6_vocab(
     mock_vocab_data, mock_table_data, modeling_realm, source_components
 ):

--- a/tests/unit/test_vocabulary_processors.py
+++ b/tests/unit/test_vocabulary_processors.py
@@ -8,10 +8,10 @@ import pytest
 import xarray as xr
 
 from access_moppy.vocabulary_processors import (
+    _CMIP7_TEMP_ACCESS_INSTITUTION_ID,
     CMIP6Vocabulary,
     CMIP7Vocabulary,
     VariableNotFoundError,
-    _CMIP7_TEMP_ACCESS_INSTITUTION_ID,
 )
 
 
@@ -707,7 +707,9 @@ def test_cmip7_source_override_injects_temporary_access_entry():
             return_value=mock_table["variable_entry"]["tas"],
         ),
         patch.object(CMIP7Vocabulary, "_load_table", return_value=mock_table),
-        pytest.warns(UserWarning, match="temporary CMIP7 controlled vocabulary override"),
+        pytest.warns(
+            UserWarning, match="temporary CMIP7 controlled vocabulary override"
+        ),
     ):
         vocab = CMIP7Vocabulary(
             compound_name="Amon.tas",
@@ -719,7 +721,10 @@ def test_cmip7_source_override_injects_temporary_access_entry():
 
     assert vocab.source["source_id"] == "ACCESS-ESM1-6"
     assert vocab.source["institution_id"] == [_CMIP7_TEMP_ACCESS_INSTITUTION_ID]
-    assert vocab.source["model_component"]["atmos"]["native_nominal_resolution"] == "250 km"
+    assert (
+        vocab.source["model_component"]["atmos"]["native_nominal_resolution"]
+        == "250 km"
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add a CMIP7-only temporary source override for ACCESS-ESM1-6 using institution_id 
- reuse the same resolver for parent_source_id validation so CMIP7 branch metadata works
- add focused unit coverage for the temporary source injection and parent validation path

## Testing
- ============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/romain/PROJECTS/ACCESS-MOPPy
configfile: pytest.ini
plugins: anyio-4.13.0, cov-7.1.0, typeguard-4.5.1
collected 33 items / 28 deselected / 5 selected

tests/unit/test_vocabulary_processors.py .....                           [100%]

======================= 5 passed, 28 deselected in 0.51s =======================

## Notes
- the shim prefers official bundled CMIP7 source metadata when present and is easy to remove once the upstream CMIP7 CV adds the ACCESS source/institution entry