### PR TITLE
Document CMIP7 FastTrack baseline workflow

### DIFF
--- a/docs/source/cmip7_fasttrack_baseline.rst
+++ b/docs/source/cmip7_fasttrack_baseline.rst
@@ -1,0 +1,246 @@
+CMIP7 FastTrack Baseline Guide
+==============================
+
+This page is a practical starting point for people contributing to the
+CMORisation of ACCESS-ESM1-6 runs for the CMIP7 FastTrack baseline variables.
+It is intentionally focused on the common NCI Gadi workflow rather than every
+possible deployment pattern.
+
+ACCESS-MOPPy is still an alpha tool and the ACCESS to CMIP7 mappings are still
+under review. Treat this workflow as contribution and verification work, not as
+the final publication path.
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+Who This Is For
+---------------
+
+Use this guide if you want to:
+
+- start checking or extending CMORisation coverage for ACCESS-ESM1-6
+- run a subset of FastTrack baseline variables on NCI Gadi
+- capture failures clearly so they can be fixed in mappings, derivations, or
+  metadata handling
+
+If you need the full batch configuration reference, use :doc:`batch_processing`.
+If you want a broader introduction to the Python API, start with
+:doc:`getting_started`.
+
+What To Prepare On Gadi
+-----------------------
+
+Before you start, make sure you have:
+
+- an NCI account with access to the relevant ACCESS archive and output projects
+- write access to a scratch area for generated NetCDF files, logs, and tracker
+  databases
+- access to the ``xp65`` module path used to load the packaged
+  ``conda/analysis3`` environment
+- the location of the ACCESS-ESM1-6 run you want to work on, usually under a
+  Payu archive tree on ``/g/data``
+
+A typical module setup on Gadi is:
+
+.. code-block:: bash
+
+   module use /g/data/xp65/public/modules
+   module load conda/analysis3-26.04
+
+This gives you access to ``moppy-cmorise`` and ``moppy-tui`` in the managed
+analysis environment used by the project examples.
+
+CMIP7-Focused Working Conventions
+---------------------------------
+
+For FastTrack baseline work in ACCESS-MOPPy:
+
+- use ``cmip_version: CMIP7``
+- use CMIP7 compound names such as
+  ``atmos.tas.tavg-h2m-hxy-u.mon.glb``
+- keep ``source_id: ACCESS-ESM1-6`` unless you are explicitly working on a
+  different source entry
+- start from the maintained example config at
+  ``src/access_moppy/examples/batch_config_esm1-6_cmip7_baseline.yml``
+
+That example file already contains:
+
+- the current baseline variable list
+- comments marking variables that are known to be unmapped
+- Gadi-oriented ``worker_init`` settings
+
+For most ACCESS-ESM1-6 baseline work, you should use the built-in file finder,
+not manual ``file_patterns`` entries. The preferred workflow is:
+
+- set ``input_folder`` to the run archive root
+- let ACCESS-MOPPy use the mapping file's ``file_discovery`` configuration
+- add ``file_patterns`` only if the run layout is unusual or you are debugging a
+  discovery problem
+
+Recommended First Contribution Loop
+-----------------------------------
+
+When you are new to a run or a variable family, avoid launching the full
+baseline list first. A small, well-documented test run is much easier to debug.
+
+1. Copy the example configuration to your working area.
+2. Reduce ``variables:`` to a small subset, ideally 1 to 5 variables from one
+   realm.
+3. Remove or comment out ``file_patterns`` so the file finder is the active
+   path.
+4. Update ``input_folder`` and ``output_folder``.
+5. Confirm ``experiment_id``, ``variant_label``, and any project-specific PBS
+   settings.
+6. Submit and monitor the batch.
+7. Record what passed, what failed, and what needs follow-up.
+
+Example:
+
+.. code-block:: bash
+
+   cp src/access_moppy/examples/batch_config_esm1-6_cmip7_baseline.yml \
+      baseline_test.yml
+
+Then edit ``baseline_test.yml`` so it contains only a small starter set, for
+example:
+
+.. code-block:: yaml
+
+   variables:
+     - atmos.tas.tavg-h2m-hxy-u.mon.glb
+     - atmos.pr.tavg-u-hxy-u.mon.glb
+     - atmos.rsds.tavg-u-hxy-u.mon.glb
+
+   cmip_version: CMIP7
+   experiment_id: historical
+   source_id: ACCESS-ESM1-6
+   variant_label: r1i1p1f1
+   grid_label: gn
+   activity_id: CMIP
+
+   input_folder: "/g/data/<project>/archive/CMIP7/ACCESS-ESM1-6/historical/<run>"
+   output_folder: "/scratch/<project>/<user>/cmor/historical_test"
+
+   worker_init: |
+     module use /g/data/xp65/public/modules
+     module load conda/analysis3-26.04
+
+In that starter config, leave ``file_patterns`` out entirely unless you already
+know the file finder does not match your archive layout. The file finder uses
+the ACCESS-ESM1-6 mapping metadata to discover the expected files from
+``input_folder`` automatically.
+
+Run It On NCI Gadi
+------------------
+
+From a Gadi login node:
+
+.. code-block:: bash
+
+   module use /g/data/xp65/public/modules
+   module load conda/analysis3-26.04
+   moppy-cmorise baseline_test.yml
+
+This will:
+
+- create a tracker database in ``output_folder/cmor_tasks.db``
+- generate PBS job scripts
+- submit one worker job per variable
+- start the monitor workflow
+
+Monitor Progress
+----------------
+
+For quick checks over SSH, the terminal dashboard is usually the easiest:
+
+.. code-block:: bash
+
+   moppy-tui --db /scratch/<project>/<user>/cmor/historical_test/cmor_tasks.db
+
+Useful follow-up commands:
+
+.. code-block:: bash
+
+   moppy-tui --status failed,running --db /scratch/<project>/<user>/cmor/historical_test/cmor_tasks.db
+   moppy-batch-report --db /scratch/<project>/<user>/cmor/historical_test/cmor_tasks.db
+
+Use :doc:`batch_processing` for the Streamlit dashboard, JSON reporting, and
+more detailed monitoring options.
+
+What To Look For
+----------------
+
+Common outcomes in early FastTrack baseline work include:
+
+- missing mapping entries for a CMIP7 compound name
+- file finder mismatches because the run layout differs from the expected
+  ACCESS-ESM1-6 archive structure
+- metadata mismatches such as invalid vocabulary values
+- derivation problems for variables computed from multiple native fields
+- memory or walltime limits that are too small for a specific variable
+
+Useful checks after a run:
+
+- confirm whether output NetCDF files were written
+- inspect the relevant ``.out`` and ``.err`` files in the generated job-script
+  directory
+- inspect ``cmor_tasks.db`` with ``moppy-tui`` or ``moppy-batch-report``
+- if a variable completed, spot-check the output metadata and dimensions
+
+Reporting Issues Clearly
+------------------------
+
+Please report problems as GitHub issues so they can be tracked centrally:
+
+`ACCESS-MOPPy issue tracker <https://github.com/ACCESS-NRI/ACCESS-MOPPy/issues>`_
+
+Include the following in each report:
+
+- the CMIP7 compound name, for example
+  ``atmos.tas.tavg-h2m-hxy-u.mon.glb``
+- the ACCESS run context:
+  ``source_id``, ``experiment_id``, ``variant_label``, and a short run label
+- whether the issue is on Gadi and which module environment you used
+- whether you were using the default file finder or a manual ``file_patterns``
+  override
+- whether the failure is a missing mapping, a runtime failure, a metadata
+  problem, or an unexpected scientific result
+- the smallest config snippet needed to reproduce the problem
+- the relevant traceback or error message from the worker ``.err`` file
+- the path to the generated batch report or the key fields copied from it
+- whether the same issue appears for one variable only or for a whole group
+
+Good issue titles are specific, for example:
+
+- ``CMIP7 FastTrack: atmos.rsds.tavg-u-hxy-u.mon.glb fails on ACCESS-ESM1-6 historical r1i1p1f1``
+- ``CMIP7 FastTrack: ocean.zos.tavg-u-hxy-sea.day.glb missing mapping in ACCESS-ESM1-6 baseline example``
+
+If you are unsure whether something is a code bug or a mapping gap, still
+report it. The important thing is to preserve enough context for someone else
+to reproduce it.
+
+Suggested Workflow For Teams
+----------------------------
+
+When several people are helping with baseline coverage, it usually works well
+to split work by realm or frequency, for example:
+
+- atmosphere monthly
+- atmosphere daily and sub-daily
+- land and land-ice
+- ocean
+- sea ice
+
+Keep one issue per distinct problem rather than one large running list. That
+makes it much easier to link fixes, tests, and validation checks back to the
+original failure.
+
+Where To Go Next
+----------------
+
+- Use :doc:`batch_processing` for the full PBS and monitoring reference.
+- Use :doc:`getting_started` if you want to inspect a single variable through
+  the Python API before moving back to batch mode.
+- Use :doc:`mapping_reference` when you need to understand how file discovery
+  and model-variable mappings are defined.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -339,6 +339,10 @@ If you want an end-to-end worked example rather than the reference guide, see
 :doc:`CMORise_ILAMB_workflow`, which shows a real multi-variable batch setup
 for ACCESS-ESM1-6.
 
+If your immediate goal is to help with CMIP7 FastTrack baseline coverage for
+ACCESS-ESM1-6 on NCI Gadi, see :doc:`cmip7_fasttrack_baseline` for a more
+task-focused contribution guide.
+
 The minimum batch workflow is:
 
 .. code-block:: bash

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,6 +50,7 @@ While retaining the core concepts of "custom" and "cmip" modes, ACCESS-MOPPy uni
    :caption: Contents:
 
    getting_started
+   cmip7_fasttrack_baseline
    batch_processing
    esmvaltool_integration
    CMORise_ILAMB_workflow

--- a/src/access_moppy/examples/batch_config_esm1-6_cmip7_baseline.yml
+++ b/src/access_moppy/examples/batch_config_esm1-6_cmip7_baseline.yml
@@ -3,6 +3,9 @@
 
 # All CMIP7 Baseline variables using CMIP7 compound names.
 # Variables with no mapping in ACCESS-ESM1-6 are commented out and marked NOT MAPPED.
+# This example is intended to use the built-in file finder by default:
+# point input_folder at the archive root and let the ACCESS-ESM1.6 mapping
+# file_discovery rules locate the native files automatically.
 
 variables:
   # --- Fixed fields ---
@@ -168,157 +171,17 @@ activity_id: CMIP
 input_folder: "YOUR_INPUT_PATH"
 output_folder: "YOUR_OUTPUT_PATH"
 
+# Optional: model_id selects which mapping file drives auto file-discovery.
+# Defaults to "ACCESS-ESM1.6" when omitted.
+# model_id: ACCESS-ESM1.6
 
-# File patterns (relative to input_folder)
-file_patterns:
-  # Fixed fields
-  atmos.areacella.ti-u-hxy-u.fx.glb:        "/output001/atmosphere/netCDF/*mon.nc"
-  land.mrsofc.ti-u-hxy-lnd.fx.glb:          "/output001/atmosphere/netCDF/*mon.nc"
-  land.orog.ti-u-hxy-u.fx.glb:              "/output001/atmosphere/netCDF/*mon.nc"
-  land.rootd.ti-u-hxy-lnd.fx.glb:           "/output001/atmosphere/netCDF/*mon.nc"
-  land.sftgif.ti-u-hxy-u.fx.glb:            "/output001/atmosphere/netCDF/*mon.nc"
-  atmos.sftlf.ti-u-hxy-u.fx.glb:            "/output001/atmosphere/netCDF/*mon.nc"
-  land.slthick.ti-sl-hxy-lnd.fx.glb:        "/output001/atmosphere/netCDF/*mon.nc"
-  ocean.areacello.ti-u-hxy-u.fx.glb:        "/output001/ocean/ocean-2d-surface_temp-1monthly-mean*.nc"
-  ocean.deptho.ti-u-hxy-sea.fx.glb:         "/output001/ocean/ocean-2d-surface_temp-1monthly-mean*.nc"
-  ocean.hfgeou.ti-u-hxy-sea.fx.glb:         "/output001/ocean/ocean-2d-surface_temp-1monthly-mean*.nc"
-  ocean.masscello.ti-ol-hxy-sea.fx.glb:     "/output001/ocean/ocean-3d-temp-1monthly-mean*.nc"
-  ocean.sftof.ti-u-hxy-u.fx.glb:            "/output001/ocean/ocean-2d-surface_temp-1monthly-mean*.nc"
-  ocean.thkcello.ti-ol-hxy-sea.fx.glb:      "/output001/ocean/ocean-3d-temp-1monthly-mean*.nc"
-
-  # Monthly atmosphere (2D)
-  atmos.clivi.tavg-u-hxy-u.mon.glb:         "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.clt.tavg-u-hxy-u.mon.glb:           "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.clwvi.tavg-u-hxy-u.mon.glb:         "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.evspsbl.tavg-u-hxy-u.mon.glb:       "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.hfls.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.hfss.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.hurs.tavg-h2m-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.huss.tavg-h2m-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.pr.tavg-u-hxy-u.mon.glb:            "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.prc.tavg-u-hxy-u.mon.glb:           "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.prsn.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.prw.tavg-u-hxy-u.mon.glb:           "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.ps.tavg-u-hxy-u.mon.glb:            "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.psl.tavg-u-hxy-u.mon.glb:           "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rlds.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rldscs.tavg-u-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rlus.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rluscs.tavg-u-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rlut.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rlutcs.tavg-u-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rsds.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rsdscs.tavg-u-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rsdt.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rsus.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rsuscs.tavg-u-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rsut.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.rsutcs.tavg-u-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.sfcWind.tavg-h10m-hxy-u.mon.glb:    "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.tas.tavg-h2m-hxy-u.mon.glb:         "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.tas.tmaxavg-h2m-hxy-u.mon.glb:      "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.tas.tminavg-h2m-hxy-u.mon.glb:      "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.tauu.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.tauv.tavg-u-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.ts.tavg-u-hxy-u.mon.glb:            "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.uas.tavg-h10m-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.vas.tavg-h10m-hxy-u.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  # Monthly atmosphere (3D — pressure-level)
-  atmos.cl.tavg-al-hxy-u.mon.glb:           "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.cli.tavg-al-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.clw.tavg-al-hxy-u.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.hur.tavg-p19-hxy-air.mon.glb:       "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.hus.tavg-p19-hxy-u.mon.glb:         "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.ta.tavg-p19-hxy-air.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.ua.tavg-p19-hxy-air.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.va.tavg-p19-hxy-air.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.wap.tavg-p19-hxy-air.mon.glb:       "/output*/atmosphere/netCDF/*mon.nc"
-  atmos.zg.tavg-p19-hxy-air.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-
-  # Monthly land
-  land.evspsblsoi.tavg-u-hxy-lnd.mon.glb:   "/output*/atmosphere/netCDF/*mon.nc"
-  land.evspsblveg.tavg-u-hxy-lnd.mon.glb:   "/output*/atmosphere/netCDF/*mon.nc"
-  land.lai.tavg-u-hxy-lnd.mon.glb:          "/output*/atmosphere/netCDF/*mon.nc"
-  landIce.mrfso.tavg-u-hxy-lnd.mon.glb:     "/output*/atmosphere/netCDF/*mon.nc"
-  land.mrro.tavg-u-hxy-lnd.mon.glb:         "/output*/atmosphere/netCDF/*mon.nc"
-  land.mrros.tavg-u-hxy-lnd.mon.glb:        "/output*/atmosphere/netCDF/*mon.nc"
-  land.mrso.tavg-u-hxy-lnd.mon.glb:         "/output*/atmosphere/netCDF/*mon.nc"
-  land.mrsol.tavg-d10cm-hxy-lnd.mon.glb:    "/output*/atmosphere/netCDF/*mon.nc"
-  landIce.snc.tavg-u-hxy-lnd.mon.glb:       "/output*/atmosphere/netCDF/*mon.nc"
-  landIce.snw.tavg-u-hxy-lnd.mon.glb:       "/output*/atmosphere/netCDF/*mon.nc"
-
-  # Monthly ocean (2D)
-  ocean.hfds.tavg-u-hxy-sea.mon.glb:        "/output*/ocean/ocean-2d-*1monthly-mean*.nc"
-  ocean.mlotst.tavg-u-hxy-sea.mon.glb:      "/output*/ocean/ocean-2d-*1monthly-mean*.nc"
-  ocean.sos.tavg-u-hxy-sea.mon.glb:         "/output*/ocean/ocean-2d-*1monthly-mean*.nc"
-  ocean.tauuo.tavg-u-hxy-sea.mon.glb:       "/output*/ocean/ocean-2d-*1monthly-mean*.nc"
-  ocean.tauvo.tavg-u-hxy-sea.mon.glb:       "/output*/ocean/ocean-2d-*1monthly-mean*.nc"
-  ocean.tos.tavg-u-hxy-sea.mon.glb:         "/output*/ocean/ocean-2d-surface_temp-1monthly-mean*.nc"
-  ocean.zos.tavg-u-hxy-sea.mon.glb:         "/output*/ocean/ocean-2d-sea_level-1monthly-mean*.nc"
-  ocean.zostoga.tavg-u-hm-sea.mon.glb:      "/output*/ocean/ocean-2d-*1monthly-mean*.nc"
-  # Monthly ocean (3D)
-  ocean.bigthetao.tavg-ol-hxy-sea.mon.glb:  "/output*/ocean/ocean-3d-temp-1monthly-mean*.nc"
-  ocean.masscello.tavg-ol-hxy-sea.mon.glb:  "/output*/ocean/ocean-3d-temp-1monthly-mean*.nc"
-  ocean.so.tavg-ol-hxy-sea.mon.glb:         "/output*/ocean/ocean-3d-salt-1monthly-mean*.nc"
-  ocean.thetao.tavg-ol-hxy-sea.mon.glb:     "/output*/ocean/ocean-3d-temp-1monthly-mean*.nc"
-  ocean.thkcello.tavg-ol-hxy-sea.mon.glb:   "/output*/ocean/ocean-3d-temp-1monthly-mean*.nc"
-  ocean.umo.tavg-ol-hxy-sea.mon.glb:        "/output*/ocean/ocean-3d-u-1monthly-mean*.nc"
-  ocean.uo.tavg-ol-hxy-sea.mon.glb:         "/output*/ocean/ocean-3d-u-1monthly-mean*.nc"
-  ocean.vmo.tavg-ol-hxy-sea.mon.glb:        "/output*/ocean/ocean-3d-v-1monthly-mean*.nc"
-  ocean.vo.tavg-ol-hxy-sea.mon.glb:         "/output*/ocean/ocean-3d-v-1monthly-mean*.nc"
-  ocean.wmo.tavg-ol-hxy-sea.mon.glb:        "/output*/ocean/ocean-3d-wt-1monthly-mean*.nc"
-  ocean.wo.tavg-ol-hxy-sea.mon.glb:         "/output*/ocean/ocean-3d-wt-1monthly-mean*.nc"
-
-  # Monthly sea ice
-  seaIce.siconc.tavg-u-hxy-u.mon.glb:       "/output*/ice/iceh*.nc"
-  seaIce.simass.tavg-u-hxy-si.mon.glb:      "/output*/ice/iceh*.nc"
-  seaIce.ts.tavg-u-hxy-si.mon.glb:          "/output*/ice/iceh*.nc"
-  seaIce.sithick.tavg-u-hxy-si.mon.glb:     "/output*/ice/iceh*.nc"
-  seaIce.sitimefrac.tavg-u-hxy-sea.mon.glb: "/output*/ice/iceh*.nc"
-  seaIce.siu.tavg-u-hxy-si.mon.glb:         "/output*/ice/iceh*.nc"
-  seaIce.siv.tavg-u-hxy-si.mon.glb:         "/output*/ice/iceh*.nc"
-
-  # Daily atmosphere
-  atmos.ps.tavg-u-hxy-u.day.glb:            "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.clt.tavg-u-hxy-u.day.glb:           "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.hur.tavg-p19-hxy-u.day.glb:         "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.hurs.tavg-h2m-hxy-u.day.glb:        "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.hus.tavg-p19-hxy-u.day.glb:         "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.huss.tavg-h2m-hxy-u.day.glb:        "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.pr.tavg-u-hxy-u.day.glb:            "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.psl.tavg-u-hxy-u.day.glb:           "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.rsds.tavg-u-hxy-u.day.glb:          "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.sfcWind.tavg-h10m-hxy-u.day.glb:    "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.ta.tavg-p19-hxy-air.day.glb:        "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.tas.tavg-h2m-hxy-u.day.glb:         "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.tas.tmax-h2m-hxy-u.day.glb:         "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.tas.tmin-h2m-hxy-u.day.glb:         "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.ua.tavg-p19-hxy-air.day.glb:        "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.uas.tavg-h10m-hxy-u.day.glb:        "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.va.tavg-p19-hxy-air.day.glb:        "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.vas.tavg-h10m-hxy-u.day.glb:        "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.wap.tavg-p19-hxy-u.day.glb:         "/output*/atmosphere/netCDF/*dai.nc"
-  atmos.zg.tavg-p19-hxy-air.day.glb:        "/output*/atmosphere/netCDF/*dai.nc"
-
-  # Daily ocean
-  ocean.sos.tavg-u-hxy-sea.day.glb:         "/output*/ocean/ocean-2d-*1daily-mean*.nc"
-  ocean.tos.tavg-u-hxy-sea.day.glb:         "/output*/ocean/ocean-2d-*1daily-mean*.nc"
-  ocean.zos.tavg-u-hxy-sea.day.glb:         "/output*/ocean/ocean-2d-*1daily-mean*.nc"
-
-  # Daily sea ice
-  seaIce.siconc.tavg-u-hxy-u.day.glb:       "/output*/ice/iceh_d*.nc"
-
-  # Sub-daily atmosphere (TODO: verify actual file patterns for your run)
-  atmos.pr.tavg-u-hxy-u.1hr.glb:            "/output*/atmosphere/netCDF/*1hr.nc"
-  atmos.huss.tpt-h2m-hxy-u.3hr.glb:         "/output*/atmosphere/netCDF/*3hr.nc"
-  atmos.pr.tavg-u-hxy-u.3hr.glb:            "/output*/atmosphere/netCDF/*3hr.nc"
-  atmos.tas.tpt-h2m-hxy-u.3hr.glb:          "/output*/atmosphere/netCDF/*3hr.nc"
-  atmos.uas.tpt-h10m-hxy-u.3hr.glb:         "/output*/atmosphere/netCDF/*3hr.nc"
-  atmos.vas.tpt-h10m-hxy-u.3hr.glb:         "/output*/atmosphere/netCDF/*3hr.nc"
-  atmos.hurs.tavg-h2m-hxy-u.6hr.glb:        "/output*/atmosphere/netCDF/*6hr.nc"
-  atmos.ta.tpt-p3-hxy-air.6hr.glb:          "/output*/atmosphere/netCDF/*6hr.nc"
-  atmos.ua.tpt-p3-hxy-air.6hr.glb:          "/output*/atmosphere/netCDF/*6hr.nc"
-  atmos.va.tpt-p3-hxy-air.6hr.glb:          "/output*/atmosphere/netCDF/*6hr.nc"
+# Optional: per-variable file-pattern overrides.
+# Leave this block commented out unless the run layout differs from the
+# expected ACCESS-ESM1-6 archive structure or you are debugging discovery.
+#
+# file_patterns:
+#   atmos.tas.tavg-h2m-hxy-u.mon.glb: "/output*/atmosphere/netCDF/*mon.nc"
+#   ocean.tos.tavg-u-hxy-sea.mon.glb: "/output*/ocean/ocean-2d-surface_temp-1monthly-mean*.nc"
 
 
 # PBS job configuration (defaults for all variables)


### PR DESCRIPTION
## Summary
- add a focused CMIP7 FastTrack baseline contributor guide for ACCESS-ESM1-6
- link the new guide from the main docs and getting started page
- update the baseline batch example to default to mapping-driven file discovery instead of manual file patterns